### PR TITLE
fix(codegen): emit maxItems arrays as regular arrays

### DIFF
--- a/.changeset/fix-maxitems-array-types.md
+++ b/.changeset/fix-maxitems-array-types.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Generate JSON Schema arrays with non-exact `maxItems` constraints as ordinary TypeScript arrays while enforcing the bounds in generated Zod runtime schemas.

--- a/scripts/generate-types.ts
+++ b/scripts/generate-types.ts
@@ -5,6 +5,7 @@ import { compile } from 'json-schema-to-typescript';
 import path from 'path';
 import { injectJsdocConstraints, removeArrayLengthConstraints } from './schema-utils';
 import { resolveSchemaRefInCache, schemaRefToCacheRelativePath } from './schema-cache-ref';
+import { relaxArrayCardinalityTypes } from './typescript-array-cardinality';
 
 // Write file only if content differs (excluding timestamp)
 function writeFileIfChanged(filePath: string, newContent: string): boolean {
@@ -4358,22 +4359,24 @@ async function generateTypes() {
   // residual jsts under-resolution artifacts (*Asset1, AssetVariant1, CreativeAsset1) —
   // see applyKnownJstsAliases for the rationale. Finally, restore the asset_type
   // discriminator on Individual*Asset slot aliases that jsts collapses (#1498).
-  const processedCoreTypes = normalizeTransformerParamJsonValueTypes(
-    relaxZodCompatibilityArrayTypes(
-      hardenTrustedMatchGeneratedTypes(
-        applyIndividualAssetDiscriminators(
-          addBackwardCompatTypeAliases(
-            simplifyForecastRange(
-              simplifyPriceBreakdown(
-                widenMediaBuyFeaturesIndexSignature(
-                  widenPostalAreaSupportIndexSignature(
-                    widenReportedOutcomeErrorIndexSignature(
-                      fixTypedIndexSignatures(
-                        removeResidualInlineIndexSignatureArms(
-                          applyKnownJstsAliases(
-                            namePostalAreaCountryBranch(
-                              renameKnownNumberedSemanticTypes(
-                                removeNumberedTypeDuplicates(removeIndexSignatureTypes(coreTypes))
+  const processedCoreTypes = relaxArrayCardinalityTypes(
+    normalizeTransformerParamJsonValueTypes(
+      relaxZodCompatibilityArrayTypes(
+        hardenTrustedMatchGeneratedTypes(
+          applyIndividualAssetDiscriminators(
+            addBackwardCompatTypeAliases(
+              simplifyForecastRange(
+                simplifyPriceBreakdown(
+                  widenMediaBuyFeaturesIndexSignature(
+                    widenPostalAreaSupportIndexSignature(
+                      widenReportedOutcomeErrorIndexSignature(
+                        fixTypedIndexSignatures(
+                          removeResidualInlineIndexSignatureArms(
+                            applyKnownJstsAliases(
+                              namePostalAreaCountryBranch(
+                                renameKnownNumberedSemanticTypes(
+                                  removeNumberedTypeDuplicates(removeIndexSignatureTypes(coreTypes))
+                                )
                               )
                             )
                           )
@@ -4387,15 +4390,19 @@ async function generateTypes() {
           )
         )
       )
-    )
+    ),
+    { maxItemsOnly: true }
   );
   const coreChanged = writeFileIfChanged(coreTypesPath, processedCoreTypes);
 
   const toolTypesPath = path.join(libOutputDir, 'tools.generated.ts');
-  const processedToolTypes = normalizeTransformerParamJsonValueTypes(
-    relaxZodCompatibilityArrayTypes(
-      addCanonicalToolTypeAliases(applyIndividualAssetDiscriminators(addBackwardCompatTypeAliases(toolTypes)), tools)
-    )
+  const processedToolTypes = relaxArrayCardinalityTypes(
+    normalizeTransformerParamJsonValueTypes(
+      relaxZodCompatibilityArrayTypes(
+        addCanonicalToolTypeAliases(applyIndividualAssetDiscriminators(addBackwardCompatTypeAliases(toolTypes)), tools)
+      )
+    ),
+    { maxItemsOnly: true }
   );
   const toolsChanged = writeFileIfChanged(toolTypesPath, processedToolTypes);
 

--- a/scripts/generate-zod-from-ts.ts
+++ b/scripts/generate-zod-from-ts.ts
@@ -7,6 +7,7 @@ import ts from 'typescript';
 import { writeFileSync, readFileSync, existsSync, readdirSync } from 'fs';
 import path from 'path';
 import { isDeepStrictEqual } from 'util';
+import { relaxArrayCardinalityTypes } from './typescript-array-cardinality';
 
 /**
  * Generate Zod v4 schemas from TypeScript types
@@ -364,148 +365,6 @@ function postProcessLazyTypeAnnotations(content: string): string {
 }
 
 const typePrinter = ts.createPrinter({ removeComments: true });
-const sourcePrinter = ts.createPrinter();
-
-function canonicalTypeText(node: ts.TypeNode, sourceFile: ts.SourceFile): string {
-  let semanticNode = node;
-  while (ts.isParenthesizedTypeNode(semanticNode)) semanticNode = semanticNode.type;
-  return typePrinter.printNode(ts.EmitHint.Unspecified, semanticNode, sourceFile);
-}
-
-function tupleArrayElementType(node: ts.TypeNode, sourceFile: ts.SourceFile): ts.TypeNode | undefined {
-  if (!ts.isTupleTypeNode(node)) return undefined;
-
-  const elements = node.elements.map(element => {
-    if (ts.isRestTypeNode(element)) {
-      return ts.isArrayTypeNode(element.type) ? element.type.elementType : undefined;
-    }
-    if (ts.isNamedTupleMember(element)) {
-      const memberType = element.type;
-      return element.dotDotDotToken && ts.isArrayTypeNode(memberType) ? memberType.elementType : memberType;
-    }
-    return element;
-  });
-  if (elements.some((element): element is undefined => element === undefined)) return undefined;
-
-  const first = elements[0];
-  if (!first) return undefined;
-  const canonical = canonicalTypeText(first, sourceFile);
-  return elements.every(element => canonicalTypeText(element!, sourceFile) === canonical) ? first : undefined;
-}
-
-function cardinalityArrayElementType(node: ts.TypeNode, sourceFile: ts.SourceFile): ts.TypeNode | undefined {
-  let semanticNode = node;
-  while (ts.isParenthesizedTypeNode(semanticNode)) semanticNode = semanticNode.type;
-  if (ts.isTupleTypeNode(semanticNode)) return tupleArrayElementType(semanticNode, sourceFile);
-  if (!ts.isUnionTypeNode(semanticNode)) return undefined;
-
-  const elements = semanticNode.types.map(type => {
-    let arm = type;
-    while (ts.isParenthesizedTypeNode(arm)) arm = arm.type;
-    if (!ts.isTupleTypeNode(arm)) return undefined;
-    return arm.elements.length === 0 ? null : tupleArrayElementType(arm, sourceFile);
-  });
-  const first = elements.find((element): element is ts.TypeNode => element != null);
-  if (!first || elements.some(element => element === undefined)) return undefined;
-  const canonical = canonicalTypeText(first, sourceFile);
-  return elements.every(element => element === null || canonicalTypeText(element, sourceFile) === canonical)
-    ? first
-    : undefined;
-}
-
-function relaxCardinalityTypeNode(
-  type: ts.TypeNode,
-  sourceFile: ts.SourceFile,
-  context: ts.TransformationContext,
-  visit: ts.Visitor
-): ts.TypeNode {
-  const element = cardinalityArrayElementType(type, sourceFile);
-  if (element) {
-    return ts.factory.createArrayTypeNode(ts.visitNode(element, visit, ts.isTypeNode));
-  }
-
-  // Cardinality metadata can apply to an array branch in a wider union or to
-  // an index-signature/record value. Descend through type containers, but not
-  // into object members where an unrelated structural tuple could live.
-  if (ts.isParenthesizedTypeNode(type)) {
-    return ts.factory.updateParenthesizedType(type, relaxCardinalityTypeNode(type.type, sourceFile, context, visit));
-  }
-  if (ts.isUnionTypeNode(type)) {
-    return ts.factory.updateUnionTypeNode(
-      type,
-      type.types.map(member => relaxCardinalityTypeNode(member, sourceFile, context, visit))
-    );
-  }
-  if (ts.isIntersectionTypeNode(type)) {
-    return ts.factory.updateIntersectionTypeNode(
-      type,
-      type.types.map(member => relaxCardinalityTypeNode(member, sourceFile, context, visit))
-    );
-  }
-  if (ts.isTypeReferenceNode(type)) {
-    return ts.factory.updateTypeReferenceNode(
-      type,
-      type.typeName,
-      type.typeArguments?.map(argument => relaxCardinalityTypeNode(argument, sourceFile, context, visit))
-    );
-  }
-  return ts.visitEachChild(type, visit, context) as ts.TypeNode;
-}
-
-/**
- * Relax non-exact JSON Schema array cardinality before passing generated TypeScript
- * to ts-to-zod. json-schema-to-typescript represents those arrays as tuple/rest or
- * bounded tuple-union types, which ts-to-zod faithfully projects as Zod tuples.
- *
- * Scoping the rewrite to declarations carrying @minItems/@maxItems provenance avoids
- * widening authored structural tuple unions. Exact min=max tuples (for example an
- * [x, y] focal point) remain tuples on the public Zod surface.
- */
-function relaxArrayCardinalityTypes(source: string): string {
-  const sourceFile = ts.createSourceFile(
-    'adcp-generated-types.ts',
-    source,
-    ts.ScriptTarget.Latest,
-    true,
-    ts.ScriptKind.TS
-  );
-  const relaxedTypeRoots = new Set<ts.TypeNode>();
-
-  const collect = (node: ts.Node): void => {
-    const tags = ts.getJSDocTags(node);
-    const minTag = tags.find(tag => tag.tagName.text === 'minItems');
-    const maxTag = tags.find(tag => tag.tagName.text === 'maxItems');
-    if (minTag || maxTag) {
-      const min = minTag ? Number(String(minTag.comment ?? '').trim()) : undefined;
-      const max = maxTag ? Number(String(maxTag.comment ?? '').trim()) : undefined;
-      const exactTuple = min !== undefined && max !== undefined && min === max;
-      const typedNode = node as ts.Node & { type?: ts.TypeNode };
-      if (!exactTuple && typedNode.type) {
-        relaxedTypeRoots.add(typedNode.type);
-      }
-    }
-    ts.forEachChild(node, collect);
-  };
-  collect(sourceFile);
-
-  const transformed = ts.transform(sourceFile, [
-    context => root => {
-      const visit: ts.Visitor = node => {
-        if (ts.isTypeNode(node) && relaxedTypeRoots.has(node)) {
-          return relaxCardinalityTypeNode(node, sourceFile, context, visit);
-        }
-        return ts.visitEachChild(node, visit, context);
-      };
-      return ts.visitNode(root, visit) as ts.SourceFile;
-    },
-  ]);
-  try {
-    return sourcePrinter.printFile(transformed.transformed[0]!);
-  } finally {
-    transformed.dispose();
-  }
-}
-
 function canonicalSchemaExpression(expression: string): string {
   const sourceFile = ts.createSourceFile(
     'zod-expression.ts',
@@ -573,6 +432,304 @@ function postProcessTupleRestArrays(content: string): string {
   }
 
   return result;
+}
+
+interface ArrayMaxItemsConstraint {
+  schemaName: string;
+  path: string[];
+  maxItems: number;
+}
+
+function jsDocNumberTag(node: ts.Node, name: string): number | undefined {
+  const tag = ts.getJSDocTags(node).find(candidate => candidate.tagName.text === name);
+  if (!tag) return undefined;
+  const value = Number(String(tag.comment ?? '').trim());
+  return Number.isSafeInteger(value) && value >= 0 ? value : undefined;
+}
+
+function isTupleType(type: ts.TypeNode): boolean {
+  let unwrapped = type;
+  while (ts.isParenthesizedTypeNode(unwrapped)) unwrapped = unwrapped.type;
+  return ts.isTupleTypeNode(unwrapped);
+}
+
+/**
+ * Collect maxItems annotations which survive the JSON-Schema-to-TypeScript
+ * hop as JSDoc. ts-to-zod deliberately only knows scalar/string JSDoc
+ * constraints, so arrays need this small source-aware bridge.
+ *
+ * `path` allows nested type literals to be handled without matching an
+ * unrelated same-named field elsewhere in a generated schema. An exact tuple
+ * already enforces its cardinality, and must remain a tuple for compatibility.
+ */
+function collectArrayMaxItemsConstraints(source: string): ArrayMaxItemsConstraint[] {
+  const sourceFile = ts.createSourceFile(
+    'adcp-generated-types.ts',
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS
+  );
+  const constraints: ArrayMaxItemsConstraint[] = [];
+
+  const visitType = (type: ts.TypeNode, schemaName: string, path: string[]): void => {
+    if (ts.isParenthesizedTypeNode(type)) {
+      visitType(type.type, schemaName, path);
+      return;
+    }
+    if (ts.isTypeLiteralNode(type)) {
+      for (const member of type.members) {
+        if (!ts.isPropertySignature(member) || !member.type) continue;
+        const propertyName =
+          ts.isIdentifier(member.name) || ts.isStringLiteral(member.name) || ts.isNumericLiteral(member.name)
+            ? member.name.text
+            : undefined;
+        if (!propertyName) continue;
+        collectMember(member, schemaName, [...path, propertyName]);
+      }
+      return;
+    }
+    if (ts.isArrayTypeNode(type)) {
+      visitType(type.elementType, schemaName, path);
+      return;
+    }
+    if (
+      ts.isTypeReferenceNode(type) &&
+      ts.isIdentifier(type.typeName) &&
+      (type.typeName.text === 'Array' || type.typeName.text === 'ReadonlyArray') &&
+      type.typeArguments?.[0]
+    ) {
+      visitType(type.typeArguments[0], schemaName, path);
+      return;
+    }
+    if (ts.isTupleTypeNode(type)) {
+      for (const element of type.elements) {
+        if (ts.isRestTypeNode(element)) visitType(element.type, schemaName, path);
+        else if (ts.isNamedTupleMember(element)) visitType(element.type, schemaName, path);
+        else visitType(element, schemaName, path);
+      }
+      return;
+    }
+    if (ts.isUnionTypeNode(type) || ts.isIntersectionTypeNode(type)) {
+      type.types.forEach(member => visitType(member, schemaName, path));
+    }
+  };
+
+  const collectMember = (member: ts.PropertySignature, schemaName: string, path: string[]): void => {
+    const maxItems = jsDocNumberTag(member, 'maxItems');
+    const minItems = jsDocNumberTag(member, 'minItems');
+    if (maxItems !== undefined && minItems !== maxItems && !isTupleType(member.type!)) {
+      constraints.push({ schemaName, path, maxItems });
+    }
+    visitType(member.type!, schemaName, path);
+  };
+
+  for (const statement of sourceFile.statements) {
+    if (ts.isInterfaceDeclaration(statement)) {
+      for (const member of statement.members) {
+        if (!ts.isPropertySignature(member) || !member.type) continue;
+        const propertyName =
+          ts.isIdentifier(member.name) || ts.isStringLiteral(member.name) || ts.isNumericLiteral(member.name)
+            ? member.name.text
+            : undefined;
+        if (propertyName) collectMember(member, statement.name.text, [propertyName]);
+      }
+      continue;
+    }
+    if (!ts.isTypeAliasDeclaration(statement)) continue;
+
+    const maxItems = jsDocNumberTag(statement, 'maxItems');
+    const minItems = jsDocNumberTag(statement, 'minItems');
+    if (maxItems !== undefined && minItems !== maxItems && !isTupleType(statement.type)) {
+      constraints.push({ schemaName: statement.name.text, path: [], maxItems });
+    }
+    visitType(statement.type, statement.name.text, []);
+  }
+
+  const unique = new Map<string, ArrayMaxItemsConstraint>();
+  for (const constraint of constraints) {
+    const key = `${constraint.schemaName}:${constraint.path.join('.')}`;
+    const existing = unique.get(key);
+    if (existing && existing.maxItems !== constraint.maxItems) {
+      throw new Error(`Conflicting @maxItems values for ${key}: ${existing.maxItems} and ${constraint.maxItems}.`);
+    }
+    unique.set(key, constraint);
+  }
+  return [...unique.values()];
+}
+
+function propertyNameText(name: ts.PropertyName): string | undefined {
+  return ts.isIdentifier(name) || ts.isStringLiteral(name) || ts.isNumericLiteral(name) ? name.text : undefined;
+}
+
+function isZodArrayCall(node: ts.Expression): node is ts.CallExpression {
+  return (
+    ts.isCallExpression(node) &&
+    ts.isPropertyAccessExpression(node.expression) &&
+    node.expression.name.text === 'array' &&
+    ts.isIdentifier(node.expression.expression) &&
+    node.expression.expression.text === 'z'
+  );
+}
+
+function isZodTupleCall(node: ts.Expression): node is ts.CallExpression {
+  return (
+    ts.isCallExpression(node) &&
+    ts.isPropertyAccessExpression(node.expression) &&
+    node.expression.name.text === 'tuple' &&
+    ts.isIdentifier(node.expression.expression) &&
+    node.expression.expression.text === 'z'
+  );
+}
+
+/** Find the outer array base beneath chains such as `.optional()` or `.nullable()`. */
+function findZodArrayBase(node: ts.Expression): ts.CallExpression | undefined {
+  if (isZodArrayCall(node)) return node;
+  if (ts.isCallExpression(node) && ts.isPropertyAccessExpression(node.expression)) {
+    return findZodArrayBase(node.expression.expression);
+  }
+  return undefined;
+}
+
+function fixedZodTupleLength(node: ts.Expression): number | undefined {
+  if (isZodTupleCall(node)) {
+    const values = node.arguments[0];
+    return values && ts.isArrayLiteralExpression(values) ? values.elements.length : undefined;
+  }
+  if (ts.isCallExpression(node) && ts.isPropertyAccessExpression(node.expression)) {
+    return fixedZodTupleLength(node.expression.expression);
+  }
+  return undefined;
+}
+
+function zodArrayMaxItems(node: ts.Expression): number | undefined {
+  let current = node;
+  while (ts.isCallExpression(current) && ts.isPropertyAccessExpression(current.expression)) {
+    if (
+      current.expression.name.text === 'max' &&
+      current.arguments.length === 1 &&
+      ts.isNumericLiteral(current.arguments[0])
+    ) {
+      return Number(current.arguments[0].text);
+    }
+    current = current.expression.expression;
+  }
+  return undefined;
+}
+
+function findSchemaVariable(sourceFile: ts.SourceFile, schemaName: string): ts.Expression | undefined {
+  for (const statement of sourceFile.statements) {
+    if (!ts.isVariableStatement(statement)) continue;
+    for (const declaration of statement.declarationList.declarations) {
+      if (ts.isIdentifier(declaration.name) && declaration.name.text === schemaName && declaration.initializer) {
+        return declaration.initializer;
+      }
+    }
+  }
+  return undefined;
+}
+
+function isZodObjectCall(node: ts.Node): node is ts.CallExpression {
+  return (
+    ts.isCallExpression(node) &&
+    ts.isPropertyAccessExpression(node.expression) &&
+    node.expression.name.text === 'object' &&
+    ts.isIdentifier(node.expression.expression) &&
+    node.expression.expression.text === 'z'
+  );
+}
+
+function collectObjectPropertyValues(expression: ts.Expression, path: readonly string[]): ts.Expression[] {
+  if (path.length === 0) return [expression];
+  const values: ts.Expression[] = [];
+  const visit = (node: ts.Node): void => {
+    if (isZodObjectCall(node)) {
+      const shape = node.arguments[0];
+      if (shape && ts.isObjectLiteralExpression(shape)) {
+        for (const property of shape.properties) {
+          if (!ts.isPropertyAssignment(property) || propertyNameText(property.name) !== path[0]) continue;
+          if (path.length === 1) values.push(property.initializer);
+          else values.push(...collectObjectPropertyValues(property.initializer, path.slice(1)));
+        }
+      }
+      // Properties inside this object are a deeper schema level. Only enter a
+      // matching property above, after consuming the current path segment.
+      return;
+    }
+    if (ts.isObjectLiteralExpression(node)) {
+      // Object literals outside z.object() are configuration/data arguments,
+      // not schema shapes.
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(expression);
+  return values;
+}
+
+/**
+ * Restore JSON Schema maxItems as ZodArray `.max(N)` chains after ts-to-zod
+ * generation. This is intentionally source-driven rather than a list of
+ * known fields so newly added schema bounds receive runtime validation.
+ */
+function postProcessArrayMaxItems(content: string, typeSource: string): string {
+  const constraints = collectArrayMaxItemsConstraints(typeSource);
+  if (constraints.length === 0) return content;
+
+  const sourceFile = ts.createSourceFile(
+    'adcp-generated-zod.ts',
+    content,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS
+  );
+  const insertions = new Map<number, number>();
+  for (const constraint of constraints) {
+    const schema = findSchemaVariable(sourceFile, `${constraint.schemaName}Schema`);
+    if (!schema) continue; // ts-to-zod may intentionally omit unsupported declarations.
+    const values = collectObjectPropertyValues(schema, constraint.path);
+    let foundArray = false;
+    let fixedTupleSatisfiesBound = false;
+    for (const value of values) {
+      const array = findZodArrayBase(value);
+      if (!array) {
+        const tupleLength = fixedZodTupleLength(value);
+        if (tupleLength !== undefined && tupleLength <= constraint.maxItems) fixedTupleSatisfiesBound = true;
+        continue;
+      }
+      foundArray = true;
+      const existingMax = zodArrayMaxItems(value);
+      if (existingMax !== undefined) {
+        if (existingMax !== constraint.maxItems) {
+          throw new Error(
+            `Conflicting generated Zod maxItems values at ${constraint.schemaName}.${constraint.path.join('.')}: ` +
+              `${existingMax} and ${constraint.maxItems}.`
+          );
+        }
+        continue;
+      }
+      const existing = insertions.get(array.end);
+      if (existing !== undefined && existing !== constraint.maxItems) {
+        throw new Error(
+          `Conflicting generated Zod maxItems values at ${constraint.schemaName}.${constraint.path.join('.')}.`
+        );
+      }
+      insertions.set(array.end, constraint.maxItems);
+    }
+    if (!foundArray && !fixedTupleSatisfiesBound) {
+      throw new Error(
+        `Unable to restore @maxItems for ${constraint.schemaName}.${constraint.path.join('.')}: ` +
+          'the generated schema did not contain a ZodArray.'
+      );
+    }
+  }
+
+  return [...insertions.entries()]
+    .sort(([left], [right]) => right - left)
+    .reduce(
+      (result, [position, maxItems]) => result.slice(0, position) + `.max(${maxItems})` + result.slice(position),
+      content
+    );
 }
 
 /**
@@ -1853,13 +2010,14 @@ type CanonicalPrimitiveConstraints = {
  * after every structural Zod rewrite has run. The TypeScript intermediary can
  * lose JSDoc when a transitive occurrence wins first-definition ownership;
  * this pass makes the canonical document authoritative without relying on a
- * growing allowlist of field names.
+ * growing allowlist of field names. Array cardinality is reconciled separately
+ * by `postProcessArrayMaxItems`.
  *
  * Constraints are applied by property name only when every occurrence of that
  * name inside the canonical document has the same constraint set. Ambiguous
  * nested names are deliberately left alone rather than applying a constraint
- * in the wrong context. Defaults and array cardinality remain documentation-
- * only by design and are not handled here.
+ * in the wrong context. Defaults are not materialized, and array cardinality
+ * is handled by the dedicated source-aware pass.
  */
 function postProcessCanonicalPrimitiveConstraints(content: string): string {
   const cacheRoot = path.join(__dirname, '../schemas/cache/latest');
@@ -2091,15 +2249,19 @@ function postProcessCanonicalVastAudioConstraints(content: string): string {
   const end = endCandidate < 0 ? content.length : endCandidate;
   let block = content.slice(start, end);
   const unconstrainedDuration = 'duration_ms_range: z.array(z.number()).optional()';
+  const maxConstrainedDuration = 'duration_ms_range: z.array(z.number()).max(2).optional()';
   const constrainedDuration = 'duration_ms_range: z.array(z.number().int().min(0)).length(2).optional()';
   if (!block.includes(constrainedDuration)) {
-    const occurrences = block.split(unconstrainedDuration).length - 1;
+    const occurrences =
+      block.split(unconstrainedDuration).length - 1 + (block.split(maxConstrainedDuration).length - 1);
     if (occurrences !== 1) {
       throw new Error(
         `postProcessCanonicalVastAudioConstraints: expected one unconstrained duration_ms_range, found ${occurrences}.`
       );
     }
-    block = block.replace(unconstrainedDuration, constrainedDuration);
+    block = block
+      .replace(unconstrainedDuration, constrainedDuration)
+      .replace(maxConstrainedDuration, constrainedDuration);
   }
 
   const refinementMarker = 'audio VAST declarations cannot combine vast_version and vast_versions';
@@ -4023,6 +4185,11 @@ async function generateZodSchemas() {
     // homogeneous tuple/rest representation without touching fixed tuples.
     zodSchemas = postProcessTupleRestArrays(zodSchemas);
 
+    // ts-to-zod does not natively support @maxItems JSDoc. Recover the
+    // retained JSON Schema provenance from the generated TS source and apply
+    // the bound to the corresponding ZodArray validators.
+    zodSchemas = postProcessArrayMaxItems(zodSchemas, combinedSource);
+
     // Post-process: Replace z.union([z.unknown(), z.undefined()]) with z.unknown().
     // ts-to-zod generates the union for Record<string, unknown> types, but z.undefined()
     // has no JSON Schema representation, breaking MCP SDK's toJSONSchema() conversion.
@@ -4480,6 +4647,7 @@ if (require.main === module) {
 
 export const __test__ = {
   postProcessTupleRestArrays,
+  postProcessArrayMaxItems,
   relaxArrayCardinalityTypes,
   postProcessForNullish,
   postProcessRecordIntersections,

--- a/scripts/schema-utils.ts
+++ b/scripts/schema-utils.ts
@@ -53,8 +53,9 @@ const TS_TO_ZOD_SUPPORTED_FORMATS = new Set([
  * `minimum: 1`. ts-to-zod natively reads six JSDoc constraint tags
  * (`@minimum`, `@maximum`, `@minLength`, `@maxLength`, `@pattern`,
  * `@format`), so we encode the constraints into the JSDoc-bound description
- * field before jsts runs. The emitted JSDoc round-trips into Zod chains
- * (`z.number().min(1)`, etc).
+ * field before jsts runs. `@maxItems` is retained for the generator's
+ * source-aware array post-pass, because ts-to-zod does not natively parse it.
+ * The emitted JSDoc round-trips into Zod chains (`z.number().min(1)`, etc).
  *
  * Skipped (Ajv still enforces these against the unstripped schema at runtime):
  *  - `exclusiveMinimum` / `exclusiveMaximum` — ts-to-zod has no exclusive variant.
@@ -136,6 +137,10 @@ export function injectJsdocConstraints(schema: any): any {
     const hasStringType = out.type === 'string' || (Array.isArray(out.type) && out.type.includes('string'));
     if (hasStringType && typeof out.minLength === 'number') addTag('minLength', out.minLength);
     if (hasStringType && typeof out.maxLength === 'number') addTag('maxLength', out.maxLength);
+    // TypeScript has no ergonomic bounded-array type, so maxItems is removed
+    // before public type generation. Preserve it as JSDoc provenance for the
+    // Zod generator, which restores the runtime ZodArray `.max()` check.
+    if (out.type === 'array' && typeof out.maxItems === 'number') addTag('maxItems', out.maxItems);
     if (typeof out.pattern === 'string' && !/[\n\r]/.test(out.pattern)) {
       // ts-to-zod wraps the JSDoc `@pattern` value as `/PATTERN/`, so we
       // need to escape any unescaped `/` to keep the regex literal valid.

--- a/scripts/typescript-array-cardinality.ts
+++ b/scripts/typescript-array-cardinality.ts
@@ -1,0 +1,186 @@
+import ts from 'typescript';
+
+const comparisonPrinter = ts.createPrinter({ removeComments: true });
+const replacementPrinter = ts.createPrinter();
+
+function canonicalTypeText(node: ts.TypeNode, sourceFile: ts.SourceFile): string {
+  let semanticNode = node;
+  while (ts.isParenthesizedTypeNode(semanticNode)) semanticNode = semanticNode.type;
+  return comparisonPrinter.printNode(ts.EmitHint.Unspecified, semanticNode, sourceFile);
+}
+
+function tupleArrayElementType(node: ts.TypeNode, sourceFile: ts.SourceFile): ts.TypeNode | undefined {
+  if (!ts.isTupleTypeNode(node)) return undefined;
+
+  const elements = node.elements.map(element => {
+    if (ts.isRestTypeNode(element)) {
+      return ts.isArrayTypeNode(element.type) ? element.type.elementType : undefined;
+    }
+    if (ts.isNamedTupleMember(element)) {
+      const memberType = element.type;
+      return element.dotDotDotToken && ts.isArrayTypeNode(memberType) ? memberType.elementType : memberType;
+    }
+    return element;
+  });
+  if (elements.some((element): element is undefined => element === undefined)) return undefined;
+
+  const first = elements[0];
+  if (!first) return undefined;
+  const canonical = canonicalTypeText(first, sourceFile);
+  return elements.every(element => canonicalTypeText(element!, sourceFile) === canonical) ? first : undefined;
+}
+
+function cardinalityArrayElementType(node: ts.TypeNode, sourceFile: ts.SourceFile): ts.TypeNode | undefined {
+  let semanticNode = node;
+  while (ts.isParenthesizedTypeNode(semanticNode)) semanticNode = semanticNode.type;
+  if (ts.isTupleTypeNode(semanticNode)) return tupleArrayElementType(semanticNode, sourceFile);
+  if (!ts.isUnionTypeNode(semanticNode)) return undefined;
+
+  const elements = semanticNode.types.map(type => {
+    let arm = type;
+    while (ts.isParenthesizedTypeNode(arm)) arm = arm.type;
+    if (!ts.isTupleTypeNode(arm)) return undefined;
+    return arm.elements.length === 0 ? null : tupleArrayElementType(arm, sourceFile);
+  });
+  const first = elements.find((element): element is ts.TypeNode => element != null);
+  if (!first || elements.some(element => element === undefined)) return undefined;
+  const canonical = canonicalTypeText(first, sourceFile);
+  return elements.every(element => element === null || canonicalTypeText(element, sourceFile) === canonical)
+    ? first
+    : undefined;
+}
+
+function relaxCardinalityTypeNode(
+  type: ts.TypeNode,
+  sourceFile: ts.SourceFile,
+  context: ts.TransformationContext,
+  visit: ts.Visitor
+): ts.TypeNode {
+  const element = cardinalityArrayElementType(type, sourceFile);
+  if (element) {
+    return ts.factory.createArrayTypeNode(ts.visitNode(element, visit, ts.isTypeNode));
+  }
+
+  // Cardinality metadata can apply to an array branch in a wider union or to
+  // an index-signature/record value. Descend through type containers, but not
+  // into object members where an unrelated structural tuple could live.
+  if (ts.isParenthesizedTypeNode(type)) {
+    return ts.factory.updateParenthesizedType(type, relaxCardinalityTypeNode(type.type, sourceFile, context, visit));
+  }
+  if (ts.isUnionTypeNode(type)) {
+    const members = type.types.map(member => relaxCardinalityTypeNode(member, sourceFile, context, visit));
+    return members.some((member, index) => member !== type.types[index])
+      ? ts.factory.updateUnionTypeNode(type, ts.factory.createNodeArray(members))
+      : type;
+  }
+  if (ts.isIntersectionTypeNode(type)) {
+    const members = type.types.map(member => relaxCardinalityTypeNode(member, sourceFile, context, visit));
+    return members.some((member, index) => member !== type.types[index])
+      ? ts.factory.updateIntersectionTypeNode(type, ts.factory.createNodeArray(members))
+      : type;
+  }
+  if (ts.isTypeReferenceNode(type)) {
+    if (ts.isIdentifier(type.typeName) && ['Array', 'ReadonlyArray'].includes(type.typeName.text)) return type;
+    const typeArguments = type.typeArguments?.map(argument =>
+      relaxCardinalityTypeNode(argument, sourceFile, context, visit)
+    );
+    if (!typeArguments?.some((argument, index) => argument !== type.typeArguments![index])) return type;
+    return ts.factory.updateTypeReferenceNode(type, type.typeName, ts.factory.createNodeArray(typeArguments));
+  }
+  return type;
+}
+
+/**
+ * Replace non-exact JSON Schema array cardinality types with ordinary arrays.
+ *
+ * json-schema-to-typescript represents maxItems as a union containing every
+ * permitted tuple length. That rejects dynamically assembled arrays and grows
+ * declarations substantially. JSDoc provenance limits this rewrite to schema
+ * cardinality artifacts; authored structural tuples and exact min=max tuples
+ * remain intact. Runtime validators retain the original bounds.
+ */
+export function relaxArrayCardinalityTypes(source: string, options: { maxItemsOnly?: boolean } = {}): string {
+  const sourceFile = ts.createSourceFile(
+    'adcp-generated-types.ts',
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS
+  );
+  const relaxedTypeRoots: ts.TypeNode[] = [];
+
+  const collect = (node: ts.Node): void => {
+    const tags = ts.getJSDocTags(node);
+    const minTag = tags.find(tag => tag.tagName.text === 'minItems');
+    const maxTag = tags.find(tag => tag.tagName.text === 'maxItems');
+    if (maxTag || (!options.maxItemsOnly && minTag)) {
+      const min = minTag ? Number(String(minTag.comment ?? '').trim()) : undefined;
+      const max = maxTag ? Number(String(maxTag.comment ?? '').trim()) : undefined;
+      const exactTuple = min !== undefined && max !== undefined && min === max;
+      const typedNode = node as ts.Node & { type?: ts.TypeNode };
+      if (!exactTuple && typedNode.type) {
+        relaxedTypeRoots.push(typedNode.type);
+      }
+    }
+    ts.forEachChild(node, collect);
+  };
+  collect(sourceFile);
+
+  const candidates = relaxedTypeRoots
+    .map(type => {
+      const directElement = cardinalityArrayElementType(type, sourceFile);
+      if (directElement) {
+        const elementText = source.slice(directElement.getStart(sourceFile), directElement.end);
+        const needsParentheses =
+          ts.isUnionTypeNode(directElement) ||
+          ts.isIntersectionTypeNode(directElement) ||
+          ts.isFunctionTypeNode(directElement) ||
+          ts.isConstructorTypeNode(directElement) ||
+          ts.isConditionalTypeNode(directElement) ||
+          ts.isTypeOperatorNode(directElement);
+        return {
+          start: type.getStart(sourceFile),
+          end: type.end,
+          text: `${needsParentheses ? `(${elementText})` : elementText}[]`,
+        };
+      }
+
+      const transformed = ts.transform(type, [
+        context => root => {
+          const visit: ts.Visitor = node => {
+            if (ts.isTypeNode(node)) {
+              return relaxCardinalityTypeNode(node, sourceFile, context, visit);
+            }
+            return ts.visitEachChild(node, visit, context);
+          };
+          return relaxCardinalityTypeNode(root, sourceFile, context, visit);
+        },
+      ]);
+      try {
+        const transformedType = transformed.transformed[0]!;
+        if (transformedType === type) return undefined;
+        return {
+          start: type.getStart(sourceFile),
+          end: type.end,
+          text: replacementPrinter.printNode(ts.EmitHint.Unspecified, transformedType, sourceFile),
+        };
+      } finally {
+        transformed.dispose();
+      }
+    })
+    .filter((candidate): candidate is NonNullable<typeof candidate> => candidate !== undefined)
+    // If nested declarations both carry cardinality tags, keep the outermost
+    // replacement so edits never overlap.
+    .sort((left, right) => left.start - right.start || right.end - left.end);
+  const nonOverlapping: typeof candidates = [];
+  for (const candidate of candidates) {
+    if (nonOverlapping.some(other => candidate.start >= other.start && candidate.end <= other.end)) continue;
+    nonOverlapping.push(candidate);
+  }
+  const replacements = nonOverlapping.sort((left, right) => right.start - left.start);
+
+  return replacements.reduce(
+    (result, replacement) => result.slice(0, replacement.start) + replacement.text + result.slice(replacement.end),
+    source
+  );
+}

--- a/src/lib/types/core.generated.ts
+++ b/src/lib/types/core.generated.ts
@@ -1,5 +1,5 @@
 // Generated AdCP core types from official schemas v3.2.0-beta.11
-// Generated at: 2026-09-02T16:59:33.605Z
+// Generated at: 2026-09-03T14:28:10.870Z
 
 // ACCOUNTCURRENCYMODE CANONICAL ENUM
 /**
@@ -2898,6 +2898,7 @@ export interface BusinessEntity {
   };
   /**
    * Contacts for billing, legal, and operational matters. Contains personal data subject to GDPR and equivalent regulations. Implementations MUST use this data only for invoicing and account management.
+   * @maxItems 10
    */
   contacts?: {
     /**
@@ -4783,7 +4784,7 @@ export interface CreativeLocalePolicy {
    * @minItems 1
    * @maxItems 50
    */
-  accepted_language_ranges: [LanguageTag, ...LanguageTag[]];
+  accepted_language_ranges: LanguageTag[];
 }
 // DELIVERYMETRICAGGREGATE PRIORITY CANONICAL SCHEMA
 /**
@@ -7374,8 +7375,7 @@ export type RightsConstraint = {
    * @maxItems 4
    */
   attestation_refs?:
-    | [
-        AttestationReference & {
+    (AttestationReference & {
           issuer?: {
             type: 'brand';
             brand: BrandReference2;
@@ -7385,113 +7385,7 @@ export type RightsConstraint = {
             type: 'resource';
             resource_type: 'https://adcontextprotocol.org/claims/subjects/rights-grant';
           };
-        }
-      ]
-    | [
-        AttestationReference & {
-          issuer?: {
-            type: 'brand';
-            brand: BrandReference2;
-          };
-          claim_type?: 'https://adcontextprotocol.org/claims/rights/grant';
-          subject?: {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/rights-grant';
-          };
-        },
-        AttestationReference & {
-          issuer?: {
-            type: 'brand';
-            brand: BrandReference2;
-          };
-          claim_type?: 'https://adcontextprotocol.org/claims/rights/grant';
-          subject?: {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/rights-grant';
-          };
-        }
-      ]
-    | [
-        AttestationReference & {
-          issuer?: {
-            type: 'brand';
-            brand: BrandReference2;
-          };
-          claim_type?: 'https://adcontextprotocol.org/claims/rights/grant';
-          subject?: {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/rights-grant';
-          };
-        },
-        AttestationReference & {
-          issuer?: {
-            type: 'brand';
-            brand: BrandReference2;
-          };
-          claim_type?: 'https://adcontextprotocol.org/claims/rights/grant';
-          subject?: {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/rights-grant';
-          };
-        },
-        AttestationReference & {
-          issuer?: {
-            type: 'brand';
-            brand: BrandReference2;
-          };
-          claim_type?: 'https://adcontextprotocol.org/claims/rights/grant';
-          subject?: {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/rights-grant';
-          };
-        }
-      ]
-    | [
-        AttestationReference & {
-          issuer?: {
-            type: 'brand';
-            brand: BrandReference2;
-          };
-          claim_type?: 'https://adcontextprotocol.org/claims/rights/grant';
-          subject?: {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/rights-grant';
-          };
-        },
-        AttestationReference & {
-          issuer?: {
-            type: 'brand';
-            brand: BrandReference2;
-          };
-          claim_type?: 'https://adcontextprotocol.org/claims/rights/grant';
-          subject?: {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/rights-grant';
-          };
-        },
-        AttestationReference & {
-          issuer?: {
-            type: 'brand';
-            brand: BrandReference2;
-          };
-          claim_type?: 'https://adcontextprotocol.org/claims/rights/grant';
-          subject?: {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/rights-grant';
-          };
-        },
-        AttestationReference & {
-          issuer?: {
-            type: 'brand';
-            brand: BrandReference2;
-          };
-          claim_type?: 'https://adcontextprotocol.org/claims/rights/grant';
-          subject?: {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/rights-grant';
-          };
-        }
-      ];
+        })[];
   ext?: ExtensionObject;
 } & {
   /**
@@ -7578,8 +7472,7 @@ export type RightsConstraint = {
    * @maxItems 4
    */
   attestation_refs?:
-    | [
-        AttestationReference & {
+    (AttestationReference & {
           issuer?: {
             type: 'brand';
             brand: BrandReference2;
@@ -7589,113 +7482,7 @@ export type RightsConstraint = {
             type: 'resource';
             resource_type: 'https://adcontextprotocol.org/claims/subjects/rights-grant';
           };
-        }
-      ]
-    | [
-        AttestationReference & {
-          issuer?: {
-            type: 'brand';
-            brand: BrandReference2;
-          };
-          claim_type?: 'https://adcontextprotocol.org/claims/rights/grant';
-          subject?: {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/rights-grant';
-          };
-        },
-        AttestationReference & {
-          issuer?: {
-            type: 'brand';
-            brand: BrandReference2;
-          };
-          claim_type?: 'https://adcontextprotocol.org/claims/rights/grant';
-          subject?: {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/rights-grant';
-          };
-        }
-      ]
-    | [
-        AttestationReference & {
-          issuer?: {
-            type: 'brand';
-            brand: BrandReference2;
-          };
-          claim_type?: 'https://adcontextprotocol.org/claims/rights/grant';
-          subject?: {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/rights-grant';
-          };
-        },
-        AttestationReference & {
-          issuer?: {
-            type: 'brand';
-            brand: BrandReference2;
-          };
-          claim_type?: 'https://adcontextprotocol.org/claims/rights/grant';
-          subject?: {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/rights-grant';
-          };
-        },
-        AttestationReference & {
-          issuer?: {
-            type: 'brand';
-            brand: BrandReference2;
-          };
-          claim_type?: 'https://adcontextprotocol.org/claims/rights/grant';
-          subject?: {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/rights-grant';
-          };
-        }
-      ]
-    | [
-        AttestationReference & {
-          issuer?: {
-            type: 'brand';
-            brand: BrandReference2;
-          };
-          claim_type?: 'https://adcontextprotocol.org/claims/rights/grant';
-          subject?: {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/rights-grant';
-          };
-        },
-        AttestationReference & {
-          issuer?: {
-            type: 'brand';
-            brand: BrandReference2;
-          };
-          claim_type?: 'https://adcontextprotocol.org/claims/rights/grant';
-          subject?: {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/rights-grant';
-          };
-        },
-        AttestationReference & {
-          issuer?: {
-            type: 'brand';
-            brand: BrandReference2;
-          };
-          claim_type?: 'https://adcontextprotocol.org/claims/rights/grant';
-          subject?: {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/rights-grant';
-          };
-        },
-        AttestationReference & {
-          issuer?: {
-            type: 'brand';
-            brand: BrandReference2;
-          };
-          claim_type?: 'https://adcontextprotocol.org/claims/rights/grant';
-          subject?: {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/rights-grant';
-          };
-        }
-      ];
+        })[];
   ext?: ExtensionObject;
 };
 /**
@@ -7890,6 +7677,7 @@ export interface PackageUpdate {
   creative_assignments?: CreativeAssignment[];
   /**
    * Replace this package's inline creative assets. Native localization is not accepted on this path; use sync_creatives before assigning the library creative. When the seller also advertises creative.has_creative_library: true, new inline creatives enter the seller's creative library and can be reused by creative_id while retained; inline-only sellers may store them as package-scoped assets. Use creative_assignments instead for existing library creatives.
+   * @maxItems 100
    */
   creatives?: CreativeAsset[];
   context?: ContextObject;
@@ -10210,6 +9998,7 @@ export interface CanonicalFormatHostedVideo {
   max_height?: number;
   /**
    * [min, max] duration in milliseconds. Either endpoint MAY be null to express an unbounded side: [null, 60000] means up to 60s; [15000, null] means at least 15s. [null, null] is invalid because at least one endpoint must be bounded. **Precedence**: when both `duration_ms_exact` and `duration_ms_range` ship on the same product, `duration_ms_exact` takes precedence — buyers MUST validate against the exact value and ignore the range. SDKs SHOULD lint a warning when both fields ship; producers SHOULD pick one.
+   * @maxItems 2
    */
   duration_ms_range?: (number | null)[];
   /**
@@ -10441,6 +10230,7 @@ export interface CanonicalFormatVASTVideo {
   simid_supported?: boolean;
   /**
    * [min, max] duration in milliseconds. **Precedence**: `duration_ms_exact` takes precedence when both ship. SDKs SHOULD lint a warning when both fields ship.
+   * @maxItems 2
    */
   duration_ms_range?: number[];
   /**
@@ -10703,6 +10493,7 @@ export interface CanonicalFormatHostedAudio {
   production_window_business_days?: number;
   /**
    * [min, max] duration in milliseconds. Either endpoint MAY be null to express an unbounded side: [null, 60000] means up to 60s; [15000, null] means at least 15s. [null, null] is invalid because at least one endpoint must be bounded. **Precedence**: when both `duration_ms_exact` and `duration_ms_range` ship on the same product, `duration_ms_exact` takes precedence — buyers MUST validate against the exact value and ignore the range. SDKs SHOULD lint a warning when both fields ship; producers SHOULD pick one.
+   * @maxItems 2
    */
   duration_ms_range?: (number | null)[];
   /**
@@ -10918,6 +10709,7 @@ export interface CanonicalFormatVASTAudio {
   media_file_requirements?: VASTMediaFileRequirements;
   /**
    * [min, max] duration in milliseconds. duration_ms_exact takes precedence when both fields are present; SDKs SHOULD warn when both are supplied.
+   * @maxItems 2
    */
   duration_ms_range?: number[];
   /**
@@ -11090,6 +10882,7 @@ export interface CanonicalFormatDAASTAudio {
   daast_versions?: DaastVersions;
   /**
    * [min, max] duration in milliseconds. **Precedence**: `duration_ms_exact` takes precedence when both ship. SDKs SHOULD lint a warning when both fields ship.
+   * @maxItems 2
    */
   duration_ms_range?: number[];
   /**
@@ -12476,6 +12269,7 @@ export interface CanonicalFormatSellerRenderedStatefulDisplay {
   canvas_constraints?: CanvasConstraint[];
   /**
    * Accepted embedded-video duration [min, max]. `duration_ms_exact` takes precedence when both are present.
+   * @maxItems 2
    */
   duration_ms_range?: (number | null)[];
   /**
@@ -12997,6 +12791,7 @@ export interface ValidatePropertyDeliveryRequest {
   account?: AccountReference;
   /**
    * Delivery records to validate. Each record represents impressions delivered to a property identifier.
+   * @maxItems 10000
    */
   records: DeliveryRecord[];
   /**
@@ -16250,411 +16045,13 @@ export type AudienceEvidence = {
    * @maxItems 10
    */
   attestation_refs?:
-    | [
-        AttestationReference & {
+    (AttestationReference & {
           subject: AttestationSubject & {
             type: 'resource';
             resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
             content_digest: string;
           };
-        }
-      ]
-    | [
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        }
-      ]
-    | [
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        }
-      ]
-    | [
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        }
-      ]
-    | [
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        }
-      ]
-    | [
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        }
-      ]
-    | [
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        }
-      ]
-    | [
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        }
-      ]
-    | [
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        }
-      ]
-    | [
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        }
-      ];
+        })[];
   ext?: ExtensionObject;
 };
 /**
@@ -17256,321 +16653,14 @@ export interface Account {
    * @maxItems 16
    */
   notification_configs?:
-    | []
-    | [NotificationConfig]
-    | [NotificationConfig, NotificationConfig]
-    | [NotificationConfig, NotificationConfig, NotificationConfig]
-    | [NotificationConfig, NotificationConfig, NotificationConfig, NotificationConfig]
-    | [NotificationConfig, NotificationConfig, NotificationConfig, NotificationConfig, NotificationConfig]
-    | [
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig
-      ]
-    | [
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig
-      ]
-    | [
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig
-      ]
-    | [
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig
-      ]
-    | [
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig
-      ]
-    | [
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig
-      ]
-    | [
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig
-      ]
-    | [
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig
-      ]
-    | [
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig
-      ]
-    | [
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig
-      ]
-    | [
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig
-      ];
+    NotificationConfig[];
   /**
    * Resolved durable reporting delivery configurations owned by the authenticated caller for this account. list_accounts MUST expose only the calling principal's set. State and seller-issued destination_ref are returned; credentials and bearer profiles MUST NOT appear. Any setup URL is a secret-free authenticated entry point, not a bearer credential.
    *
    * @maxItems 16
    */
   reporting_delivery_configs?:
-    | []
-    | [ReportingDeliveryConfigurationState]
-    | [ReportingDeliveryConfigurationState, ReportingDeliveryConfigurationState]
-    | [ReportingDeliveryConfigurationState, ReportingDeliveryConfigurationState, ReportingDeliveryConfigurationState]
-    | [
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState
-      ]
-    | [
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState
-      ]
-    | [
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState
-      ]
-    | [
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState
-      ]
-    | [
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState
-      ]
-    | [
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState
-      ]
-    | [
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState
-      ]
-    | [
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState
-      ]
-    | [
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState
-      ]
-    | [
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState
-      ]
-    | [
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState
-      ]
-    | [
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState
-      ]
-    | [
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState
-      ];
+    ReportingDeliveryConfigurationState[];
   /**
    * Recent webhook delivery attempts scoped to this account when the caller requested webhook activity on list_accounts and the seller surfaces the log. Includes account-anchored notifications such as account.status_changed and MAY include other account-level fires relevant to this account. Three-state presence follows the shared webhook_activity[] contract: omitted means unsupported or not requested, [] means supported but no retained fires, non-empty lists recent attempts most-recent-first.
    *
@@ -17827,8 +16917,7 @@ export interface AudienceEvidenceSelection {
    * @maxItems 10
    */
   attestation_evaluations?:
-    | [
-        {
+    {
           reference: AttestationReference;
           evaluation: AttestationEvaluation & {
             action_binding: {
@@ -17837,566 +16926,7 @@ export interface AudienceEvidenceSelection {
               action_digest: string;
             };
           };
-        }
-      ]
-    | [
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        }
-      ]
-    | [
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        }
-      ]
-    | [
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        }
-      ]
-    | [
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        }
-      ]
-    | [
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        }
-      ]
-    | [
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        }
-      ]
-    | [
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        }
-      ]
-    | [
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        }
-      ]
-    | [
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        }
-      ];
+        }[];
   ext?: ExtensionObject;
 }
 /**
@@ -20864,138 +19394,7 @@ export type GetProductsResponse = AdCPVersionEnvelope &
      * @maxItems 20
      */
     suggestions?:
-      | []
-      | [string]
-      | [string, string]
-      | [string, string, string]
-      | [string, string, string, string]
-      | [string, string, string, string, string]
-      | [string, string, string, string, string, string]
-      | [string, string, string, string, string, string, string]
-      | [string, string, string, string, string, string, string, string]
-      | [string, string, string, string, string, string, string, string, string]
-      | [string, string, string, string, string, string, string, string, string, string]
-      | [string, string, string, string, string, string, string, string, string, string, string]
-      | [string, string, string, string, string, string, string, string, string, string, string, string]
-      | [string, string, string, string, string, string, string, string, string, string, string, string, string]
-      | [string, string, string, string, string, string, string, string, string, string, string, string, string, string]
-      | [
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string
-        ]
-      | [
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string
-        ]
-      | [
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string
-        ]
-      | [
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string
-        ]
-      | [
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string
-        ]
-      | [
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string
-        ];
+      string[];
     /**
      * [AdCP 3.0] Indicates whether deprecated top-level property_list filtering was applied. True if the agent filtered products based on the provided property_list; every returned product also carries the corresponding property/include list_applications receipt. Absent or false if property_list was not provided or not supported by this agent.
      */
@@ -21234,137 +19633,7 @@ export type GetProductsRejected = AdCPVersionEnvelope &
      * @maxItems 20
      */
     suggestions?:
-      | [string]
-      | [string, string]
-      | [string, string, string]
-      | [string, string, string, string]
-      | [string, string, string, string, string]
-      | [string, string, string, string, string, string]
-      | [string, string, string, string, string, string, string]
-      | [string, string, string, string, string, string, string, string]
-      | [string, string, string, string, string, string, string, string, string]
-      | [string, string, string, string, string, string, string, string, string, string]
-      | [string, string, string, string, string, string, string, string, string, string, string]
-      | [string, string, string, string, string, string, string, string, string, string, string, string]
-      | [string, string, string, string, string, string, string, string, string, string, string, string, string]
-      | [string, string, string, string, string, string, string, string, string, string, string, string, string, string]
-      | [
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string
-        ]
-      | [
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string
-        ]
-      | [
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string
-        ]
-      | [
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string
-        ]
-      | [
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string
-        ]
-      | [
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string
-        ];
+      string[];
     context?: ContextObject;
     ext?: ExtensionObject;
   };
@@ -24986,14 +23255,14 @@ export interface SyncCatalogsSuccess {
    * @minItems 1
    * @maxItems 1000
    */
-  item_availability_updates?: [CatalogItemAvailabilityUpdateResult, ...CatalogItemAvailabilityUpdateResult[]];
+  item_availability_updates?: CatalogItemAvailabilityUpdateResult[];
   /**
    * Current-state results for item_availability_queries, evaluated after updates in a mixed request. The array length MUST equal the request query length; entry N MUST have request_index N, occupy position N, and exactly echo catalog_id, catalog_generation, and item_id. Buyers MUST reject any mismatch. A replayed response is historical; use a fresh query idempotency_key before treating it as current after time-dependent expiry or catalog deletion/recreation.
    *
    * @minItems 1
    * @maxItems 1000
    */
-  item_availability_states?: [CatalogItemAvailabilityState, ...CatalogItemAvailabilityState[]];
+  item_availability_states?: CatalogItemAvailabilityState[];
   /**
    * When true, this response contains simulated data from sandbox mode.
    */
@@ -25959,6 +24228,9 @@ export interface GetBrandIdentitySuccess {
            * CSS font-family name
            */
           family: string;
+          /**
+           * @maxItems 36
+           */
           files?: {
             /**
              * HTTPS URL to the font file
@@ -25974,6 +24246,7 @@ export interface GetBrandIdentitySuccess {
             weight?: number;
             /**
              * Variable font weight axis range as [min, max]
+             * @maxItems 2
              */
             weight_range?: number[];
             /**
@@ -25983,10 +24256,12 @@ export interface GetBrandIdentitySuccess {
           }[];
           /**
            * OpenType feature tags to enable (e.g., ['ss01', 'tnum'])
+           * @maxItems 20
            */
           opentype_features?: string[];
           /**
            * Ordered fallback font-family names for script coverage
+           * @maxItems 10
            */
           fallbacks?: string[];
         };
@@ -26000,6 +24275,9 @@ export interface GetBrandIdentitySuccess {
            * CSS font-family name
            */
           family: string;
+          /**
+           * @maxItems 36
+           */
           files?: {
             /**
              * HTTPS URL to the font file
@@ -26015,6 +24293,7 @@ export interface GetBrandIdentitySuccess {
             weight?: number;
             /**
              * Variable font weight axis range as [min, max]
+             * @maxItems 2
              */
             weight_range?: number[];
             /**
@@ -26024,10 +24303,12 @@ export interface GetBrandIdentitySuccess {
           }[];
           /**
            * OpenType feature tags to enable (e.g., ['ss01', 'tnum'])
+           * @maxItems 20
            */
           opentype_features?: string[];
           /**
            * Ordered fallback font-family names for script coverage
+           * @maxItems 10
            */
           fallbacks?: string[];
         };
@@ -26039,6 +24320,9 @@ export interface GetBrandIdentitySuccess {
                * CSS font-family name
                */
               family: string;
+              /**
+               * @maxItems 36
+               */
               files?: {
                 /**
                  * HTTPS URL to the font file
@@ -26054,6 +24338,7 @@ export interface GetBrandIdentitySuccess {
                 weight?: number;
                 /**
                  * Variable font weight axis range as [min, max]
+                 * @maxItems 2
                  */
                 weight_range?: number[];
                 /**
@@ -26063,10 +24348,12 @@ export interface GetBrandIdentitySuccess {
               }[];
               /**
                * OpenType feature tags to enable (e.g., ['ss01', 'tnum'])
+               * @maxItems 20
                */
               opentype_features?: string[];
               /**
                * Ordered fallback font-family names for script coverage
+               * @maxItems 10
                */
               fallbacks?: string[];
             }
@@ -27041,6 +25328,7 @@ export interface VerifyBrandClaimsRequestBulk {
   adcp_major_version?: number;
   /**
    * Ordered list of verification claims. The agent MUST return `results[]` in the same order (positional zip-by-index). Maximum batch size is 100 per call; agents MAY enforce a lower limit and SHOULD advertise it via `get_adcp_capabilities` (see the task page).
+   * @maxItems 100
    */
   claims: ClaimEntry[];
 }
@@ -27405,138 +25693,7 @@ export type GetProductsCompletion = AdCPVersionEnvelope &
      * @maxItems 20
      */
     suggestions?:
-      | []
-      | [string]
-      | [string, string]
-      | [string, string, string]
-      | [string, string, string, string]
-      | [string, string, string, string, string]
-      | [string, string, string, string, string, string]
-      | [string, string, string, string, string, string, string]
-      | [string, string, string, string, string, string, string, string]
-      | [string, string, string, string, string, string, string, string, string]
-      | [string, string, string, string, string, string, string, string, string, string]
-      | [string, string, string, string, string, string, string, string, string, string, string]
-      | [string, string, string, string, string, string, string, string, string, string, string, string]
-      | [string, string, string, string, string, string, string, string, string, string, string, string, string]
-      | [string, string, string, string, string, string, string, string, string, string, string, string, string, string]
-      | [
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string
-        ]
-      | [
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string
-        ]
-      | [
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string
-        ]
-      | [
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string
-        ]
-      | [
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string
-        ]
-      | [
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string
-        ];
+      string[];
     /**
      * [AdCP 3.0] Indicates whether deprecated top-level property_list filtering was applied. True if the agent filtered products based on the provided property_list; every returned product also carries the corresponding property/include list_applications receipt. Absent or false if property_list was not provided or not supported by this agent.
      */
@@ -28712,6 +26869,7 @@ export interface AccountChange {
   resource_revision?: number | string;
   /**
    * Bounded set of RFC 6901 JSON Pointers naming material fields that changed. Values are intentionally omitted.
+   * @maxItems 64
    */
   changed_paths?: string[];
   /**
@@ -28776,12 +26934,14 @@ export type AccountIdentityChangePreview =
   | AccountIdentityChangeBlocked;
 /**
  * Account areas the seller evaluated for continuity or reauthorization. Non-blocked outcomes cannot carry a blocked effect.
+ * @maxItems 16
  */
 export type NonblockingImpacts = (Impact & {
   effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
 })[];
 /**
  * Account areas evaluated for a blocked change. At least one impact identifies the blocking area.
+ * @maxItems 16
  */
 export type BlockedImpacts = Impact[];
 
@@ -28984,6 +27144,9 @@ export interface AgentNotificationConfigState {
    * @deprecated
    */
   authentication?: {
+    /**
+     * @maxItems 1
+     */
     schemes: AuthenticationScheme[];
   };
   active?: boolean;
@@ -29023,6 +27186,9 @@ export interface AgentNotificationConfig {
    * Legacy authentication selector. Same precedence and semantics as `push-notification-config.authentication` and account-level `notification-config.authentication`: presence opts the seller into Bearer or HMAC-SHA256 signing; absence selects the default RFC 9421 webhook profile keyed off the seller's brand.json `agents[]` JWKS. Deprecated; removed in AdCP 4.0. Credentials are write-only and MUST NOT be echoed on reads.
    */
   authentication?: {
+    /**
+     * @maxItems 1
+     */
     schemes: AuthenticationScheme[];
     /**
      * Credentials for the legacy scheme. Bearer: token. HMAC-SHA256: shared secret. Minimum 32 characters. Exchanged out-of-band during onboarding. Write-only.
@@ -29073,6 +27239,7 @@ export interface AgentReportingDestinationState {
   destination_ref: string;
   /**
    * Retained superseded generation references for this destination_id, newest first, still resolvable for existing authorized account bindings and retained reporting history. Enumerable only by the owning principal. Suspension and revocation of the destination apply to these generations too.
+   * @maxItems 32
    */
   prior_destination_refs?: string[];
   state: ReportingDestinationSetupState;
@@ -29095,6 +27262,7 @@ export interface AgentReportingDestinationState {
   };
   /**
    * Structured validation or setup issues. Messages and details are untrusted display data and MUST NOT be executed as instructions.
+   * @maxItems 16
    */
   issues?: Error[];
 }
@@ -30611,6 +28779,7 @@ export interface CreativeFilters {
   name_contains?: string;
   /**
    * Filter by specific creative IDs
+   * @maxItems 100
    */
   creative_ids?: string[];
   /**
@@ -30746,6 +28915,7 @@ export interface CreativeLocalizationReadback {
   locale_matching: 'rfc4647_lookup';
   /**
    * Exact buyer-declared language-family substitutions preserved from sync. For each requested preference, rules are checked from the most specific progressively truncated range to the least specific only after strict Lookup finds no equal available tag for that preference.
+   * @maxItems 50
    */
   locale_fallbacks?: {
     language_range: LanguageTag;
@@ -30757,6 +28927,7 @@ export interface CreativeLocalizationReadback {
   }[];
   /**
    * The source variant followed by every target variant, or only the source for monolingual topology. Assets are fully resolved after source inheritance. The enclosing creative status applies to the set as a whole.
+   * @maxItems 51
    */
   variants: (SourceLocalizationReadback | TargetLocalizationReadback)[];
 }
@@ -30813,6 +28984,7 @@ export interface CreativeLocalization {
   };
   /**
    * Complete desired target-locale set for this creative. May be empty for a monolingual source-only creative. Every target contains materialized locale-specific asset overrides. Missing slots inherit source assets; after inheritance every resolved variant MUST satisfy the selected creative format.
+   * @maxItems 50
    */
   target_variants: {
     /**
@@ -30835,6 +29007,7 @@ export interface CreativeLocalization {
   }[];
   /**
    * Optional explicit language-family substitutions evaluated only when strict RFC 4647 Lookup finds no equal available tag for the current requested preference. For each preference in order, the seller checks progressively truncated ranges from most to least specific and applies the first rule whose language_range equals that candidate. A rule may map a regional request to a different materialized regional variant, but no substitution is inferred when a rule is absent.
+   * @maxItems 50
    */
   locale_fallbacks?: {
     language_range: LanguageTag;
@@ -33835,6 +32008,9 @@ export interface PlacementPresentationDocument {
      */
     clip: true;
   };
+  /**
+   * @maxItems 100
+   */
   decorations?: (BoxDecoration | TextDecoration | ImageDecoration)[];
 }
 export interface BoxDecoration {
@@ -34102,6 +32278,7 @@ export interface PrincipalDeclarationsState {
   selected_async_adcp_version?: string;
   /**
    * Every declared value that is absent from the accepted intersection, with the seller's reason. Present whenever declared and accepted differ, so a buyer can see why a capability it relies on was not accepted instead of diffing the two sets.
+   * @maxItems 64
    */
   exclusions?: {
     axis: 'async_adcp_versions' | 'webhook_signing_algorithms' | 'experimental_features';
@@ -34129,14 +32306,7 @@ export interface AgentDeclarations {
    * @maxItems 8
    */
   async_adcp_versions?:
-    | [string]
-    | [string, string]
-    | [string, string, string]
-    | [string, string, string, string]
-    | [string, string, string, string, string]
-    | [string, string, string, string, string, string]
-    | [string, string, string, string, string, string, string]
-    | [string, string, string, string, string, string, string, string];
+    string[];
   /**
    * RFC 9421 webhook-signing algorithms the caller can verify. The accepted intersection with the seller's webhook_signing.algorithms MUST be non-empty when the caller has any active webhook subscriber; an empty intersection fails the sync request with UNSUPPORTED_FEATURE because delivery would be unverifiable.
    *
@@ -34149,7 +32319,7 @@ export interface AgentDeclarations {
    * @minItems 1
    * @maxItems 32
    */
-  experimental_features?: [ExperimentalFeatureID, ...ExperimentalFeatureID[]];
+  experimental_features?: ExperimentalFeatureID[];
 }
 
 // core/principal-state.json
@@ -34159,15 +32329,18 @@ export interface AgentDeclarations {
 export interface PrincipalState {
   /**
    * Current agent-level webhook subscribers. authentication.credentials is always omitted because it is write-only.
+   * @maxItems 16
    */
   notification_configs?: AgentNotificationConfigState[];
   /**
    * Current reusable reporting destination bindings and setup states. destination_id and destination_ref values MUST each be unique within this caller-scoped array; superseded generations of a current destination appear in its prior_destination_refs.
+   * @maxItems 64
    */
   reporting_destinations?: AgentReportingDestinationState[];
   declarations?: PrincipalDeclarationsState;
   /**
    * Destinations the caller revoked by omitting them from a submitted reporting_destinations section, retained while any generation remains resolvable for reporting history. Enumerable only by the owning principal. Reusing a retired destination_id requires fresh registration and proof and produces a new generation.
+   * @maxItems 64
    */
   retired_destinations?: {
     /**
@@ -34178,6 +32351,7 @@ export interface PrincipalState {
     destination_id: string;
     /**
      * Retained generation references of the revoked destination, newest first, still resolvable for retained reporting history but ineligible for delivery and for new bindings.
+     * @maxItems 32
      */
     destination_refs: string[];
     /**
@@ -35424,6 +33598,9 @@ export interface EmptyReportGoldenVector {
    */
   name: string;
   purpose: 'empty_report';
+  /**
+   * @maxItems 0
+   */
   input_rows: unknown[];
   /**
    * Base64 of the exact UTF-8 bytes for [].
@@ -36528,6 +34705,7 @@ export interface ReportingStatusChangedWebhook {
   previous_health?: ReportingHealth;
   /**
    * Stable identifiers of the open issues that caused or survived this transition, matching issues[].issue_id on get_reporting_status, so consumers can project AdCP reporting issues into durable work items. Empty or absent on recovery transitions.
+   * @maxItems 16
    */
   issue_ids?: string[];
   ext?: ExtensionObject;
@@ -36554,6 +34732,7 @@ export interface ReportingWebhook {
   authentication: {
     /**
      * Array of authentication schemes. ['Bearer'] for simple token auth, ['HMAC-SHA256'] for legacy shared-secret signing. Both are deprecated; new integrations SHOULD use the RFC 9421 webhook signing profile instead.
+     * @maxItems 1
      */
     schemes: AuthenticationScheme[];
     /**
@@ -37961,6 +36140,7 @@ export interface TasksListRequest {
     updated_before?: string;
     /**
      * Filter by specific task IDs
+     * @maxItems 100
      */
     task_ids?: string[];
     /**
@@ -39365,6 +37545,7 @@ export interface VideoBrief {
 export interface AccessibilityViolationDetails {
   /**
    * Accessibility requirements the creative or its assets failed. This is distinct from error.issues, which carries JSON Schema validator failures.
+   * @maxItems 4
    */
   violations: {
     /**
@@ -41795,6 +39976,7 @@ export interface ContextMatchRequest {
   artifact?: Artifact;
   /**
    * Public content references adjacent to this ad opportunity. Each artifact identifies content via a public identifier the buyer can resolve independently — no private registry sync required.
+   * @maxItems 20
    */
   artifact_refs?: {
     /**
@@ -41837,6 +40019,7 @@ export interface ContextMatchRequest {
   context_signals?: {
     /**
      * Content topic identifiers. Use IAB Content Taxonomy 3.0 IDs (e.g., '632' for Food & Drink) when taxonomy_id is 7, or human-readable strings (e.g., 'cooking.pasta') for custom taxonomies.
+     * @maxItems 50
      */
     topics?: string[];
     /**
@@ -41854,6 +40037,7 @@ export interface ContextMatchRequest {
     sentiment?: 'positive' | 'negative' | 'neutral' | 'mixed';
     /**
      * Content keywords extracted by the publisher's classifier.
+     * @maxItems 50
      */
     keywords?: string[];
     /**
@@ -41863,6 +40047,7 @@ export interface ContextMatchRequest {
     language?: string;
     /**
      * Policy IDs from the AdCP policy registry that this content satisfies (e.g., 'csbs' for Common Sense Brand Standards). Buyers filter on policies they require. An empty array means no policies have been evaluated.
+     * @maxItems 20
      */
     content_policies?: string[];
     /**
@@ -41888,6 +40073,7 @@ export interface ContextMatchRequest {
   };
   /**
    * Restrict evaluation to specific packages. When omitted, the provider evaluates all eligible packages for this placement (the common case). MUST NOT vary by user — the same package_ids must be sent for every user on a given placement. User-dependent filtering leaks identity into the context path.
+   * @maxItems 500
    */
   package_ids?: string[];
 }
@@ -42100,6 +40286,7 @@ export interface IdentityMatchRequest {
   seller_agent_url: string;
   /**
    * Identity tokens for the user, each tagged with its type. Publishers SHOULD include every token they have available — the buyer resolves on whichever graph matches. Entry order is not semantically significant; buyers use their own preference order when multiple entries resolve. Duplicate `(uid_type, user_token)` pairs MUST NOT appear; routers MAY reject or dedupe. `maxItems: 3` matches the TMPX plaintext budget (~120 bytes after HPKE overhead fits three 32-byte tokens); exceeding it forces buyer-side truncation.
+   * @maxItems 3
    */
   identities: {
     /**
@@ -42126,6 +40313,7 @@ export interface IdentityMatchRequest {
       action?: string;
       /**
        * Claims this attestation establishes. Closed, issuer-agnostic set.
+       * @maxItems 16
        */
       claims: AttestationClaim[];
       /**
@@ -42180,6 +40368,7 @@ export interface IdentityMatchRequest {
   country?: string;
   /**
    * Optional HPKE-sealed credentials addressed to specific audiences — the network-as-RP ("issuer-as-RP"/Mechanism B) carrier. Each payload is opaque to the publisher, who relays it untouched; the inner plaintext is an `attestation` (see identities[].attestation) scoped to the audience's relying party. Reuses the TMPX envelope format. Router handling (normative — see docs/trusted-match/specification.mdx): the router forwards each entry only to the provider that owns its `audience_kid` (not broadcast), folds `sealed_credentials` into the per-provider re-signature canonical bytes so an injected/swapped blob breaks the signature, and includes a `sealed_credentials_hash` in the dedup cache key. Receivers decrypt only entries whose `audience_kid` they hold a key for and ignore the rest. Receivers MUST bound count and size to prevent DoS amplification.
+   * @maxItems 8
    */
   sealed_credentials?: {
     /**
@@ -42276,6 +40465,7 @@ export interface IdentityMatchResponseRouterPublisher {
       | {
           /**
            * Ordered TMPX chunks for this provider. Each entry is a `{slot_id, value}` pair copied verbatim from the provider's `tmpx_chunks`. Ordered-prefix invariant: the sequence of `slot_id`s MUST equal an ordered prefix of the provider's registered `tmpx_slots` — publishers MAY reject responses whose slot_ids or ordering diverge. Cap of 2 chunks in v1; the cap MAY rise without a shape change.
+           * @maxItems 2
            */
           chunks: TMPXChunk[];
         }
@@ -42448,6 +40638,7 @@ export interface IdentityMatchResponseProviderRouter {
   serve_window_sec: number;
   /**
    * Ordered TMPX chunk/value pairs this identity agent mints. Each entry names the provider-local `slot_id` the value fills (from the provider's registered `tmpx_slots` in provider-registration.json). Ordered-prefix invariant: a response that carries fewer chunks than the provider registered MUST emit an ordered prefix of the registered `tmpx_slots` — routers MUST NOT reorder or fill gaps. The router MUST validate this contract before forwarding: if the provider has no `tmpx_slots` registration, or if the chunk `slot_id` sequence is not an exact non-empty ordered prefix of the registered list (duplicate, reordered, sparse, or unregistered slot IDs), the router MUST drop that provider's chunks atomically and MUST NOT forward them into `tmpx_providers`. Cap of 2 chunks in v1 aligned with the GAM macro-slot budget; the cap MAY rise without a shape change. Omitted when this provider mints no TMPX (e.g. no eligible packages).
+   * @maxItems 2
    */
   tmpx_chunks?: TMPXChunk[];
 }
@@ -42510,6 +40701,7 @@ export type TMPProviderRegistration = (
   priority?: number;
   /**
    * Stable provider-local slot identifiers for the ordered TMPX chunks this provider mints. Slot IDs are opaque provider-namespaced tokens (e.g. `["primary","secondary"]`), NOT ad-server macro names — publishers map `(provider_id, slot_id)` → local destination via `tmpx_macro_mapping` in publisher-tmpx-config.json, so the destination namespace stays publisher-owned and the router never accepts a destination name from an untrusted provider. Distinct providers MAY reuse the same slot_id without collision because publisher lookup is keyed on `(provider_id, slot_id)`. Publishers use this list at startup to validate `tmpx_macro_mapping` covers every slot the provider mints and to detect config drift when the provider's slot contract changes. Ordering carries the ordered-prefix invariant: a provider that emits fewer chunks than it registered MUST emit an ordered prefix of this list — chunks map to slots in registration order and MUST NOT be shifted, sparse, or reordered. Cap of 2 slots in v1 aligned with the GAM macro-slot budget; the cap MAY rise without a shape change. A provider that emits TMPX (populates `tmpx_chunks` on its identity-match response) MUST register this list; a provider that does not emit TMPX omits it. Schema cannot enforce that predicate because "emits TMPX" is not schema-visible.
+   * @maxItems 2
    */
   tmpx_slots?: string[];
   /**

--- a/src/lib/types/schemas.generated.ts
+++ b/src/lib/types/schemas.generated.ts
@@ -1,5 +1,5 @@
 // Generated Zod v4 schemas from TypeScript types
-// Generated at: 2026-09-02T17:24:17.391Z
+// Generated at: 2026-09-03T14:32:21.501Z
 // Sources:
 //   - core.generated.ts (core types)
 //   - tools.generated.ts (tool types)
@@ -523,7 +523,7 @@ export const BusinessEntitySchema = z.object({
         name: z.string().max(200).optional(),
         email: z.email().optional(),
         phone: z.string().max(30).optional()
-    }).passthrough()).optional(),
+    }).passthrough()).max(10).optional(),
     bank: z.object({
         account_holder: z.string().max(200),
         iban: z.string().regex(/^[A-Z]{2}[0-9]{2}[A-Z0-9]{4,30}$/).optional(),
@@ -869,7 +869,7 @@ export const MacroProcessingCapabilitySchema = z.object({}).passthrough().merge(
 }).passthrough());
 
 export const CreativeLocalePolicySchema = z.object({
-    accepted_language_ranges: z.array(LanguageTagSchema)
+    accepted_language_ranges: z.array(LanguageTagSchema).max(50)
 }).passthrough();
 
 export const CancellationPolicySchema = z.object({
@@ -1699,7 +1699,7 @@ export const CanonicalFormatHostedVideoSchema = z.object({
     min_height: z.int().min(1).optional(),
     max_width: z.int().min(1).optional(),
     max_height: z.int().min(1).optional(),
-    duration_ms_range: z.array(z.number().nullable()).optional(),
+    duration_ms_range: z.array(z.number().nullable()).max(2).optional(),
     duration_ms_exact: z.int().min(1).optional(),
     video_codecs: z.array(z.union([z.literal("h264"), z.literal("h265"), z.literal("vp8"), z.literal("vp9"), z.literal("av1"), z.literal("prores")])).optional(),
     audio_codecs: z.array(z.union([z.literal("aac"), z.literal("mp3"), z.literal("opus"), z.literal("pcm")])).optional(),
@@ -1763,7 +1763,7 @@ export const CanonicalFormatHostedAudioSchema = z.object({
     required_connections: z.array(DownstreamConnectionRequirementSchema).optional(),
     reference_mutability: z.union([z.literal("immutable_snapshot"), z.literal("mutable_requires_reapproval"), z.literal("mutable_auto_recheck")]).optional(),
     production_window_business_days: z.number().optional(),
-    duration_ms_range: z.array(z.number().nullable()).optional(),
+    duration_ms_range: z.array(z.number().nullable()).max(2).optional(),
     duration_ms_exact: z.int().min(1).optional(),
     audio_codecs: z.array(z.union([z.literal("mp3"), z.literal("aac"), z.literal("wav"), z.literal("opus"), z.literal("flac")])).optional(),
     audio_sample_rates: z.array(z.number()).optional(),
@@ -1878,7 +1878,7 @@ export const CanonicalFormatDAASTAudioSchema = z.object({
     production_window_business_days: z.number().optional(),
     daast_version: DAASTVersionSchema.optional(),
     daast_versions: DaastVersionsSchema.optional(),
-    duration_ms_range: z.array(z.number()).optional(),
+    duration_ms_range: z.array(z.number()).max(2).optional(),
     duration_ms_exact: z.int().min(1).optional(),
     linear_required: z.boolean().optional(),
     max_wrapper_depth: z.int().min(0).optional(),
@@ -2228,7 +2228,7 @@ export const CanonicalFormatVASTVideoSchema = z.object({
     vpaid_enabled: z.boolean().optional(),
     vpaid_version: z.union([z.literal("1.0"), z.literal("2.0")]).optional(),
     simid_supported: z.boolean().optional(),
-    duration_ms_range: z.array(z.number()).optional(),
+    duration_ms_range: z.array(z.number()).max(2).optional(),
     duration_ms_exact: z.int().min(1).optional(),
     min_width: z.int().min(1).optional(),
     max_width: z.int().min(1).optional(),
@@ -3774,7 +3774,7 @@ export const PaginationResponseSchema = z.object({
 export const GetProductsRejectedSchema = AdCPVersionEnvelopeSchema.merge(ProtocolEnvelopeSchema).and(z.object({
     status: z.literal("rejected"),
     reason: z.string().min(1).max(2000),
-    suggestions: z.array(z.string()).optional(),
+    suggestions: z.array(z.string()).max(20).optional(),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough());
@@ -4691,22 +4691,22 @@ export const GetBrandIdentitySuccessSchema = z.object({
                 files: z.array(z.object({
                     url: z.string().regex(/^https:\/\//),
                     weight: z.int().min(100).max(900).optional(),
-                    weight_range: z.array(z.number()).optional(),
+                    weight_range: z.array(z.number()).max(2).optional(),
                     style: z.union([z.literal("normal"), z.literal("italic"), z.literal("oblique")]).optional()
-                }).passthrough()).optional(),
-                opentype_features: z.array(z.string()).optional(),
-                fallbacks: z.array(z.string()).optional()
+                }).passthrough()).max(36).optional(),
+                opentype_features: z.array(z.string()).max(20).optional(),
+                fallbacks: z.array(z.string()).max(10).optional()
             }).passthrough()]).optional(),
         secondary: z.union([z.string(), z.object({
                 family: z.string(),
                 files: z.array(z.object({
                     url: z.string().regex(/^https:\/\//),
                     weight: z.int().min(100).max(900).optional(),
-                    weight_range: z.array(z.number()).optional(),
+                    weight_range: z.array(z.number()).max(2).optional(),
                     style: z.union([z.literal("normal"), z.literal("italic"), z.literal("oblique")]).optional()
-                }).passthrough()).optional(),
-                opentype_features: z.array(z.string()).optional(),
-                fallbacks: z.array(z.string()).optional()
+                }).passthrough()).max(36).optional(),
+                opentype_features: z.array(z.string()).max(20).optional(),
+                fallbacks: z.array(z.string()).max(10).optional()
             }).passthrough()]).optional()
     }).passthrough().catchall(z.union([z.string(), z.object({
                 family: z.string(),
@@ -4949,7 +4949,7 @@ export const ClaimEntrySchema = z.union([VerifySubsidiaryClaimSchema, VerifyPare
 export const VerifyBrandClaimsRequestBulkSchema = z.object({
     adcp_version: z.string().regex(new RegExp("^(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)(?:-[a-zA-Z0-9](?:[a-zA-Z0-9.-]*[a-zA-Z0-9])?)?$")).optional(),
     adcp_major_version: z.number().int().gte(1).lte(99).optional(),
-    claims: z.array(ClaimEntrySchema)
+    claims: z.array(ClaimEntrySchema).max(100)
 }).passthrough();
 
 export const VerifyBrandClaimsErrorSchema = z.object({
@@ -5147,7 +5147,7 @@ export const ArtifactSchema = z.object({
             transcript_format: z.union([z.literal("text/plain"), z.literal("text/markdown"), z.literal("application/json")]).optional(),
             transcript_source: z.union([z.literal("original_script"), z.literal("closed_captions"), z.literal("generated")]).optional(),
             provenance: ProvenanceSchema.optional()
-        }).passthrough()])),
+        }).passthrough()])).max(200),
     metadata: z.object({
         canonical: z.string().refine(adcpJsonSchemaUri, "Invalid URI").optional(),
         author: z.string().optional(),
@@ -5285,7 +5285,7 @@ export const AccountChangeSchema = z.object({
         connection_id: z.string().max(255).optional()
     }).passthrough(),
     resource_revision: z.union([z.number().int(), z.string()]).optional(),
-    changed_paths: z.array(z.string()).optional(),
+    changed_paths: z.array(z.string()).max(64).optional(),
     repair: z.object({
         task: z.union([z.literal("list_accounts"), z.literal("get_media_buys"), z.literal("get_media_buy_delivery"), z.literal("list_creatives"), z.literal("sync_audiences"), z.literal("sync_event_sources"), z.literal("sync_catalogs"), z.literal("get_account_financials"), z.literal("list_products"), z.literal("get_signals")]),
         available: z.boolean().optional(),
@@ -5306,11 +5306,11 @@ export const ImpactSchema = z.object({
     reason: z.string().optional()
 }).passthrough();
 
-export const BlockedImpactsSchema = z.array(ImpactSchema);
+export const BlockedImpactsSchema = z.array(ImpactSchema).max(16);
 
 export const NonblockingImpactsSchema = z.array(ImpactSchema.and(z.object({
     effect: z.union([z.literal("preserved"), z.literal("revalidation_required"), z.literal("revoke_and_regrant")]).optional()
-}).passthrough()));
+}).passthrough())).max(16);
 
 export const AccountIdentityChangeWouldRequireApprovalSchema = z.object({
     outcome: z.literal("would_require_approval"),
@@ -5684,7 +5684,7 @@ export const CreativeFiltersSchema = z.object({
     tags: z.array(z.string()).optional(),
     tags_any: z.array(z.string()).optional(),
     name_contains: z.string().optional(),
-    creative_ids: z.array(z.string()).optional(),
+    creative_ids: z.array(z.string()).max(100).optional(),
     created_after: z.string().refine(adcpJsonSchemaDateTime, "Invalid date-time").optional(),
     created_before: z.string().refine(adcpJsonSchemaDateTime, "Invalid date-time").optional(),
     updated_after: z.string().refine(adcpJsonSchemaDateTime, "Invalid date-time").optional(),
@@ -6355,9 +6355,9 @@ export const PrincipalChangedWebhookSchema = z.object({
 }).passthrough();
 
 export const AgentDeclarationsSchema = z.object({
-    async_adcp_versions: z.array(z.string()).optional(),
+    async_adcp_versions: z.array(z.string()).max(8).optional(),
     webhook_signing_algorithms: z.array(z.union([z.literal("ed25519"), z.literal("ecdsa-p256-sha256")])).optional(),
-    experimental_features: z.array(ExperimentalFeatureIDSchema).optional()
+    experimental_features: z.array(ExperimentalFeatureIDSchema).max(32).optional()
 }).passthrough();
 
 export const PrincipalDeclarationsStateSchema = z.object({
@@ -6368,7 +6368,7 @@ export const PrincipalDeclarationsStateSchema = z.object({
         axis: z.union([z.literal("async_adcp_versions"), z.literal("webhook_signing_algorithms"), z.literal("experimental_features")]),
         value: z.string().min(1).max(128),
         reason: z.string().min(1).max(512)
-    }).passthrough()).optional()
+    }).passthrough()).max(64).optional()
 }).passthrough();
 
 export const ProductChangeMapSchema = z.record(z.string(), z.union([z.literal("include"), z.literal("omit")]));
@@ -6513,7 +6513,7 @@ export const ReportingPrimaryKeySchema = z.string();
 export const EmptyReportGoldenVectorSchema = z.object({
     name: z.string().min(1).max(128).regex(/^[A-Za-z0-9_.:-]{1,128}$/),
     purpose: z.literal("empty_report"),
-    input_rows: z.array(z.unknown()),
+    input_rows: z.array(z.unknown()).max(0),
     canonical_utf8_base64: z.literal("W10="),
     sha256: z.literal("4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945")
 }).passthrough();
@@ -6799,7 +6799,7 @@ export const ReportingStatusChangedWebhookSchema = z.object({
     reporting_obligation_id: z.string().min(1).max(255).regex(/^[A-Za-z0-9_.:-]{1,255}$/).optional(),
     health: ReportingHealthSchema,
     previous_health: ReportingHealthSchema.optional(),
-    issue_ids: z.array(z.string()).optional(),
+    issue_ids: z.array(z.string()).max(16).optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
@@ -7045,7 +7045,7 @@ export const TasksListRequestSchema = z.object({
         created_before: z.iso.datetime().optional(),
         updated_after: z.iso.datetime().optional(),
         updated_before: z.iso.datetime().optional(),
-        task_ids: z.array(z.string()).optional(),
+        task_ids: z.array(z.string()).max(100).optional(),
         context_contains: z.string().optional(),
         has_webhook: z.boolean().optional()
     }).passthrough().optional(),
@@ -7290,7 +7290,7 @@ export const AccessibilityViolationDetailsSchema = z.object({
         required_level: z.string().min(1).max(64).regex(/^[^\u0000-\u001F\u007F]+$/),
         failure_kind: z.union([z.union([z.literal("alt_text_missing"), z.literal("contrast_ratio_insufficient"), z.literal("captions_missing"), z.literal("transcript_missing"), z.literal("keyboard_navigation_failure"), z.literal("focus_order_invalid"), z.literal("aria_label_missing"), z.literal("other")]), z.string()]),
         remediation: z.string().max(256).regex(/^[^\u0000-\u001F\u007F]*$/).optional()
-    }).passthrough()),
+    }).passthrough()).max(4),
     truncated: z.boolean().optional()
 }).passthrough();
 
@@ -7874,7 +7874,7 @@ export const ContextMatchRequestSchema = z.object({
     artifact_refs: z.array(z.object({
         type: z.union([z.literal("url"), z.literal("url_hash"), z.literal("eidr"), z.literal("gracenote"), z.literal("isrc"), z.literal("gtin"), z.literal("rss_guid"), z.literal("isbn"), z.literal("custom")]),
         value: z.string()
-    }).strict()).optional(),
+    }).strict()).max(20).optional(),
     geo: z.object({
         country: z.string().regex(/^[A-Z]{2}$/).optional(),
         region: z.string().regex(/^[A-Z]{2}-[A-Z0-9]{1,3}$/).optional(),
@@ -7884,19 +7884,19 @@ export const ContextMatchRequestSchema = z.object({
         }).strict().optional()
     }).strict().optional(),
     context_signals: z.object({
-        topics: z.array(z.string()).optional(),
+        topics: z.array(z.string()).max(50).optional(),
         taxonomy_source: z.string().optional(),
         taxonomy_id: z.int().optional(),
         sentiment: z.union([z.literal("positive"), z.literal("negative"), z.literal("neutral"), z.literal("mixed")]).optional(),
-        keywords: z.array(z.string()).optional(),
+        keywords: z.array(z.string()).max(50).optional(),
         language: z.string().regex(/^[a-z]{2}$/).optional(),
-        content_policies: z.array(z.string()).optional(),
+        content_policies: z.array(z.string()).max(20).optional(),
         summary: z.string().max(500).optional(),
         embedding: z.string().optional(),
         embedding_model: z.string().optional(),
         embedding_dims: z.int().min(64).max(2048).optional()
     }).strict().optional(),
-    package_ids: z.array(z.string()).optional()
+    package_ids: z.array(z.string()).max(500).optional()
 }).strict();
 
 export const TargetingKvsSchema = z.array(z.object({
@@ -7933,13 +7933,13 @@ export const IdentityMatchRequestSchema = z.object({
             scheme: z.string(),
             relying_party_id: z.string().optional(),
             action: z.string().optional(),
-            claims: z.array(AttestationClaimSchema),
+            claims: z.array(AttestationClaimSchema).max(16),
             verification_level: z.union([z.literal("orb"), z.literal("device"), z.literal("document")]).optional(),
             signal_binding: z.string().optional(),
             proof: z.object({}).passthrough(),
             expires_at: z.iso.datetime().optional()
         }).strict().optional()
-    }).strict()),
+    }).strict()).max(3),
     consent: z.object({
         gdpr: z.boolean().optional(),
         tcf_consent: z.string().optional(),
@@ -7951,7 +7951,7 @@ export const IdentityMatchRequestSchema = z.object({
     sealed_credentials: z.array(z.object({
         audience_kid: z.string().max(128),
         payload: z.string().max(8192)
-    }).strict()).optional()
+    }).strict()).max(8).optional()
 }).strict();
 
 export const TMPXChunkSchema = z.object({
@@ -8454,7 +8454,7 @@ export const DeclineProposalsRequestSchema = z.object({
     governance_context: z.string().min(1).max(4096).optional(),
     push_notification_config: PushNotificationConfigSchema.optional(),
     idempotency_key: z.string().min(16).max(255).regex(/^[A-Za-z0-9_.:-]{16,255}$/),
-    declines: z.array(ProposalDeclineSchema),
+    declines: z.array(ProposalDeclineSchema).max(25),
     opportunity: OpportunityContextSchema.optional()
 }).passthrough();
 
@@ -8882,8 +8882,8 @@ export const GetReportingStatusRequestSchema = z.object({
     adcp_major_version: z.number().int().gte(1).lte(99).optional(),
     account: CanonicalAccountReferenceSchema,
     view: ReportingStatusViewSchema,
-    media_buy_ids: z.array(ReportingMediaBuyIDSchema).optional(),
-    delivery_config_ids: z.array(z.string()).optional(),
+    media_buy_ids: z.array(ReportingMediaBuyIDSchema).max(100).optional(),
+    delivery_config_ids: z.array(z.string()).max(16).optional(),
     feed_purposes: z.array(ReportingFeedPurposeSchema).optional(),
     period: z.object({
         start: z.iso.datetime(),
@@ -8985,7 +8985,7 @@ export const UnavailableLookupSchema = z.object({
     errors: z.array(z.object({
         code: z.literal("NOT_FOUND"),
         message: z.literal("Reporting status resource is unavailable.")
-    }).passthrough())
+    }).passthrough()).max(1)
 }).passthrough();
 
 export const OperationalFailureSchema = z.object({
@@ -9008,7 +9008,7 @@ export const SyncReportingReceiptsRequestSchema = z.object({
     adcp_major_version: z.number().optional(),
     account: CanonicalAccountReferenceSchema,
     idempotency_key: z.string().min(16).max(255).regex(/^[A-Za-z0-9_.:-]{16,255}$/),
-    receipts: z.array(ReportingReceiptSchema),
+    receipts: z.array(ReportingReceiptSchema).max(100),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
@@ -9026,7 +9026,7 @@ export const UnchangedReportingReceiptSchema = z.object({
 export const FailedReportingReceiptSchema = z.object({
     result: z.literal("failed"),
     reporting_receipt_id: z.string().min(16).max(255).regex(/^[A-Za-z0-9_.:-]{16,255}$/),
-    errors: z.array(ErrorSchema)
+    errors: z.array(ErrorSchema).max(16)
 }).passthrough();
 
 export const ProvidePerformanceFeedbackRequestSchema = z.object({
@@ -9136,7 +9136,7 @@ export const LogEventRequestSchema = z.object({
     adcp_major_version: z.number().int().gte(1).lte(99).optional(),
     event_source_id: z.string(),
     test_event_code: z.string().optional(),
-    events: z.array(EventSchema),
+    events: z.array(EventSchema).max(10000),
     idempotency_key: z.string().min(16).max(255).regex(/^[A-Za-z0-9_.:-]{16,255}$/),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
@@ -9252,10 +9252,10 @@ export const SyncCatalogsRequestSchema = z.object({}).passthrough().merge(z.obje
     adcp_major_version: z.number().int().gte(1).lte(99).optional(),
     idempotency_key: z.string().min(16).max(255).regex(/^[A-Za-z0-9_.:-]{16,255}$/),
     account: AccountReferenceSchema,
-    catalogs: z.array(CatalogSchema).optional(),
-    item_availability_updates: z.array(CatalogItemAvailabilityUpdateSchema).optional(),
-    item_availability_queries: z.array(CatalogItemAvailabilityReferenceSchema).optional(),
-    catalog_ids: z.array(z.string()).optional(),
+    catalogs: z.array(CatalogSchema).max(50).optional(),
+    item_availability_updates: z.array(CatalogItemAvailabilityUpdateSchema).max(1000).optional(),
+    item_availability_queries: z.array(CatalogItemAvailabilityReferenceSchema).max(1000).optional(),
+    catalog_ids: z.array(z.string()).max(50).optional(),
     delete_missing: z.boolean().optional(),
     dry_run: z.boolean().optional(),
     validation_mode: ValidationModeSchema.optional(),
@@ -9287,8 +9287,8 @@ export const SyncCatalogsSuccessSchema = z.object({
         errors: z.array(ErrorSchema).optional(),
         warnings: z.array(z.string()).optional()
     }).passthrough()),
-    item_availability_updates: z.array(CatalogItemAvailabilityUpdateResultSchema).optional(),
-    item_availability_states: z.array(CatalogItemAvailabilityStateSchema).optional(),
+    item_availability_updates: z.array(CatalogItemAvailabilityUpdateResultSchema).max(1000).optional(),
+    item_availability_states: z.array(CatalogItemAvailabilityStateSchema).max(1000).optional(),
     sandbox: z.boolean().optional(),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
@@ -10178,7 +10178,7 @@ export const Artifact1Schema = z.object({
             transcript_format: z.union([z.literal("text/plain"), z.literal("text/markdown"), z.literal("application/json")]).optional(),
             transcript_source: z.union([z.literal("original_script"), z.literal("closed_captions"), z.literal("generated")]).optional(),
             provenance: ProvenanceSchema.optional()
-        }).passthrough()])),
+        }).passthrough()])).max(200),
     metadata: z.object({
         canonical: z.string().optional(),
         author: z.string().optional(),
@@ -10324,7 +10324,7 @@ export const ValidateContentDeliveryRequestSchema = z.object({
             brand_id: z.string().optional(),
             sku_id: z.string().optional()
         }).passthrough().optional()
-    }).passthrough()),
+    }).passthrough()).max(10000),
     feature_ids: z.array(z.string()).optional(),
     include_passed: z.boolean().optional(),
     context: ContextObjectSchema.optional(),
@@ -10724,7 +10724,7 @@ export const CheckGovernanceResponseSchema = z.object({
         action_binding: z.object({
             action_type: z.literal("https://adcontextprotocol.org/actions/governance-check")
         }).passthrough()
-    }).passthrough())).optional(),
+    }).passthrough())).max(10).optional(),
     runtime_attestation_binding_digest: z.string().regex(/^sha256:[a-f0-9]{64}$/).optional(),
     governance_context: z.string().min(1).max(4096).regex(/^[\x20-\x7E]+$/).optional(),
     context: ContextObjectSchema.optional(),
@@ -10961,10 +10961,10 @@ export const AttestationCapabilitiesSchema = z.object({}).passthrough().merge(z.
         proof_formats: z.array(z.string()).optional(),
         credential_origins: z.array(z.string()).optional(),
         resolvers: z.array(z.object({
-            resolver_id: z.string().min(1).max(255).regex(new RegExp("^[A-Za-z0-9._:-]+$")),
-            url: z.string().regex(new RegExp("^https://[^/?#@]+(?:/[^?#]*)?(?:\\?[^#]*)?$")).refine(adcpJsonSchemaUri, "Invalid URI"),
-            authentication: z.union([z.literal("none"), z.literal("evaluator_managed")])
-        }).passthrough()).optional(),
+                resolver_id: z.string().min(1).max(255).regex(new RegExp("^[A-Za-z0-9._:-]+$")),
+                url: z.string().regex(new RegExp("^https://[^/?#@]+(?:/[^?#]*)?(?:\\?[^#]*)?$")).refine(adcpJsonSchemaUri, "Invalid URI"),
+                authentication: z.union([z.literal("none"), z.literal("evaluator_managed")])
+            }).passthrough()).optional(),
         ext: ExtensionObjectSchema.optional()
     }).passthrough()),
     accepted_verifiers: z.array(z.object({
@@ -11141,7 +11141,7 @@ export const ListTasksRequestSchema = z.object({
         created_before: z.iso.datetime().optional(),
         updated_after: z.iso.datetime().optional(),
         updated_before: z.iso.datetime().optional(),
-        task_ids: z.array(z.string()).optional(),
+        task_ids: z.array(z.string()).max(100).optional(),
         context_contains: z.string().optional(),
         has_webhook: z.boolean().optional()
     }).passthrough().optional(),
@@ -11202,7 +11202,7 @@ export const SyncAgentNotificationConfigsRequestSchema = z.object({
     adcp_version: z.string().regex(new RegExp("^(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)(?:-[a-zA-Z0-9](?:[a-zA-Z0-9.-]*[a-zA-Z0-9])?)?$")).optional(),
     adcp_major_version: z.number().int().gte(1).lte(99).optional(),
     idempotency_key: z.string().min(16).max(255).regex(/^[A-Za-z0-9_.:-]{16,255}$/),
-    notification_configs: z.array(AgentNotificationConfigSchema),
+    notification_configs: z.array(AgentNotificationConfigSchema).max(16),
     dry_run: z.boolean().optional(),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
@@ -11224,7 +11224,7 @@ export const SyncAgentNotificationConfigsResponseSchema = z.object({
     adcp_major_version: z.number().int().gte(1).lte(99).optional(),
     dry_run: z.boolean().optional(),
     action: z.union([z.literal("updated"), z.literal("unchanged"), z.literal("cleared"), z.literal("failed")]),
-    notification_configs: z.array(AgentNotificationConfigSchema).optional(),
+    notification_configs: z.array(AgentNotificationConfigSchema).max(16).optional(),
     errors: z.array(ErrorSchema).optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
@@ -11258,7 +11258,7 @@ export const AgentReportingDestinationSchema = z.union([FileTransferDestinationS
 export const AgentReportingDestinationStateSchema = z.object({}).passthrough().merge(z.object({
     destination_id: z.string().min(1).max(64).regex(new RegExp("^[A-Za-z0-9_.:-]{1,64}$")),
     destination_ref: z.string().min(1).max(255),
-    prior_destination_refs: z.array(z.string()).optional(),
+    prior_destination_refs: z.array(z.string()).max(32).optional(),
     state: ReportingDestinationSetupStateSchema,
     configuration: AgentReportingDestinationSchema,
     setup: z.object({
@@ -11266,30 +11266,30 @@ export const AgentReportingDestinationStateSchema = z.object({}).passthrough().m
         setup_url: z.string().regex(new RegExp("^https://[!z.string()-;=@-~]+$")).refine(adcpJsonSchemaUri, "Invalid URI").optional(),
         expires_at: z.string().refine(adcpJsonSchemaDateTime, "Invalid date-time").optional()
     }).passthrough().optional(),
-    issues: z.array(ErrorSchema).optional()
+    issues: z.array(ErrorSchema).max(16).optional()
 }).passthrough());
 
 export const ValidatedPrincipalDryRunSchema = z.object({
     kind: z.literal("validated"),
     action: z.union([z.literal("would_update"), z.literal("would_be_unchanged"), z.literal("would_clear")]),
     dry_run: z.literal(true),
-    warnings: z.array(ErrorSchema).optional()
+    warnings: z.array(ErrorSchema).max(16).optional()
 }).passthrough();
 
 export const FailedPrincipalSyncSchema = z.object({
     kind: z.literal("failed"),
-    errors: z.array(ErrorSchema)
+    errors: z.array(ErrorSchema).max(16)
 }).passthrough();
 
 export const PrincipalStateSchema = z.object({
-    notification_configs: z.array(AgentNotificationConfigStateSchema).optional(),
-    reporting_destinations: z.array(AgentReportingDestinationStateSchema).optional(),
+    notification_configs: z.array(AgentNotificationConfigStateSchema).max(16).optional(),
+    reporting_destinations: z.array(AgentReportingDestinationStateSchema).max(64).optional(),
     declarations: PrincipalDeclarationsStateSchema.optional(),
     retired_destinations: z.array(z.object({
         destination_id: z.string().min(1).max(64).regex(new RegExp("^[A-Za-z0-9_.:-]{1,64}$")),
-        destination_refs: z.array(z.string()),
+        destination_refs: z.array(z.string()).max(32),
         revoked_at: z.string().refine(adcpJsonSchemaDateTime, "Invalid date-time").optional()
-    }).passthrough()).optional()
+    }).passthrough()).max(64).optional()
 }).passthrough();
 
 export const GetPrincipalRequestSchema = z.object({
@@ -11319,7 +11319,7 @@ export const UnconfiguredPrincipalSchema = z.object({
 
 export const FailedPrincipalReadSchema = z.object({
     kind: z.literal("failed"),
-    errors: z.array(ErrorSchema)
+    errors: z.array(ErrorSchema).max(16)
 }).passthrough();
 
 export const ListAccountChangesRequestSchema = z.object({
@@ -11328,7 +11328,7 @@ export const ListAccountChangesRequestSchema = z.object({
     account: AccountReferenceSchema,
     cursor: z.string().min(1).max(4096).optional(),
     starting_position: z.union([z.literal("earliest"), z.literal("latest")]).optional(),
-    resource_types: z.array(z.string()).optional(),
+    resource_types: z.array(z.string()).max(50).optional(),
     max_results: z.int().min(1).max(100).optional(),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
@@ -11348,7 +11348,7 @@ export const ListAccountChangesResponseSchema = z.object({
     payload: z.object({}).passthrough().optional(),
     adcp_version: z.string().regex(new RegExp("^(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)(?:-[a-zA-Z0-9](?:[a-zA-Z0-9.-]*[a-zA-Z0-9])?)?$")).optional(),
     adcp_major_version: z.number().int().gte(1).lte(99).optional(),
-    changes: z.array(AccountChangeSchema).optional(),
+    changes: z.array(AccountChangeSchema).max(100).optional(),
     cursor: z.string().min(1).max(4096).optional(),
     has_more: z.boolean().optional(),
     available_since: z.iso.datetime().optional(),
@@ -11361,12 +11361,12 @@ export const ListAccountChangesResponseSchema = z.object({
         observed_through: z.iso.datetime().optional(),
         last_successful_sync_at: z.iso.datetime().optional(),
         stale_after_seconds: z.int().min(1).max(2592000).optional(),
-        resource_types: z.array(z.string())
-    }).passthrough()).optional(),
+        resource_types: z.array(z.string()).max(50)
+    }).passthrough()).max(50).optional(),
     errors: z.array(ErrorSchema).optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough().and(z.union([z.object({
-        changes: z.array(AccountChangeSchema),
+        changes: z.array(AccountChangeSchema).max(100),
         cursor: z.string().min(1).max(4096),
         has_more: z.boolean(),
         available_since: z.iso.datetime(),
@@ -11379,14 +11379,14 @@ export const ListAccountChangesResponseSchema = z.object({
             observed_through: z.iso.datetime().optional(),
             last_successful_sync_at: z.iso.datetime().optional(),
             stale_after_seconds: z.int().min(1).max(2592000).optional(),
-            resource_types: z.array(z.string())
-        }).passthrough()).optional(),
+            resource_types: z.array(z.string()).max(50)
+        }).passthrough()).max(50).optional(),
         errors: z.array(ErrorSchema).optional(),
         context: ContextObjectSchema.optional(),
         ext: ExtensionObjectSchema.optional(),
         status: z.literal("completed")
     }).passthrough(), z.object({
-        changes: z.array(AccountChangeSchema).optional(),
+        changes: z.array(AccountChangeSchema).max(100).optional(),
         cursor: z.string().min(1).max(4096).optional(),
         has_more: z.boolean().optional(),
         available_since: z.iso.datetime().optional(),
@@ -11399,8 +11399,8 @@ export const ListAccountChangesResponseSchema = z.object({
             observed_through: z.iso.datetime().optional(),
             last_successful_sync_at: z.iso.datetime().optional(),
             stale_after_seconds: z.int().min(1).max(2592000).optional(),
-            resource_types: z.array(z.string())
-        }).passthrough()).optional(),
+            resource_types: z.array(z.string()).max(50)
+        }).passthrough()).max(50).optional(),
         errors: z.array(ErrorSchema),
         context: ContextObjectSchema.optional(),
         ext: ExtensionObjectSchema.optional(),
@@ -11443,11 +11443,11 @@ export const SyncGovernanceRequestSchema = z.object({
         governance_agents: z.array(z.object({
             url: z.string().refine(adcpJsonSchemaUri, "Invalid URI").regex(/^https:\/\//),
             authentication: z.object({
-                schemes: z.array(z.literal("Bearer")),
+                schemes: z.array(z.literal("Bearer")).max(1),
                 credentials: z.string().min(32)
             }).passthrough()
-        }).passthrough())
-    }).passthrough()),
+        }).passthrough()).max(1)
+    }).passthrough()).max(100),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
@@ -11458,7 +11458,7 @@ export const SyncGovernanceSuccessSchema = z.object({
         status: z.union([z.literal("synced"), z.literal("failed")]),
         governance_agents: z.array(z.object({
             url: z.string().regex(/^https:\/\//)
-        }).passthrough()).optional(),
+        }).passthrough()).max(1).optional(),
         errors: z.array(ErrorSchema).optional()
     }).passthrough()),
     context: ContextObjectSchema.optional(),
@@ -11665,7 +11665,7 @@ export const ForcedDirectiveSuccessSchema = z.object({
         arm: z.union([z.literal("submitted"), z.literal("input-required"), z.literal("rejected")]),
         task_id: z.string().max(128).optional(),
         reason: z.string().min(1).max(2000).optional(),
-        suggestions: z.array(z.string()).optional()
+        suggestions: z.array(z.string()).max(20).optional()
     }).passthrough(),
     message: z.string().optional(),
     context: ContextObjectSchema.optional(),
@@ -11725,7 +11725,7 @@ export const DigestAttestationSchema = z.object({
     identifier_match_proofs: z.array(z.object({
         identifier_value_sha256: z.string().regex(/^[a-f0-9]{64}$/),
         found: z.boolean()
-    }).passthrough()).optional(),
+    }).passthrough()).max(64).optional(),
     timestamp: z.iso.datetime(),
     status_code: z.int().min(100).max(599).optional()
 }).passthrough();
@@ -12052,7 +12052,7 @@ export const AudienceEvidenceSchema: z.ZodType = z.object({}).passthrough().merg
             resource_type: z.literal("https://adcontextprotocol.org/claims/subjects/audience-evidence"),
             content_digest: z.string().regex(new RegExp("^sha256:[a-f0-9]{64}$"))
         }).passthrough())
-    }).passthrough())).optional(),
+    }).passthrough())).max(10).optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough()).merge(z.object({
     evidence_id: z.string().min(1),
@@ -12085,7 +12085,7 @@ export const AudienceEvidenceSchema: z.ZodType = z.object({}).passthrough().merg
             resource_type: z.literal("https://adcontextprotocol.org/claims/subjects/audience-evidence"),
             content_digest: z.string().regex(new RegExp("^sha256:[a-f0-9]{64}$"))
         }).passthrough())
-    }).passthrough())).optional(),
+    }).passthrough())).max(10).optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough());
 
@@ -12130,7 +12130,7 @@ export const AudienceEvidenceSelectionSchema: z.ZodType = z.object({
                 action_digest: z.string()
             }).passthrough()
         }).passthrough())
-    }).passthrough()).optional(),
+    }).passthrough()).max(10).optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
@@ -12521,7 +12521,7 @@ export const RightsConstraintSchema = z.object({}).passthrough().merge(z.object(
             type: z.literal("resource"),
             resource_type: z.literal("https://adcontextprotocol.org/claims/subjects/rights-grant")
         }).passthrough().optional()
-    }).passthrough())).optional(),
+    }).passthrough())).max(4).optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough()).merge(z.object({
     rights_id: z.string(),
@@ -12554,7 +12554,7 @@ export const RightsConstraintSchema = z.object({}).passthrough().merge(z.object(
             type: z.literal("resource"),
             resource_type: z.literal("https://adcontextprotocol.org/claims/subjects/rights-grant")
         }).passthrough().optional()
-    }).passthrough())).optional(),
+    }).passthrough())).max(4).optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough());
 
@@ -13018,11 +13018,11 @@ export const CreativeLocalizationSchema = z.object({
         locale_variant_id: z.string().min(1).max(255),
         locale: LanguageTagSchema,
         assets: z.record(z.string(), z.union([LocalizedCreativeAssetSchema, z.array(LocalizedCreativeAssetSchema)]))
-    }).passthrough()),
+    }).passthrough()).max(50),
     locale_fallbacks: z.array(z.object({
         language_range: LanguageTagSchema,
         locale_variant_id: z.string().min(1).max(255)
-    }).passthrough()).optional(),
+    }).passthrough()).max(50).optional(),
     default_locale_variant_id: z.string().min(1).max(255),
     unmatched_locale_action: z.union([z.literal("serve_default"), z.literal("do_not_serve")])
 }).passthrough();
@@ -14301,7 +14301,7 @@ export const RefineProposalsRequestSchema = z.object({
     governance_context: z.string().min(1).max(4096).optional(),
     push_notification_config: PushNotificationConfigSchema.optional(),
     idempotency_key: z.string().min(16).max(255).regex(/^[A-Za-z0-9_.:-]{16,255}$/),
-    refinements: z.array(ProposalRefinementSchema)
+    refinements: z.array(ProposalRefinementSchema).max(25)
 }).passthrough();
 
 export const BuyProductsRequestSchema = z.object({
@@ -14504,7 +14504,7 @@ export const PackageRequestSchema: z.ZodObject<{ [K in keyof PackageRequest]-?: 
             }).passthrough().optional()
         }).passthrough()])).optional(),
     creative_assignments: z.array(CreativeAssignmentSchema).optional(),
-    creatives: z.array(CreativeAssetSchema.and(z.object({}).passthrough())).optional(),
+    creatives: z.array(CreativeAssetSchema.and(z.object({}).passthrough())).max(100).optional(),
     agency_estimate_number: z.string().max(100).optional(),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
@@ -14886,7 +14886,7 @@ export const PackageUpdateSchema: z.ZodObject<{ [K in keyof PackageUpdate]-?: un
         match_type: MatchTypeSchema
     }).passthrough()).optional(),
     creative_assignments: z.array(CreativeAssignmentSchema).optional(),
-    creatives: z.array(CreativeAssetSchema).optional(),
+    creatives: z.array(CreativeAssetSchema).max(100).optional(),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
@@ -14956,9 +14956,9 @@ export const AccountSchema = z.object({
         setup_instructions: z.string().regex(new RegExp("^https://")).refine(adcpJsonSchemaUri, "Invalid URI").optional()
     }).passthrough().optional(),
     sandbox: z.boolean().optional(),
-    notification_configs: z.array(NotificationConfigSchema).optional(),
-    reporting_delivery_configs: z.array(ReportingDeliveryConfigurationStateSchema).optional(),
-    webhook_activity: z.array(WebhookActivityRecordSchema).optional(),
+    notification_configs: z.array(NotificationConfigSchema).max(16).optional(),
+    reporting_delivery_configs: z.array(ReportingDeliveryConfigurationStateSchema).max(16).optional(),
+    webhook_activity: z.array(WebhookActivityRecordSchema).max(200).optional(),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
@@ -15274,7 +15274,7 @@ export const SyncReportingReceiptsResponseSchema = z.object({
     payload: z.object({}).passthrough().optional(),
     adcp_version: z.string().regex(new RegExp("^(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)(?:-[a-zA-Z0-9](?:[a-zA-Z0-9.-]*[a-zA-Z0-9])?)?$")).optional(),
     adcp_major_version: z.number().int().gte(1).lte(99).optional(),
-    results: z.array(z.union([RecordedReportingReceiptSchema, UnchangedReportingReceiptSchema, FailedReportingReceiptSchema])),
+    results: z.array(z.union([RecordedReportingReceiptSchema, UnchangedReportingReceiptSchema, FailedReportingReceiptSchema])).max(100),
     ext: ExtensionObjectSchema.optional()
 }).passthrough();
 
@@ -15357,9 +15357,9 @@ export const BuildCreativeRequestSchema = z.object({
     media_buy_id: z.string().optional(),
     package_id: z.string().optional(),
     target_format_id: FormatReferenceStructuredObjectSchema.optional(),
-    target_format_ids: z.array(FormatReferenceStructuredObjectSchema).optional(),
+    target_format_ids: z.array(FormatReferenceStructuredObjectSchema).max(50).optional(),
     target_capability_id: z.string().regex(/^[a-zA-Z0-9_-]+$/).optional(),
-    target_capability_ids: z.array(z.string()).optional(),
+    target_capability_ids: z.array(z.string()).max(50).optional(),
     transformer_id: z.string().optional(),
     config: z.object({}).passthrough().optional(),
     refine_from_build_variant_id: z.string().optional(),
@@ -15460,7 +15460,7 @@ export const PreviewCreativeRequestSchema: z.ZodObject<{ request_type: z.ZodType
         quality: CreativeQualitySchema.optional(),
         output_format: PreviewOutputFormatSchema.optional(),
         item_limit: z.int().min(1).optional()
-    }).passthrough()).optional(),
+    }).passthrough()).max(50).optional(),
     variant_id: z.string().optional(),
     creative_id: z.string().optional(),
     allow_async: z.boolean().optional(),
@@ -15602,8 +15602,8 @@ export const CreativeLocalizationReadbackSchema: z.ZodType = z.object({
     locale_fallbacks: z.array(z.object({
         language_range: LanguageTagSchema,
         locale_variant_id: z.string().min(1).max(255)
-    }).passthrough()).optional(),
-    variants: z.array(z.union([SourceLocalizationReadbackSchema, TargetLocalizationReadbackSchema]))
+    }).passthrough()).max(50).optional(),
+    variants: z.array(z.union([SourceLocalizationReadbackSchema, TargetLocalizationReadbackSchema])).max(51)
 }).passthrough();
 
 // @ts-ignore -- preserve the public schema type across lossy TS-to-Zod projection details.
@@ -15614,15 +15614,15 @@ export const SyncCreativesRequestSchema: z.ZodObject<{ [K in keyof SyncCreatives
     creatives: z.array(CreativeAssetSchema.and(z.object({
         revision_id: CreativeRevisionIDSchema.optional(),
         localization: CreativeLocalizationSchema.optional().nullable()
-    }).passthrough())).optional(),
-    creative_ids: z.array(z.string()).optional(),
+    }).passthrough())).max(100).optional(),
+    creative_ids: z.array(z.string()).max(100).optional(),
     assignments: z.array(z.object({
         creative_id: z.string(),
         package_id: z.string(),
         weight: z.number().min(0).max(100).optional(),
         placement_ids: z.array(z.string()).optional()
     }).passthrough()).optional(),
-    assignment_operations: z.array(z.union([AssignOrUpdateSchema, UnassignSchema, ReplaceAssignmentSchema])).optional(),
+    assignment_operations: z.array(z.union([AssignOrUpdateSchema, UnassignSchema, ReplaceAssignmentSchema])).max(500).optional(),
     idempotency_key: z.string().min(16).max(255).regex(/^[A-Za-z0-9_.:-]{16,255}$/),
     delete_missing: z.boolean().optional(),
     dry_run: z.boolean().optional(),
@@ -15660,7 +15660,7 @@ export const ValidateInputRequestSchema = z.object({
     account: AccountReferenceSchema.optional(),
     brand: BrandReferenceSchema.optional(),
     manifest: CreativeManifestSchema,
-    targets: z.array(z.union([CanonicalFormatTargetSchema, ProductTargetSchema, ThirdPartyFormatTargetSchema, CreativeCapabilityTargetSchema])).optional()
+    targets: z.array(z.union([CanonicalFormatTargetSchema, ProductTargetSchema, ThirdPartyFormatTargetSchema, CreativeCapabilityTargetSchema])).max(50).optional()
 }).passthrough();
 
 export const ActivateSignalResponseSchema = z.object({
@@ -16026,7 +16026,7 @@ export const GetPlanAuditLogsResponseSchema = z.object({
             runtime_attestations: z.array(z.object({
                 reference: AttestationReferenceSchema,
                 evaluation: AttestationEvaluationSchema
-            }).passthrough()).optional(),
+            }).passthrough()).max(10).optional(),
             runtime_attestation_binding_digest: z.string().regex(/^sha256:[a-f0-9]{64}$/).optional(),
             purchase_type: PurchaseTypeSchema.optional(),
             outcome_status: z.string().optional(),
@@ -16102,7 +16102,7 @@ export const GetAdCPCapabilitiesResponseSchema: z.ZodObject<{ [K in keyof GetAdC
                 formats: z.array(z.union([z.literal("jsonl"), z.literal("csv"), z.literal("parquet"), z.literal("avro"), z.literal("orc")])).optional(),
                 access_modes: z.array(z.string()).optional(),
                 verification_profiles: ReportingVerificationProfileSetSchema
-            }).passthrough()).optional(),
+            }).passthrough()).max(3).optional(),
             suspension_interval_seconds: z.int().min(1).max(86400).optional(),
             caller_event_types: z.array(NotificationTypeSchema).optional(),
             optimistic_concurrency: z.boolean()
@@ -16116,31 +16116,31 @@ export const GetAdCPCapabilitiesResponseSchema: z.ZodObject<{ [K in keyof GetAdC
         governance_enforcement: z.object({
             tasks: z.array(z.union([z.object({
                     task: z.literal("create_media_buy"),
-                    modes: z.array(z.union([z.literal("signed_context"), z.literal("online_execution_check")]))
+                    modes: z.array(z.union([z.literal("signed_context"), z.literal("online_execution_check")])).max(1)
                 }).passthrough(), z.object({
                     task: z.literal("update_media_buy"),
-                    modes: z.array(z.union([z.literal("signed_context"), z.literal("online_execution_check")]))
+                    modes: z.array(z.union([z.literal("signed_context"), z.literal("online_execution_check")])).max(1)
                 }).passthrough(), z.object({
                     task: z.literal("buy_products"),
-                    modes: z.array(z.union([z.literal("signed_context"), z.literal("online_execution_check")]))
+                    modes: z.array(z.union([z.literal("signed_context"), z.literal("online_execution_check")])).max(1)
                 }).passthrough(), z.object({
                     task: z.literal("accept_proposal"),
-                    modes: z.array(z.union([z.literal("signed_context"), z.literal("online_execution_check")]))
+                    modes: z.array(z.union([z.literal("signed_context"), z.literal("online_execution_check")])).max(1)
                 }).passthrough(), z.object({
                     task: z.literal("control_media_buy"),
-                    modes: z.array(z.union([z.literal("signed_context"), z.literal("online_execution_check")]))
+                    modes: z.array(z.union([z.literal("signed_context"), z.literal("online_execution_check")])).max(1)
                 }).passthrough(), z.object({
                     task: z.literal("build_creative"),
-                    modes: z.array(z.literal("signed_context"))
+                    modes: z.array(z.literal("signed_context")).max(1)
                 }).passthrough(), z.object({
                     task: z.literal("activate_signal"),
-                    modes: z.array(z.literal("signed_context"))
+                    modes: z.array(z.literal("signed_context")).max(1)
                 }).passthrough(), z.object({
                     task: z.literal("acquire_rights"),
-                    modes: z.array(z.literal("signed_context"))
+                    modes: z.array(z.literal("signed_context")).max(1)
                 }).passthrough(), z.object({
                     task: z.literal("update_rights"),
-                    modes: z.array(z.literal("signed_context"))
+                    modes: z.array(z.literal("signed_context")).max(1)
                 }).passthrough()])),
             accepted_governance_agents: AcceptedGovernanceAgentsSchema.optional()
         }).passthrough().optional(),
@@ -16190,9 +16190,9 @@ export const GetAdCPCapabilitiesResponseSchema: z.ZodObject<{ [K in keyof GetAdC
         relationship_notifications: z.object({
             supported: z.literal(true),
             registration_task: z.literal("sync_accounts"),
-            event_types: z.array(z.union([z.literal("indicators.changed"), z.literal("creative.assignment_changed")])),
-            repair_tasks: z.array(z.literal("get_media_buys")),
-            projection_tasks: z.array(z.literal("list_creatives")).optional(),
+            event_types: z.array(z.union([z.literal("indicators.changed"), z.literal("creative.assignment_changed")])).max(2),
+            repair_tasks: z.array(z.literal("get_media_buys")).max(1),
+            projection_tasks: z.array(z.literal("list_creatives")).max(1).optional(),
             supports_webhook_activity: z.boolean().optional()
         }).passthrough().optional(),
         features: MediaBuyFeaturesSchema.optional(),
@@ -16494,8 +16494,8 @@ export const SyncPrincipalRequestSchema = z.object({
     expected_configuration_version: z.string().min(1).max(255).optional(),
     expected_principal_kind: PrincipalKindSchema.optional(),
     configuration: z.object({
-        notification_configs: z.array(AgentNotificationConfigSchema).optional(),
-        reporting_destinations: z.array(AgentReportingDestinationSchema).optional(),
+        notification_configs: z.array(AgentNotificationConfigSchema).max(16).optional(),
+        reporting_destinations: z.array(AgentReportingDestinationSchema).max(64).optional(),
         declarations: AgentDeclarationsSchema.optional()
     }).passthrough(),
     dry_run: z.boolean().optional(),
@@ -16511,7 +16511,7 @@ export const AppliedPrincipalConfigurationSchema = z.object({
     principal_kind: PrincipalKindSchema,
     configuration_version: z.string().min(1).max(255),
     configuration: PrincipalStateSchema,
-    warnings: z.array(ErrorSchema).optional()
+    warnings: z.array(ErrorSchema).max(16).optional()
 }).passthrough();
 
 export const GetPrincipalResponseSchema = z.object({
@@ -16567,8 +16567,8 @@ export const ProvisioningModeSchema = z.object({
     payment_terms: PaymentTermsSchema.optional(),
     sandbox: z.boolean().optional(),
     preferred_reporting_protocol: CloudStorageProtocolSchema.optional(),
-    reporting_delivery_configs: z.array(ReportingDeliveryConfigurationSchema).optional(),
-    notification_configs: z.array(NotificationConfigSchema).optional()
+    reporting_delivery_configs: z.array(ReportingDeliveryConfigurationSchema).max(16).optional(),
+    notification_configs: z.array(NotificationConfigSchema).max(16).optional()
 }).passthrough();
 
 export const SettingsUpdateModeSchema = z.object({
@@ -16580,8 +16580,8 @@ export const SettingsUpdateModeSchema = z.object({
     payment_terms: PaymentTermsSchema.optional(),
     sandbox: z.boolean().optional(),
     preferred_reporting_protocol: CloudStorageProtocolSchema.optional(),
-    reporting_delivery_configs: z.array(ReportingDeliveryConfigurationSchema).optional(),
-    notification_configs: z.array(NotificationConfigSchema).optional()
+    reporting_delivery_configs: z.array(ReportingDeliveryConfigurationSchema).max(16).optional(),
+    notification_configs: z.array(NotificationConfigSchema).max(16).optional()
 }).passthrough();
 
 export const SyncAccountsSuccessSchema = z.object({
@@ -16617,8 +16617,8 @@ export const SyncAccountsSuccessSchema = z.object({
         errors: z.array(ErrorSchema).optional(),
         warnings: z.array(z.string()).optional(),
         sandbox: z.boolean().optional(),
-        notification_configs: z.array(NotificationConfigSchema).optional(),
-        reporting_delivery_configs: z.array(ReportingDeliveryConfigurationStateSchema).optional(),
+        notification_configs: z.array(NotificationConfigSchema).max(16).optional(),
+        reporting_delivery_configs: z.array(ReportingDeliveryConfigurationStateSchema).max(16).optional(),
         authorization: AccountAuthorizationSchema.optional()
     }).passthrough()),
     context: ContextObjectSchema.optional(),
@@ -16664,7 +16664,7 @@ export const GetProductsCompletionSchema: z.ZodType = AdCPVersionEnvelopeSchema.
     proposals: z.array(ProposalSchema).optional(),
     errors: z.array(ErrorSchema).optional(),
     reason: z.string().optional(),
-    suggestions: z.array(z.string()).optional(),
+    suggestions: z.array(z.string()).max(20).optional(),
     property_list_applied: z.boolean().optional(),
     catalog_applied: z.boolean().optional(),
     refinement_applied: z.array(z.union([z.object({
@@ -16726,7 +16726,7 @@ export const ValidatePropertyDeliveryRequestSchema = z.object({
     adcp_major_version: z.number().int().gte(1).lte(99).optional(),
     list_id: z.string(),
     account: AccountReferenceSchema.optional(),
-    records: z.array(DeliveryRecordSchema),
+    records: z.array(DeliveryRecordSchema).max(10000),
     include_compliant: z.boolean().optional(),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
@@ -17758,7 +17758,7 @@ export const GetProductsResponseSchema: z.ZodObject<{ [K in keyof GetProductsRes
     proposals: z.array(ProposalSchema).optional(),
     errors: z.array(ErrorSchema).optional(),
     reason: z.string().min(1).max(2000).optional(),
-    suggestions: z.array(z.string()).optional(),
+    suggestions: z.array(z.string()).max(20).optional(),
     property_list_applied: z.boolean().optional(),
     catalog_applied: z.boolean().optional(),
     refinement_applied: z.array(z.union([z.object({
@@ -18670,7 +18670,7 @@ export const GetMediaBuysResponseMediaBuySchema: z.ZodType = z.object({
     context: ContextObjectSchema.optional(),
     valid_actions: z.array(MediaBuyValidActionSchema).optional(),
     available_actions: z.array(z.union([CanonicalMediaBuyActionSchema, MediaBuyAvailableActionSchema])).optional(),
-    webhook_activity: z.array(WebhookActivityRecordSchema).optional(),
+    webhook_activity: z.array(WebhookActivityRecordSchema).max(200).optional(),
     history: z.array(z.object({
         revision: z.int().min(1),
         timestamp: z.iso.datetime(),
@@ -18803,7 +18803,7 @@ export const ListedCreativeNamedFormatReferenceSchema: z.ZodType = z.object({
         at: z.iso.datetime(),
         reason_code: CreativeEventReasonCodeSchema
     }).passthrough().optional(),
-    webhook_activity: z.array(WebhookActivityRecordSchema).optional()
+    webhook_activity: z.array(WebhookActivityRecordSchema).max(200).optional()
 }).passthrough();
 
 export const ListedCreativeCanonicalFormatKindSchema: z.ZodType = z.object({
@@ -18864,7 +18864,7 @@ export const ListedCreativeCanonicalFormatKindSchema: z.ZodType = z.object({
         at: z.iso.datetime(),
         reason_code: CreativeEventReasonCodeSchema
     }).passthrough().optional(),
-    webhook_activity: z.array(WebhookActivityRecordSchema).optional()
+    webhook_activity: z.array(WebhookActivityRecordSchema).max(200).optional()
 }).passthrough();
 
 export const CheckGovernanceRequestSchema = z.object({}).passthrough().merge(z.object({
@@ -18919,7 +18919,7 @@ export const CheckGovernanceRequestSchema = z.object({}).passthrough().merge(z.o
             type: z.literal("resource"),
             resource_type: z.literal("https://adcontextprotocol.org/claims/subjects/signal")
         }).passthrough().optional()
-    }).passthrough())).optional(),
+    }).passthrough())).max(10).optional(),
     invoice_recipient: BusinessEntitySchema.optional(),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional()
@@ -18947,7 +18947,7 @@ export const SyncAccountsRequestSchema = z.object({
     adcp_version: z.string().regex(new RegExp("^(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)(?:-[a-zA-Z0-9](?:[a-zA-Z0-9.-]*[a-zA-Z0-9])?)?$")).optional(),
     adcp_major_version: z.number().int().gte(1).lte(99).optional(),
     idempotency_key: z.string().min(16).max(255).regex(/^[A-Za-z0-9_.:-]{16,255}$/),
-    accounts: z.array(z.union([ProvisioningModeSchema, SettingsUpdateModeSchema])),
+    accounts: z.array(z.union([ProvisioningModeSchema, SettingsUpdateModeSchema])).max(1000),
     delete_missing: z.boolean().optional(),
     dry_run: z.boolean().optional(),
     push_notification_config: PushNotificationConfigSchema.optional(),
@@ -19033,7 +19033,7 @@ export const ComplyTestControllerRequestSchema: z.ZodObject<Record<string, z.Zod
         task_id: z.string().max(128).optional(),
         message: z.string().max(2000).optional(),
         reason: z.string().min(1).max(2000).optional(),
-        suggestions: z.array(z.string()).optional(),
+        suggestions: z.array(z.string()).max(20).optional(),
         format_id: z.string().optional(),
         vendor: BrandReferenceSchema.optional(),
         metrics: z.array(z.object({
@@ -19047,7 +19047,7 @@ export const ComplyTestControllerRequestSchema: z.ZodObject<Record<string, z.Zod
         endpoint_pattern: z.string().optional(),
         limit: z.int().min(1).max(1000).optional(),
         attestation_mode: z.union([z.literal("raw"), z.literal("digest")]).optional(),
-        identifier_value_digests: z.array(z.string()).optional()
+        identifier_value_digests: z.array(z.string()).max(64).optional()
     }).passthrough().optional(),
     context: ContextObjectSchema.optional(),
     ext: ExtensionObjectSchema.optional(),
@@ -19134,7 +19134,7 @@ export const CreateMediaBuyRequestSchema: z.ZodObject<{ [K in keyof CreateMediaB
         url: z.string().refine(adcpJsonSchemaUri, "Invalid URI"),
         token: z.string().min(16).optional(),
         authentication: z.object({
-            schemes: z.array(AuthenticationSchemeSchema),
+            schemes: z.array(AuthenticationSchemeSchema).max(1),
             credentials: z.string().min(32)
         }).passthrough(),
         delivery_mode: z.union([z.literal("realtime"), z.literal("batched")]),

--- a/src/lib/types/tools.generated.ts
+++ b/src/lib/types/tools.generated.ts
@@ -4332,411 +4332,13 @@ export type AudienceEvidence = {
    * @maxItems 10
    */
   attestation_refs?:
-    | [
-        AttestationReference & {
+    (AttestationReference & {
           subject: AttestationSubject & {
             type: 'resource';
             resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
             content_digest: string;
           };
-        }
-      ]
-    | [
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        }
-      ]
-    | [
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        }
-      ]
-    | [
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        }
-      ]
-    | [
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        }
-      ]
-    | [
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        }
-      ]
-    | [
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        }
-      ]
-    | [
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        }
-      ]
-    | [
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        }
-      ]
-    | [
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        }
-      ];
+        })[];
   ext?: ExtensionObject;
 } & {
   /**
@@ -4809,411 +4411,13 @@ export type AudienceEvidence = {
    * @maxItems 10
    */
   attestation_refs?:
-    | [
-        AttestationReference & {
+    (AttestationReference & {
           subject: AttestationSubject & {
             type: 'resource';
             resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
             content_digest: string;
           };
-        }
-      ]
-    | [
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        }
-      ]
-    | [
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        }
-      ]
-    | [
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        }
-      ]
-    | [
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        }
-      ]
-    | [
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        }
-      ]
-    | [
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        }
-      ]
-    | [
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        }
-      ]
-    | [
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        }
-      ]
-    | [
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        },
-        AttestationReference & {
-          subject: AttestationSubject & {
-            type: 'resource';
-            resource_type: 'https://adcontextprotocol.org/claims/subjects/audience-evidence';
-            content_digest: string;
-          };
-        }
-      ];
+        })[];
   ext?: ExtensionObject;
 };
 /**
@@ -5941,6 +5145,7 @@ export interface GetProductsResponse {
   reason?: string;
   /**
    * Actionable alternatives available only on the GetProductsRejected arm.
+   * @maxItems 20
    */
   suggestions?: string[];
   /**
@@ -6234,7 +5439,7 @@ export interface CreativeLocalePolicy {
    * @minItems 1
    * @maxItems 50
    */
-  accepted_language_ranges: [LanguageTag, ...LanguageTag[]];
+  accepted_language_ranges: LanguageTag[];
 }
 export interface ImageFormatDeclaration {
   format_kind: 'image';
@@ -7656,8 +6861,7 @@ export interface AudienceEvidenceSelection {
    * @maxItems 10
    */
   attestation_evaluations?:
-    | [
-        {
+    {
           reference: AttestationReference;
           evaluation: AttestationEvaluation & {
             action_binding: {
@@ -7666,566 +6870,7 @@ export interface AudienceEvidenceSelection {
               action_digest: string;
             };
           };
-        }
-      ]
-    | [
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        }
-      ]
-    | [
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        }
-      ]
-    | [
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        }
-      ]
-    | [
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        }
-      ]
-    | [
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        }
-      ]
-    | [
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        }
-      ]
-    | [
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        }
-      ]
-    | [
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        }
-      ]
-    | [
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        },
-        {
-          reference: AttestationReference;
-          evaluation: AttestationEvaluation & {
-            action_binding: {
-              action_type: 'https://adcontextprotocol.org/actions/audience-evidence-evaluation';
-              action_id: string;
-              action_digest: string;
-            };
-          };
-        }
-      ];
+        }[];
   ext?: ExtensionObject;
 }
 /**
@@ -10608,6 +9253,7 @@ export interface RefineProposalsRequest {
   idempotency_key: string;
   /**
    * Proposal operations to apply, with at most 25 entries per request. revise creates a draft successor from a draft, committed, or accepted source. finalize MUST target a draft, reserves inventory, and creates a committed successor whose expires_at is the hold deadline. A batch containing finalize MUST contain only finalize entries and is atomic. proposal_id values MUST be unique; results preserve request order.
+   * @maxItems 25
    */
   refinements: ProposalRefinement[];
 }
@@ -10959,6 +9605,7 @@ export interface DeclineProposalsRequest {
   idempotency_key: string;
   /**
    * Proposal declines to apply. proposal_id is the semantic uniqueness key and values MUST be unique even when two entries otherwise differ; implementations enforce this rule because JSON Schema uniqueItems only compares whole objects. Results preserve request order.
+   * @maxItems 25
    */
   declines: ProposalDecline[];
   opportunity?: OpportunityContext;
@@ -12302,6 +10949,7 @@ export type CreateMediaBuyRequest = (
     authentication: {
       /**
        * Array of authentication schemes. ['Bearer'] for simple token auth, ['HMAC-SHA256'] for legacy shared-secret signing. Both are deprecated; new integrations SHOULD use the RFC 9421 webhook signing profile instead.
+       * @maxItems 1
        */
       schemes: AuthenticationScheme[];
       /**
@@ -12520,12 +11168,8 @@ export type PackageRequest = AdCPVersionEnvelope & {
    * @minItems 1
    * @maxItems 100
    */
-  creatives?: [
-    CreativeAsset & {
-    },
-    ...(CreativeAsset & {
-    })[]
-  ];
+  creatives?: (CreativeAsset & {
+    })[];
   /**
    * Agency estimate or authorization number for this package. Overrides the media buy-level estimate number when different packages correspond to different agency estimates (e.g., different stations or flights within the same buy).
    */
@@ -16229,321 +14873,14 @@ export interface Account {
    * @maxItems 16
    */
   notification_configs?:
-    | []
-    | [NotificationConfig]
-    | [NotificationConfig, NotificationConfig]
-    | [NotificationConfig, NotificationConfig, NotificationConfig]
-    | [NotificationConfig, NotificationConfig, NotificationConfig, NotificationConfig]
-    | [NotificationConfig, NotificationConfig, NotificationConfig, NotificationConfig, NotificationConfig]
-    | [
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig
-      ]
-    | [
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig
-      ]
-    | [
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig
-      ]
-    | [
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig
-      ]
-    | [
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig
-      ]
-    | [
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig
-      ]
-    | [
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig
-      ]
-    | [
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig
-      ]
-    | [
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig
-      ]
-    | [
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig
-      ]
-    | [
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig,
-        NotificationConfig
-      ];
+    NotificationConfig[];
   /**
    * Resolved durable reporting delivery configurations owned by the authenticated caller for this account. list_accounts MUST expose only the calling principal's set. State and seller-issued destination_ref are returned; credentials and bearer profiles MUST NOT appear. Any setup URL is a secret-free authenticated entry point, not a bearer credential.
    *
    * @maxItems 16
    */
   reporting_delivery_configs?:
-    | []
-    | [ReportingDeliveryConfigurationState]
-    | [ReportingDeliveryConfigurationState, ReportingDeliveryConfigurationState]
-    | [ReportingDeliveryConfigurationState, ReportingDeliveryConfigurationState, ReportingDeliveryConfigurationState]
-    | [
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState
-      ]
-    | [
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState
-      ]
-    | [
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState
-      ]
-    | [
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState
-      ]
-    | [
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState
-      ]
-    | [
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState
-      ]
-    | [
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState
-      ]
-    | [
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState
-      ]
-    | [
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState
-      ]
-    | [
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState
-      ]
-    | [
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState
-      ]
-    | [
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState
-      ]
-    | [
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState,
-        ReportingDeliveryConfigurationState
-      ];
+    ReportingDeliveryConfigurationState[];
   /**
    * Recent webhook delivery attempts scoped to this account when the caller requested webhook activity on list_accounts and the seller surfaces the log. Includes account-anchored notifications such as account.status_changed and MAY include other account-level fires relevant to this account. Three-state presence follows the shared webhook_activity[] contract: omitted means unsupported or not requested, [] means supported but no retained fires, non-empty lists recent attempts most-recent-first.
    *
@@ -17416,6 +15753,7 @@ export interface GetMediaBuysResponseMediaBuy {
   available_actions?: (CanonicalMediaBuyAction | MediaBuyAvailableAction)[];
   /**
    * Recent webhook fires relevant to this buy for the calling principal, most-recent first. Includes per-buy delivery/health fires and account-anchored indicators.changed or creative.assignment_changed invalidations whose payload names this media_buy_id. Present only when include_webhook_activity was true and the seller surfaces this debug capability. Account-anchored records MUST include subscriber_id. Three-state presence and the 30-day retention floor follow snapshot-and-log.mdx § Webhook activity log pattern.
+   * @maxItems 200
    */
   webhook_activity?: WebhookActivityRecord[];
   /**
@@ -19009,10 +17347,12 @@ export interface GetReportingStatusRequest {
   view: ReportingStatusView;
   /**
    * Optional summary/periods scope. Omit for every accessible media buy in the account.
+   * @maxItems 100
    */
   media_buy_ids?: ReportingMediaBuyID[];
   /**
    * Optional summary/periods scope. Use to reconcile billing, analytics, and pacing independently. Omit for every active caller-owned configuration.
+   * @maxItems 16
    */
   delivery_config_ids?: string[];
   /**
@@ -19627,6 +17967,9 @@ export interface UnavailableLookup {
     code: 'NOT_FOUND';
     message: 'Reporting status resource is unavailable.';
   };
+  /**
+   * @maxItems 1
+   */
   errors: {
     code: 'NOT_FOUND';
     message: 'Reporting status resource is unavailable.';
@@ -19676,6 +18019,9 @@ export interface SyncReportingReceiptsRequest {
    * @pattern ^[A-Za-z0-9_.:-]{16,255}$
    */
   idempotency_key: string;
+  /**
+   * @maxItems 100
+   */
   receipts: ReportingReceipt[];
   context?: ContextObject;
   ext?: ExtensionObject;
@@ -19731,6 +18077,9 @@ export interface SyncReportingReceiptsResponse {
    * DEPRECATED in favor of adcp_version (release-precision string). Servers MUST continue to honor this field through 3.x. Removed in 4.0. Original semantics: the AdCP major version the buyer's payloads conform to. Sellers validate against their supported major_versions and return VERSION_UNSUPPORTED if unsupported. When omitted, the seller assumes its highest supported version.
    */
   adcp_major_version?: number;
+  /**
+   * @maxItems 100
+   */
   results: (RecordedReportingReceipt | UnchangedReportingReceipt | FailedReportingReceipt)[];
   ext?: ExtensionObject;
 }
@@ -19752,6 +18101,9 @@ export interface FailedReportingReceipt {
    * @pattern ^[A-Za-z0-9_.:-]{16,255}$
    */
   reporting_receipt_id: string;
+  /**
+   * @maxItems 16
+   */
   errors: Error[];
 }
 
@@ -20362,6 +18714,7 @@ export interface LogEventRequest {
   test_event_code?: string;
   /**
    * Events to log
+   * @maxItems 10000
    */
   events: Event[];
   /**
@@ -20929,18 +19282,22 @@ export type SyncCatalogsRequest = {
   account: AccountReference;
   /**
    * Array of catalog feeds to sync (create or update). When omitted together with item_availability_updates and item_availability_queries, the call is discovery-only and returns all existing catalogs on the account without modification.
+   * @maxItems 50
    */
   catalogs?: Catalog[];
   /**
    * Immediate suppress or restore operations for items in buyer-managed catalogs. Sellers declaring media_buy.features.catalog_item_availability_updates MUST process these updates synchronously and MUST NOT silently ignore them or return a submitted task. A seller that does not declare the capability MUST reject the request with UNSUPPORTED_FEATURE before lookup or mutation and MUST NOT interpret it as discovery. The combined number of item_availability_updates and item_availability_queries MUST NOT exceed 1,000; excess entries are an operation-level INVALID_REQUEST before lookup or mutation. Each (catalog_id, catalog_generation, item_id) tuple MUST appear at most once in updates; a duplicate is an operation-level INVALID_REQUEST before mutation in every validation mode. For mixed catalog/update requests, the seller MUST validate and stage the entire request against the post-upsert candidate state, then commit catalog and availability changes atomically. It MUST reject before any mutation if synchronous atomic commit is unavailable. A successful suppress acknowledgement means the seller MUST stop selecting or rendering the item and every cached or pre-generated creative it materialized from the item. Seller-internal generation lineage MUST retain resolved_account_id, catalog_id, catalog_generation, and item_id. If the seller cannot enforce that guarantee, it MUST return a failed per-item result. Suppression persists across scheduled feed fetches and catalog upserts until explicit restore, expires_at, or deletion of the containing catalog. Restore removes only an existing buyer-authored overlay or tombstone in the same catalog generation and cannot override seller rejection, withdrawal, policy, rights, or inventory controls. A restore for an absent item without such prior state fails with REFERENCE_NOT_FOUND.
+   * @maxItems 1000
    */
   item_availability_updates?: CatalogItemAvailabilityUpdate[];
   /**
    * Read current buyer-authored availability state. Queries require media_buy.features.catalog_item_availability_updates; a seller that does not declare it rejects with UNSUPPORTED_FEATURE before lookup. Any request containing queries is synchronous. In a mixed request the seller validates and stages catalog upserts and availability updates first, evaluates queries against that post-upsert/post-update candidate state, and atomically commits the staged mutations before returning those query results. If the mixed work cannot commit synchronously, it rejects before mutation. The seller returns exactly one item_availability_states entry per query in the same order and echoes request_index and the complete identity. Unknown, inaccessible, stale-generation, and unauthorized references use the normalized REFERENCE_NOT_FOUND shape described by validation_mode. Use a fresh idempotency_key for a current read; a replayed response is a historical snapshot.
+   * @maxItems 1000
    */
   item_availability_queries?: CatalogItemAvailabilityReference[];
   /**
    * Optional filter to limit sync scope to specific catalog IDs. When provided, only these catalogs will be created/updated. Other catalogs on the account are unaffected.
+   * @maxItems 50
    */
   catalog_ids?: string[];
   /**
@@ -21265,10 +19622,12 @@ export interface SyncCatalogsSuccess {
   }[];
   /**
    * Acknowledgements for item_availability_updates. The array length MUST equal the request array length; entry N MUST have request_index N, occupy position N, and exactly echo catalog_id, catalog_generation, item_id, and action from request entry N. Buyers MUST reject the response as non-conformant if count, ordering, request_index, or echoed identity differs. Lenient-mode failures stay in their request positions. In strict mode, any per-entry failure instead produces the operation-level error branch before mutation and this array is absent.
+   * @maxItems 1000
    */
   item_availability_updates?: CatalogItemAvailabilityUpdateResult[];
   /**
    * Current-state results for item_availability_queries, evaluated after updates in a mixed request. The array length MUST equal the request query length; entry N MUST have request_index N, occupy position N, and exactly echo catalog_id, catalog_generation, and item_id. Buyers MUST reject any mismatch. A replayed response is historical; use a fresh query idempotency_key before treating it as current after time-dependent expiry or catalog deletion/recreation.
+   * @maxItems 1000
    */
   item_availability_states?: CatalogItemAvailabilityState[];
   /**
@@ -21371,6 +19730,7 @@ export type BuildCreativeRequest = {
     /**
      * @deprecated
      * **DEPRECATED in 3.2.** Legacy named-format selectors. Use `target_capability_ids` with values advertised in `get_adcp_capabilities.creative.supported_formats[].capability_id`.
+     * @maxItems 50
      */
     target_format_ids?: FormatReferenceStructuredObject[];
     /**
@@ -21380,6 +19740,7 @@ export type BuildCreativeRequest = {
     target_capability_id?: string;
     /**
      * Canonical 3.2 multi-output selector. Each value matches a `get_adcp_capabilities.creative.supported_formats[].capability_id`. The creative agent produces one canonical manifest per capability in request order. Mutually exclusive with `target_capability_id` and the deprecated target_format_id fields.
+     * @maxItems 50
      */
     target_capability_ids?: string[];
     /**
@@ -22829,6 +21190,7 @@ export type PreviewCreativeRequest = {
   item_limit?: number;
   /**
    * Array of preview requests (1-50 items). Required when request_type is 'batch'. Each item follows the single request structure.
+   * @maxItems 50
    */
   requests?: {
     /**
@@ -23807,7 +22169,7 @@ export interface CreativeFilters {
    * @minItems 1
    * @maxItems 100
    */
-  creative_ids?: [string, ...string[]];
+  creative_ids?: string[];
   /**
    * Filter creatives created after this date (ISO 8601)
    */
@@ -24272,6 +22634,7 @@ export interface ListedCreativeNamedFormatReference {
   };
   /**
    * Recent webhook fires scoped to this creative — creative.status_changed, creative.purged, creative.assignment_changed, and assignment-level indicators.changed deliveries. Present only when include_webhook_activity is true. Account-anchored records include subscriber_id; the parent creative_id disambiguates the record. Retention: 30 days from completed_at. See snapshot-and-log.mdx § Webhook activity log pattern.
+   * @maxItems 200
    */
   webhook_activity?: WebhookActivityRecord[];
 }
@@ -24297,26 +22660,17 @@ export interface CreativeLocalizationReadback {
    * @minItems 1
    * @maxItems 50
    */
-  locale_fallbacks?: [
-    {
+  locale_fallbacks?: {
       language_range: LanguageTag;
       locale_variant_id: string;
-    },
-    ...{
-      language_range: LanguageTag;
-      locale_variant_id: string;
-    }[]
-  ];
+    }[];
   /**
    * The source variant followed by every target variant, or only the source for monolingual topology. Assets are fully resolved after source inheritance. The enclosing creative status applies to the set as a whole.
    *
    * @minItems 1
    * @maxItems 51
    */
-  variants: [
-    SourceLocalizationReadback | TargetLocalizationReadback,
-    ...(SourceLocalizationReadback | TargetLocalizationReadback)[]
-  ];
+  variants: (SourceLocalizationReadback | TargetLocalizationReadback)[];
 }
 export interface SourceLocalizationReadback {
   /**
@@ -24605,6 +22959,7 @@ export interface ListedCreativeCanonicalFormatKind {
   };
   /**
    * Recent webhook fires scoped to this creative — creative.status_changed, creative.purged, creative.assignment_changed, and assignment-level indicators.changed deliveries. Present only when include_webhook_activity is true. Account-anchored records include subscriber_id; the parent creative_id disambiguates the record. Retention: 30 days from completed_at. See snapshot-and-log.mdx § Webhook activity log pattern.
+   * @maxItems 200
    */
   webhook_activity?: WebhookActivityRecord[];
 }
@@ -24626,6 +22981,7 @@ export interface SyncCreativesRequest {
   account: AccountReference;
   /**
    * Array of creative assets to sync (create or update)
+   * @maxItems 100
    */
   creatives?: (CreativeAsset & {
     revision_id?: CreativeRevisionID;
@@ -24636,6 +22992,7 @@ export interface SyncCreativesRequest {
   })[];
   /**
    * Optional filter to limit sync scope to specific creative IDs. When provided, only these creatives will be created/updated. Other creatives in the library are unaffected. Useful for partial updates and error recovery.
+   * @maxItems 100
    */
   creative_ids?: string[];
   /**
@@ -24664,6 +23021,7 @@ export interface SyncCreativesRequest {
   }[];
   /**
    * Explicit, ordered assignment mutations. These operations may be sent without creatives to traffic existing creative IDs independently from MediaBuy commercial control. The entire request is atomic under idempotency_key and therefore requires strict validation; lenient partial processing is not permitted.
+   * @maxItems 500
    */
   assignment_operations?: (AssignOrUpdate | Unassign | ReplaceAssignment)[];
   /**
@@ -24729,22 +23087,13 @@ export interface CreativeLocalization {
    * @minItems 1
    * @maxItems 50
    */
-  locale_fallbacks?: [
-    {
+  locale_fallbacks?: {
       language_range: LanguageTag;
       /**
        * Source or target locale variant to serve when this explicit fallback rule matches.
        */
       locale_variant_id: string;
-    },
-    ...{
-      language_range: LanguageTag;
-      /**
-       * Source or target locale variant to serve when this explicit fallback rule matches.
-       */
-      locale_variant_id: string;
-    }[]
-  ];
+    }[];
   /**
    * The source or target locale_variant_id used when neither strict RFC 4647 Lookup nor an explicit locale_fallbacks rule matches and unmatched_locale_action is serve_default.
    */
@@ -25010,6 +23359,7 @@ export interface ValidateInputRequest {
   manifest: CreativeManifest;
   /**
    * Discriminated list of validation targets. Each entry mirrors the `target` shape on `validate-input-result.json` so the request/response wire shapes match exactly. Multi-target requests enable universal-creative scenarios where one manifest targets multiple sellers' format declarations in a single round-trip; the response carries one result per target in the same order.
+   * @maxItems 50
    */
   targets?: (CanonicalFormatTarget | ProductTarget | ThirdPartyFormatTarget | CreativeCapabilityTarget)[];
 }
@@ -28667,6 +27017,7 @@ export interface ValidateContentDeliveryRequest {
   standards_id: string;
   /**
    * Delivery records to validate (max 10,000)
+   * @maxItems 10000
    */
   records: {
     /**
@@ -30674,6 +29025,7 @@ export interface GetPlanAuditLogsResponse {
       plan_hash?: string;
       /**
        * Portable attestation presentations and their evaluator-of-record results retained as ordered pairs for this check entry. Auditors recompute each evaluation.reference_digest from JCS(reference), then recompute runtime_attestation_binding_digest from the ordered evaluations and attestation-bound findings.
+       * @maxItems 10
        */
       runtime_attestations?: {
         reference: AttestationReference;
@@ -31018,6 +29370,7 @@ export type CheckGovernanceRequest = {
   modification_summary?: string;
   /**
    * Optional independently issued runtime evidence for an activate_signal intent check whose payload action is activate (or omitted, which defaults to activate). It MUST NOT be supplied for deactivate. Each item is the shared portable AttestationReference from the core #4529 contract; it carries no authoritative buyer-supplied decision or confidence. The governance agent MUST evaluate every item under adcp.attestations plus governance.runtime_attestations capability policy, preserve input order in response runtime_attestation_evaluations[], and reject off-policy issuers, resolvers, credential origins, and verifier nominations without network access. This field is per-check evidence outside the synced plan and therefore outside the plan_hash preimage. Other tools and purchase types cannot carry this field.
+   * @maxItems 10
    */
   runtime_attestations?: (AttestationReference & {
     subject?: {
@@ -31192,6 +29545,7 @@ export interface CheckGovernanceResponse {
   mode?: GovernanceMode;
   /**
    * Evaluator-of-record results for request runtime_attestations[], in the same order and with exactly one result per presentation. Each result is the shared AttestationEvaluation and MUST bind to this response's check_id through action_binding.action_type = https://adcontextprotocol.org/actions/governance-check and action_binding.action_id = check_id. The signed governance_context MUST bind the same reference_digest/outcome pairs; large evidence stays in the audit log rather than the token.
+   * @maxItems 10
    */
   runtime_attestation_evaluations?: (AttestationEvaluation & {
     action_binding: {
@@ -32812,6 +31166,7 @@ export interface GetAdCPCapabilitiesResponse {
       max_reporting_destinations?: number;
       /**
        * Objective per-pattern delivery offering, so buyers can select a compatible destination without submit-and-reject probing. A destination whose pattern, transport, access mode, format set, or verification-profile set falls outside this offering fails the sync request atomically with UNSUPPORTED_FEATURE; provider-side setup outcomes for in-offering destinations are expressed only through destination states.
+       * @maxItems 3
        */
       reporting_destination_offerings?: {
         pattern: 'file_transfer' | 'warehouse_materialization' | 'dataset_share';
@@ -32902,18 +31257,30 @@ export interface GetAdCPCapabilitiesResponse {
           }
         | {
             task: 'build_creative';
+            /**
+             * @maxItems 1
+             */
             modes: 'signed_context'[];
           }
         | {
             task: 'activate_signal';
+            /**
+             * @maxItems 1
+             */
             modes: 'signed_context'[];
           }
         | {
             task: 'acquire_rights';
+            /**
+             * @maxItems 1
+             */
             modes: 'signed_context'[];
           }
         | {
             task: 'update_rights';
+            /**
+             * @maxItems 1
+             */
             modes: 'signed_context'[];
           }
       )[];
@@ -33116,14 +31483,17 @@ export interface GetAdCPCapabilitiesResponse {
       registration_task: 'sync_accounts';
       /**
        * Relationship invalidation events supported by this seller. indicators.changed requires supported_indicator_types but is not required merely because polling readback is available. creative.assignment_changed is independently available when the seller can detect assignment or assignment-approval changes; it does not require indicator support or list_creatives.
+       * @maxItems 2
        */
       event_types: ('indicators.changed' | 'creative.assignment_changed')[];
       /**
        * Complete authoritative snapshot reads used after an invalidation. get_media_buys is mandatory and is the only 3.2 repair task for this contract.
+       * @maxItems 1
        */
       repair_tasks: 'get_media_buys'[];
       /**
        * Optional bounded reverse projections of relationship-scoped indicator and approval state. list_creatives is a discovery/read convenience for creative-library sellers, not a complete repair path; declaring it also requires creative in supported_protocols. Buyers fall back to get_media_buys whenever nested assignments are truncated or a relationship must be proven absent.
+       * @maxItems 1
        */
       projection_tasks?: 'list_creatives'[];
       /**
@@ -34637,6 +33007,7 @@ export interface ListTasksRequest {
     updated_before?: string;
     /**
      * Filter by specific task IDs
+     * @maxItems 100
      */
     task_ids?: string[];
     /**
@@ -34839,6 +33210,7 @@ export interface SyncAgentNotificationConfigsRequest {
   idempotency_key: string;
   /**
    * Complete desired set of agent-level notification subscribers for the authenticated caller or registry identity. Omit is invalid; send an empty array to remove every subscriber owned by this caller. Each entry registers a URL, the agent-level event types the subscriber wants, and optional legacy auth. Duplicate `subscriber_id` values are rejected within this caller-scoped array. If any entry fails validation or activation proof, the seller rejects the replacement and leaves this caller's previous set unchanged.
+   * @maxItems 16
    */
   notification_configs: AgentNotificationConfig[];
   /**
@@ -34961,6 +33333,7 @@ export interface SyncAgentNotificationConfigsResponse {
   action: 'updated' | 'unchanged' | 'cleared' | 'failed';
   /**
    * Current persisted agent-level notification subscribers owned by the authenticated caller after the request. Entries are keyed by `subscriber_id`; `authentication.credentials` is omitted on every entry because credentials are write-only. Present on successful actions and MAY be present on `failed` responses to show the unchanged prior caller-scoped set.
+   * @maxItems 16
    */
   notification_configs?: AgentNotificationConfig[];
   /**
@@ -35011,10 +33384,12 @@ export interface SyncPrincipalRequest {
   configuration: {
     /**
      * Complete desired agent-level subscriber set. The same caller-scoping, proof-of-control, secret handling, and replacement rules as sync_agent_notification_configs apply.
+     * @maxItems 16
      */
     notification_configs?: AgentNotificationConfig[];
     /**
      * Complete desired reusable reporting destination set. Omitting a previously present destination_id revokes it, and [] revokes every destination: the seller halts new deliveries to all of its generations within the advertised suspension_interval_seconds and retains it as a retired generation for reporting history. Revocation does not delete caller-owned data already delivered. destination_id values MUST be unique.
+     * @maxItems 64
      */
     reporting_destinations?: AgentReportingDestination[];
     declarations?: AgentDeclarations;
@@ -35145,14 +33520,7 @@ export interface AgentDeclarations {
    * @maxItems 8
    */
   async_adcp_versions?:
-    | [string]
-    | [string, string]
-    | [string, string, string]
-    | [string, string, string, string]
-    | [string, string, string, string, string]
-    | [string, string, string, string, string, string]
-    | [string, string, string, string, string, string, string]
-    | [string, string, string, string, string, string, string, string];
+    string[];
   /**
    * RFC 9421 webhook-signing algorithms the caller can verify. The accepted intersection with the seller's webhook_signing.algorithms MUST be non-empty when the caller has any active webhook subscriber; an empty intersection fails the sync request with UNSUPPORTED_FEATURE because delivery would be unverifiable.
    *
@@ -35165,7 +33533,7 @@ export interface AgentDeclarations {
    * @minItems 1
    * @maxItems 32
    */
-  experimental_features?: [ExperimentalFeatureID, ...ExperimentalFeatureID[]];
+  experimental_features?: ExperimentalFeatureID[];
 }
 
 // sync_principal response
@@ -35210,56 +33578,7 @@ export type AgentReportingDestinationState = {
    * @maxItems 16
    */
   issues?:
-    | []
-    | [Error]
-    | [Error, Error]
-    | [Error, Error, Error]
-    | [Error, Error, Error, Error]
-    | [Error, Error, Error, Error, Error]
-    | [Error, Error, Error, Error, Error, Error]
-    | [Error, Error, Error, Error, Error, Error, Error]
-    | [Error, Error, Error, Error, Error, Error, Error, Error]
-    | [Error, Error, Error, Error, Error, Error, Error, Error, Error]
-    | [Error, Error, Error, Error, Error, Error, Error, Error, Error, Error]
-    | [Error, Error, Error, Error, Error, Error, Error, Error, Error, Error, Error]
-    | [Error, Error, Error, Error, Error, Error, Error, Error, Error, Error, Error, Error]
-    | [Error, Error, Error, Error, Error, Error, Error, Error, Error, Error, Error, Error, Error]
-    | [Error, Error, Error, Error, Error, Error, Error, Error, Error, Error, Error, Error, Error, Error]
-    | [
-        Error,
-        Error,
-        Error,
-        Error,
-        Error,
-        Error,
-        Error,
-        Error,
-        Error,
-        Error,
-        Error,
-        Error,
-        Error,
-        Error,
-        Error
-      ]
-    | [
-        Error,
-        Error,
-        Error,
-        Error,
-        Error,
-        Error,
-        Error,
-        Error,
-        Error,
-        Error,
-        Error,
-        Error,
-        Error,
-        Error,
-        Error,
-        Error
-      ];
+    Error[];
 };
 /**
  * Result of synchronizing selected sections of the principal's standing configuration. Applied responses return the complete current credential-free configuration. Validated dry-run responses report the would-be action without issuing durable identifiers. Failed responses deliberately cannot carry principal identifiers, versions, or configuration state.
@@ -35334,6 +33653,9 @@ export interface AppliedPrincipalConfiguration {
    */
   configuration_version: string;
   configuration: PrincipalState;
+  /**
+   * @maxItems 16
+   */
   warnings?: Error[];
 }
 /**
@@ -35346,166 +33668,7 @@ export interface PrincipalState {
    * @maxItems 16
    */
   notification_configs?:
-    | []
-    | [AgentNotificationConfigState]
-    | [AgentNotificationConfigState, AgentNotificationConfigState]
-    | [AgentNotificationConfigState, AgentNotificationConfigState, AgentNotificationConfigState]
-    | [
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState
-      ]
-    | [
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState
-      ]
-    | [
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState
-      ]
-    | [
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState
-      ]
-    | [
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState
-      ]
-    | [
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState
-      ]
-    | [
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState
-      ]
-    | [
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState
-      ]
-    | [
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState
-      ]
-    | [
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState
-      ]
-    | [
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState
-      ]
-    | [
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState
-      ]
-    | [
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState,
-        AgentNotificationConfigState
-      ];
+    AgentNotificationConfigState[];
   /**
    * Current reusable reporting destination bindings and setup states. destination_id and destination_ref values MUST each be unique within this caller-scoped array; superseded generations of a current destination appear in its prior_destination_refs.
    *
@@ -35526,7 +33689,7 @@ export interface PrincipalState {
      * @minItems 1
      * @maxItems 32
      */
-    destination_refs: [string, ...string[]];
+    destination_refs: string[];
     revoked_at?: string;
   }[];
 }
@@ -35594,10 +33757,16 @@ export interface ValidatedPrincipalDryRun {
   kind: 'validated';
   action: 'would_update' | 'would_be_unchanged' | 'would_clear';
   dry_run: true;
+  /**
+   * @maxItems 16
+   */
   warnings?: Error[];
 }
 export interface FailedPrincipalSync {
   kind: 'failed';
+  /**
+   * @maxItems 16
+   */
   errors: Error[];
 }
 
@@ -35709,6 +33878,9 @@ export interface UnconfiguredPrincipal {
 }
 export interface FailedPrincipalRead {
   kind: 'failed';
+  /**
+   * @maxItems 16
+   */
   errors: Error[];
 }
 
@@ -35744,6 +33916,7 @@ export interface ListAccountChangesRequest {
   starting_position?: 'earliest' | 'latest';
   /**
    * Optional exact resource-type filter. The cursor is bound to the normalized filter. Unknown resource types are allowed for forward compatibility.
+   * @maxItems 50
    */
   resource_types?: string[];
   /**
@@ -35809,6 +33982,7 @@ export type ListAccountChangesResponse = {
   adcp_major_version?: number;
   /**
    * Matching changes in oldest-first total account order. Timestamps are descriptive and do not define this order.
+   * @maxItems 100
    */
   changes?: AccountChange[];
   /**
@@ -35833,6 +34007,7 @@ export type ListAccountChangesResponse = {
   generated_at?: string;
   /**
    * Account-specific feed and connector coverage. Buyers use this to distinguish feed catch-up from upstream freshness. Omission means no additional connected-source coverage is declared.
+   * @maxItems 50
    */
   source_coverage?: {
     /**
@@ -35866,6 +34041,9 @@ export type ListAccountChangesResponse = {
      * @format int
      */
     stale_after_seconds?: number;
+    /**
+     * @maxItems 50
+     */
     resource_types: string[];
   }[];
   errors?: Error[];
@@ -35874,6 +34052,7 @@ export type ListAccountChangesResponse = {
   | {
       /**
        * Matching changes in oldest-first total account order. Timestamps are descriptive and do not define this order.
+       * @maxItems 100
        */
       changes: AccountChange[];
       /**
@@ -35898,6 +34077,7 @@ export type ListAccountChangesResponse = {
       generated_at: string;
       /**
        * Account-specific feed and connector coverage. Buyers use this to distinguish feed catch-up from upstream freshness. Omission means no additional connected-source coverage is declared.
+       * @maxItems 50
        */
       source_coverage?: {
         /**
@@ -35931,6 +34111,9 @@ export type ListAccountChangesResponse = {
          * @format int
          */
         stale_after_seconds?: number;
+        /**
+         * @maxItems 50
+         */
         resource_types: string[];
       }[];
       errors?: Error[];
@@ -35941,6 +34124,7 @@ export type ListAccountChangesResponse = {
   | {
       /**
        * Matching changes in oldest-first total account order. Timestamps are descriptive and do not define this order.
+       * @maxItems 100
        */
       changes?: AccountChange[];
       /**
@@ -35965,6 +34149,7 @@ export type ListAccountChangesResponse = {
       generated_at?: string;
       /**
        * Account-specific feed and connector coverage. Buyers use this to distinguish feed catch-up from upstream freshness. Omission means no additional connected-source coverage is declared.
+       * @maxItems 50
        */
       source_coverage?: {
         /**
@@ -35998,6 +34183,9 @@ export type ListAccountChangesResponse = {
          * @format int
          */
         stale_after_seconds?: number;
+        /**
+         * @maxItems 50
+         */
         resource_types: string[];
       }[];
       errors: Error[];
@@ -36289,6 +34477,7 @@ export interface SyncAccountsRequest {
   idempotency_key: string;
   /**
    * Per-account sync entries. Each entry uses one of two key shapes: the `account` field (AccountRef) for settings-update mode, or the flat `brand` + `operator` + `billing` trio for provisioning mode. An operator_identity settings update MUST carry the latest account revision.
+   * @maxItems 1000
    */
   accounts: (ProvisioningMode | SettingsUpdateMode)[];
   /**
@@ -36334,6 +34523,7 @@ export interface ProvisioningMode {
   preferred_reporting_protocol?: CloudStorageProtocol;
   /**
    * Caller-owned desired state for durable reporting delivery on this account. Declarative replacement is scoped to (authenticated caller, resolved account): omission leaves that caller's set unchanged; [] deactivates that caller's set and starts grant revocation; another caller's entries MUST NOT be read, replaced, or deleted. Entries are keyed by immutable (delivery_config_id, delivery_config_version); duplicate tuples MUST reject the entire account entry, and reusing a tuple with changed content MUST be rejected. Each generation binds the exact report_definition_id advertised by its offering. destination.mode provision asks the seller to verify caller disclosure authority and destination/recipient control from non-secret provider coordinates; destination.mode existing reuses a caller-scoped immutable destination-generation reference, including one registered through sync_agent_configuration. The account configuration independently authorizes disclosure for this feed and scope, so possession of a reusable reference is never account authority. Unknown, unauthorized, and cross-caller refs MUST be indistinguishable. Credentials never transit AdCP, including nested extension fields. Permitted in both provisioning and settings-update modes. Sellers accepting this field MUST advertise media_buy.reporting_delivery in experimental_features and echo resolved secret-free state on sync_accounts and list_accounts.
+   * @maxItems 16
    */
   reporting_delivery_configs?: ReportingDeliveryConfiguration[];
   /**
@@ -36342,6 +34532,7 @@ export interface ProvisioningMode {
    * Activation proof: before activating a new or changed active subscriber, the seller MUST validate the URL, complete the account-level webhook proof-of-control challenge, and only then persist or expose the subscriber as `active: true`. For `account.status_changed`, sellers MUST assign `account_id` before completing proof so subsequent status transitions can identify the account and be repaired through `list_accounts`, even when external approval remains pending. A valid existing proof for the same `(account_id, subscriber_id, normalized url, authentication mode/credential binding, normalized event_types)` tuple MAY be reused; changing any element of that tuple requires fresh proof. The challenge POST itself MUST be signed with the seller's RFC 9421 webhook profile key and MUST include seller_agent_url, delivery_auth, and event_types so the receiver can verify the pending registration before echoing the challenge. New signers use `adcp_use: "request-signing"`; deprecated `webhook-signing` keys remain accepted during the compatibility window. Entries sent with `active: false` may skip only the outbound proof challenge while inactive; sellers MUST still enforce URL parsing, HTTPS, hostname normalization, and reserved-range rejection at write time, and those entries MUST NOT receive fires until reactivated. If proof fails or times out, the seller rejects the account entry with `action: "failed"`, leaves the prior notification_configs[] set unchanged, and reports `VALIDATION_ERROR` (or `INVALID_REQUEST` for malformed URLs) at the failing `notification_configs[j].url` field.
    *
    * **Cap rationale:** `maxItems: 16` is a practical fan-out cap (governance + buyer ingestion + audit bus + dx team + a few partner hooks). The cap exists to prevent unbounded subscriber arrays in storage and to bound the seller's per-event fan-out work. Sellers that hit the cap with legitimate subscribers should surface this on the protocol roadmap rather than work around it.
+   * @maxItems 16
    */
   notification_configs?: NotificationConfig[];
 }
@@ -36367,6 +34558,7 @@ export interface SettingsUpdateMode {
   preferred_reporting_protocol?: CloudStorageProtocol;
   /**
    * Caller-owned desired state for durable reporting delivery on this account. Declarative replacement is scoped to (authenticated caller, resolved account): omission leaves that caller's set unchanged; [] deactivates that caller's set and starts grant revocation; another caller's entries MUST NOT be read, replaced, or deleted. Entries are keyed by immutable (delivery_config_id, delivery_config_version); duplicate tuples MUST reject the entire account entry, and reusing a tuple with changed content MUST be rejected. Each generation binds the exact report_definition_id advertised by its offering. destination.mode provision asks the seller to verify caller disclosure authority and destination/recipient control from non-secret provider coordinates; destination.mode existing reuses a caller-scoped immutable destination-generation reference, including one registered through sync_agent_configuration. The account configuration independently authorizes disclosure for this feed and scope, so possession of a reusable reference is never account authority. Unknown, unauthorized, and cross-caller refs MUST be indistinguishable. Credentials never transit AdCP, including nested extension fields. Permitted in both provisioning and settings-update modes. Sellers accepting this field MUST advertise media_buy.reporting_delivery in experimental_features and echo resolved secret-free state on sync_accounts and list_accounts.
+   * @maxItems 16
    */
   reporting_delivery_configs?: ReportingDeliveryConfiguration[];
   /**
@@ -36375,6 +34567,7 @@ export interface SettingsUpdateMode {
    * Activation proof: before activating a new or changed active subscriber, the seller MUST validate the URL, complete the account-level webhook proof-of-control challenge, and only then persist or expose the subscriber as `active: true`. For `account.status_changed`, sellers MUST assign `account_id` before completing proof so subsequent status transitions can identify the account and be repaired through `list_accounts`, even when external approval remains pending. A valid existing proof for the same `(account_id, subscriber_id, normalized url, authentication mode/credential binding, normalized event_types)` tuple MAY be reused; changing any element of that tuple requires fresh proof. The challenge POST itself MUST be signed with the seller's RFC 9421 webhook profile key and MUST include seller_agent_url, delivery_auth, and event_types so the receiver can verify the pending registration before echoing the challenge. New signers use `adcp_use: "request-signing"`; deprecated `webhook-signing` keys remain accepted during the compatibility window. Entries sent with `active: false` may skip only the outbound proof challenge while inactive; sellers MUST still enforce URL parsing, HTTPS, hostname normalization, and reserved-range rejection at write time, and those entries MUST NOT receive fires until reactivated. If proof fails or times out, the seller rejects the account entry with `action: "failed"`, leaves the prior notification_configs[] set unchanged, and reports `VALIDATION_ERROR` (or `INVALID_REQUEST` for malformed URLs) at the failing `notification_configs[j].url` field.
    *
    * **Cap rationale:** `maxItems: 16` is a practical fan-out cap (governance + buyer ingestion + audit bus + dx team + a few partner hooks). The cap exists to prevent unbounded subscriber arrays in storage and to bound the seller's per-event fan-out work. Sellers that hit the cap with legitimate subscribers should surface this on the protocol roadmap rather than work around it.
+   * @maxItems 16
    */
   notification_configs?: NotificationConfig[];
 }
@@ -36442,446 +34635,9 @@ export type AccountIdentityChangePreview =
  * @maxItems 16
  */
 export type NonblockingImpacts =
-  | [
-      Impact & {
+  (Impact & {
         effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      }
-    ]
-  | [
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      }
-    ]
-  | [
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      }
-    ]
-  | [
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      }
-    ]
-  | [
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      }
-    ]
-  | [
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      }
-    ]
-  | [
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      }
-    ]
-  | [
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      }
-    ]
-  | [
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      }
-    ]
-  | [
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      }
-    ]
-  | [
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      }
-    ]
-  | [
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      }
-    ]
-  | [
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      }
-    ]
-  | [
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      }
-    ]
-  | [
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      }
-    ]
-  | [
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      },
-      Impact & {
-        effect?: 'preserved' | 'revalidation_required' | 'revoke_and_regrant';
-      }
-    ];
+      })[];
 /**
  * Account areas evaluated for a blocked change. At least one impact identifies the blocking area.
  *
@@ -36889,55 +34645,7 @@ export type NonblockingImpacts =
  * @maxItems 16
  */
 export type BlockedImpacts =
-  | [Impact]
-  | [Impact, Impact]
-  | [Impact, Impact, Impact]
-  | [Impact, Impact, Impact, Impact]
-  | [Impact, Impact, Impact, Impact, Impact]
-  | [Impact, Impact, Impact, Impact, Impact, Impact]
-  | [Impact, Impact, Impact, Impact, Impact, Impact, Impact]
-  | [Impact, Impact, Impact, Impact, Impact, Impact, Impact, Impact]
-  | [Impact, Impact, Impact, Impact, Impact, Impact, Impact, Impact, Impact]
-  | [Impact, Impact, Impact, Impact, Impact, Impact, Impact, Impact, Impact, Impact]
-  | [Impact, Impact, Impact, Impact, Impact, Impact, Impact, Impact, Impact, Impact, Impact]
-  | [Impact, Impact, Impact, Impact, Impact, Impact, Impact, Impact, Impact, Impact, Impact, Impact]
-  | [Impact, Impact, Impact, Impact, Impact, Impact, Impact, Impact, Impact, Impact, Impact, Impact, Impact]
-  | [Impact, Impact, Impact, Impact, Impact, Impact, Impact, Impact, Impact, Impact, Impact, Impact, Impact, Impact]
-  | [
-      Impact,
-      Impact,
-      Impact,
-      Impact,
-      Impact,
-      Impact,
-      Impact,
-      Impact,
-      Impact,
-      Impact,
-      Impact,
-      Impact,
-      Impact,
-      Impact,
-      Impact
-    ]
-  | [
-      Impact,
-      Impact,
-      Impact,
-      Impact,
-      Impact,
-      Impact,
-      Impact,
-      Impact,
-      Impact,
-      Impact,
-      Impact,
-      Impact,
-      Impact,
-      Impact,
-      Impact,
-      Impact
-    ];
+  Impact[];
 /**
  * Sync operation processed accounts (individual accounts may be pending or have action=failed)
  */
@@ -37045,10 +34753,12 @@ export interface SyncAccountsSuccess {
     sandbox?: boolean;
     /**
      * Applied notification subscribers for this account after declarative replacement and activation-proof checks. Present on `created`, `updated`, and `unchanged` results when the buyer included `notification_configs` in the request or any persisted entries exist on the account. Entries are keyed by account-scoped `subscriber_id`; re-sending an existing `subscriber_id` replaces that subscriber's config rather than creating a duplicate. Only configs that the seller has persisted are echoed. `authentication.credentials` is omitted on every entry (write-only).
+     * @maxItems 16
      */
     notification_configs?: NotificationConfig[];
     /**
      * Resolved caller-owned durable reporting delivery configurations after declarative replacement. Each item echoes desired state and reports validation/setup state plus the seller-issued destination_ref when resolved. A setup action may direct an authenticated user to complete a provider grant or Open Sharing activation, but MUST NOT carry credentials or a bearer URL.
+     * @maxItems 16
      */
     reporting_delivery_configs?: ReportingDeliveryConfigurationState[];
     authorization?: AccountAuthorization;
@@ -37120,11 +34830,13 @@ export interface SyncGovernanceRequest {
   idempotency_key: string;
   /**
    * Per-account governance agent configuration. Each entry pairs an account reference with the governance agents for that account.
+   * @maxItems 100
    */
   accounts: {
     account: AccountReference;
     /**
      * Governance agent endpoint for this account. Exactly one entry — the single agent that owns the account's full governance lifecycle. The seller calls this agent via check_governance during media buy lifecycle events. The array shape is preserved for wire compatibility with 3.0 senders; `maxItems: 1` is load-bearing and mirrors the singular `governance_context` on the protocol envelope.
+     * @maxItems 1
      */
     governance_agents: {
       /**
@@ -37138,6 +34850,7 @@ export interface SyncGovernanceRequest {
       authentication: {
         /**
          * The seller authenticates outbound check_governance calls with the registered Bearer credential. Other shared webhook authentication schemes are not valid for this agent-to-agent call.
+         * @maxItems 1
          */
         schemes: 'Bearer'[];
         /**
@@ -37218,6 +34931,7 @@ export interface SyncGovernanceSuccess {
     status: 'synced' | 'failed';
     /**
      * Governance agent now synced on this account. Reflects the persisted state after sync. Exactly one entry; the array shape mirrors the request schema and the one-agent-per-account invariant. See sync_governance request schema.
+     * @maxItems 1
      */
     governance_agents?: {
       /**
@@ -37744,138 +35458,7 @@ export type GetProductsCompletion = AdCPVersionEnvelope &
      * @maxItems 20
      */
     suggestions?:
-      | []
-      | [string]
-      | [string, string]
-      | [string, string, string]
-      | [string, string, string, string]
-      | [string, string, string, string, string]
-      | [string, string, string, string, string, string]
-      | [string, string, string, string, string, string, string]
-      | [string, string, string, string, string, string, string, string]
-      | [string, string, string, string, string, string, string, string, string]
-      | [string, string, string, string, string, string, string, string, string, string]
-      | [string, string, string, string, string, string, string, string, string, string, string]
-      | [string, string, string, string, string, string, string, string, string, string, string, string]
-      | [string, string, string, string, string, string, string, string, string, string, string, string, string]
-      | [string, string, string, string, string, string, string, string, string, string, string, string, string, string]
-      | [
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string
-        ]
-      | [
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string
-        ]
-      | [
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string
-        ]
-      | [
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string
-        ]
-      | [
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string
-        ]
-      | [
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string,
-          string
-        ];
+      string[];
     /**
      * [AdCP 3.0] Indicates whether deprecated top-level property_list filtering was applied. True if the agent filtered products based on the provided property_list; every returned product also carries the corresponding property/include list_applications receipt. Absent or false if property_list was not provided or not supported by this agent.
      */
@@ -38369,6 +35952,7 @@ export interface ComplyTestControllerRequest {
     reason?: string;
     /**
      * Optional deterministic alternatives the seller MUST emit on the next get_products rejection. Used only by force_get_products_arm with arm 'rejected'.
+     * @maxItems 20
      */
     suggestions?: string[];
     /**
@@ -38420,6 +36004,7 @@ export interface ComplyTestControllerRequest {
     attestation_mode?: 'raw' | 'digest';
     /**
      * When `attestation_mode` is `digest`, the runner MAY supply SHA-256 digests (lowercase hex, 64 chars) of identifier values it wants the controller to verify echo for. The controller scans each recorded call's payload for string tokens whose SHA-256 hash matches any digest in this list and returns booleans in `recorded_calls[].identifier_match_proofs[]`. Lets the runner verify `identifier_paths` echo without ever transmitting plaintext identifiers to the controller — the digest is the comparison key. Cap of 64 digests per query to bound the controller's work; storyboards with more identifiers SHOULD batch across multiple queries. Has no effect when `attestation_mode` is `raw` (the runner does the matching in-process against the full payload).
+     * @maxItems 64
      */
     identifier_value_digests?: string[];
   };
@@ -38633,6 +36218,7 @@ export interface ForcedDirectiveSuccess {
     reason?: string;
     /**
      * Echo of the optional deterministic alternatives registered for a rejected get_products response.
+     * @maxItems 20
      */
     suggestions?: string[];
   };
@@ -38807,6 +36393,7 @@ export interface DigestAttestation {
   payload_length: number;
   /**
    * Per-identifier echo proofs for digest-mode calls. Required when `attestation_mode` is `digest` AND the request supplied `params.identifier_value_digests`; MUST be absent or empty otherwise. Each entry corresponds to one digest from the request. Capped at 64 to match the request-side `params.identifier_value_digests` cap. Lets storyboards verify `identifier_paths` echo in digest mode without ever transmitting plaintext identifiers to the controller. SHA-256 is a privacy mechanism here, not a trust mechanism — controllers self-report `found` and a determined façade can return any boolean; consumers MUST NOT treat digest-mode passing as cryptographically more trustworthy than raw mode. Tokenization is normative: for `application/json` and `*+json` content types, controllers MUST scan exactly the JSON string-typed leaf values of the post-redaction canonicalized body — no substring matching, no word splitting, no case folding, no Unicode normalization. A token matches when its SHA-256 hash equals one of the requested digests byte-for-byte. For non-JSON content types (form-urlencoded, multipart, plain text), `identifier_match_proofs` MUST be empty and runner-side `identifier_paths` assertions targeting those calls grade `not_applicable` — token boundaries are not portably defined across non-JSON shapes.
+   * @maxItems 64
    */
   identifier_match_proofs?: {
     /**

--- a/test/generate-zod-object-intersections.test.js
+++ b/test/generate-zod-object-intersections.test.js
@@ -62,6 +62,36 @@ function postProcessTupleRestArrays(input) {
   return runPostProcess('postProcessTupleRestArrays', input, '.zod-tuple-rest-');
 }
 
+function postProcessArrayMaxItems(typeSource, zodSource, passes = 1) {
+  const harnessDir = fs.mkdtempSync(path.join(os.tmpdir(), '.zod-array-max-items-'));
+  const scriptPath = path.join(harnessDir, 'harness.ts');
+  const outPath = path.join(harnessDir, 'out.txt');
+  const generateZodPath = path.join(REPO_ROOT, 'scripts/generate-zod-from-ts.ts');
+
+  fs.writeFileSync(
+    scriptPath,
+    `
+import { writeFileSync } from 'fs';
+import { __test__ } from ${JSON.stringify(generateZodPath)};
+let output = ${JSON.stringify(zodSource)};
+for (let pass = 0; pass < ${JSON.stringify(passes)}; pass++) {
+  output = __test__.postProcessArrayMaxItems(output, ${JSON.stringify(typeSource)});
+}
+writeFileSync(${JSON.stringify(outPath)}, output);
+`
+  );
+
+  try {
+    const result = spawnSync('npx', ['tsx', scriptPath], { cwd: REPO_ROOT, encoding: 'utf8' });
+    if (result.status !== 0) {
+      throw new Error(`harness failed (${result.status}): ${result.stderr}\n${result.stdout}`);
+    }
+    return fs.readFileSync(outPath, 'utf8');
+  } finally {
+    fs.rmSync(harnessDir, { recursive: true, force: true });
+  }
+}
+
 function postProcessMarkerUnionObjectIntersections(input) {
   return runPostProcess('postProcessMarkerUnionObjectIntersections', input, '.zod-marker-union-');
 }
@@ -189,7 +219,7 @@ export const ArraySchema = z.array(z.string()).max(5);
 test('relaxArrayCardinalityTypes uses source metadata and preserves structural tuples', () => {
   const output = relaxArrayCardinalityTypes(`
 /** @minItems 1 */
-export type ComplexArray = [{ value: string }, ...{ value: string }[]];
+export type ComplexArray = [{ /** Item value. */ value: string }, ...{ /** Item value. */ value: string }[]];
 /**
  * @minItems 1
  * @maxItems 3
@@ -203,10 +233,198 @@ export type Coordinate = [number, number];
 export type StructuralTupleUnion = [string] | [string, string];
 `);
 
-  assert.match(output, /type ComplexArray = \{\s*value: string;\s*\}\[\]/);
-  assert.match(output, /type BoundedArray = \{\s*value: string;\s*\}\[\]/);
+  assert.match(output, /type ComplexArray = \{[\s\S]*?value: string;?[\s\S]*?\}\[\]/);
+  assert.match(output, /Item value\./);
+  assert.match(output, /type BoundedArray =\s*\{\s*value: string;?\s*\}\[\]/);
   assert.match(output, /type Coordinate = \[\s*number,\s*number\s*\]/);
   assert.match(output, /type StructuralTupleUnion = \[\s*string\s*\] \| \[\s*string,\s*string\s*\]/);
+});
+
+test('relaxArrayCardinalityTypes makes maxItems properties assignable from ordinary arrays', () => {
+  const output = relaxArrayCardinalityTypes(`
+export interface ReportingDeliveryConfigurationState {}
+export interface Account {
+  /** @maxItems 16 */
+  reporting_delivery_configs?:
+    | []
+    | [ReportingDeliveryConfigurationState]
+    | [ReportingDeliveryConfigurationState, ReportingDeliveryConfigurationState];
+}
+`);
+
+  assert.match(output, /reporting_delivery_configs\?:\s*ReportingDeliveryConfigurationState\[\];/);
+  assert.doesNotMatch(output, /reporting_delivery_configs\?:\s*\| \[\]/);
+});
+
+test('relaxArrayCardinalityTypes is idempotent for relaxed intersection arrays', () => {
+  const source = `
+export interface AttestationReference {}
+/** @maxItems 3 */
+export type AttestationRefs = (AttestationReference & {
+  /** Inline provenance. */
+  required: true;
+})[];
+/** @maxItems 4 */
+export type Matrix = [number, number][];
+/** @maxItems 4 */
+export type GenericMatrix = Array<[number, number]>;
+`;
+
+  assert.equal(relaxArrayCardinalityTypes(source), source);
+
+  const bounded = `
+export interface AttestationReference {}
+/** @maxItems 2 */
+export type AttestationRefs =
+  | [AttestationReference & { required: true }]
+  | [AttestationReference & { required: true }, AttestationReference & { required: true }];
+`;
+  const relaxed = relaxArrayCardinalityTypes(bounded);
+  assert.equal(relaxArrayCardinalityTypes(relaxed), relaxed);
+});
+
+test('generated Account maxItems property accepts dynamically assembled arrays', () => {
+  const tmpDir = fs.mkdtempSync(path.join(REPO_ROOT, '.tmp-maxitems-types-'));
+  const reproPath = path.join(tmpDir, 'repro.ts');
+  fs.writeFileSync(
+    reproPath,
+    `import type { Account, ReportingDeliveryConfigurationState } from '../src/lib/types/tools.generated';
+declare const states: ReportingDeliveryConfigurationState[];
+const configs: Account['reporting_delivery_configs'] = states;
+void configs;
+`
+  );
+
+  try {
+    const result = spawnSync(
+      'npx',
+      [
+        'tsc',
+        reproPath,
+        '--noEmit',
+        '--skipLibCheck',
+        '--module',
+        'NodeNext',
+        '--moduleResolution',
+        'NodeNext',
+        '--target',
+        'ES2022',
+      ],
+      { cwd: REPO_ROOT, encoding: 'utf8' }
+    );
+    assert.equal(result.status, 0, `TypeScript repro failed:\n${result.stderr}\n${result.stdout}`);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('postProcessArrayMaxItems restores metadata bounds without changing exact tuples', () => {
+  const typeSource = `
+export interface CreativeLocalePolicy {
+  /**
+   * @minItems 1
+   * @maxItems 50
+   */
+  accepted_language_ranges: string[];
+  nested_entries: {
+    /** @maxItems 16 */
+    reporting_delivery_configs?: number[];
+  }[];
+}
+/** @minItems 2 @maxItems 2 */
+export type Coordinate = [number, number];
+`;
+  const zodSource = `
+export const CreativeLocalePolicySchema = z.object({
+  accepted_language_ranges: z.array(z.string()),
+  nested_entries: z.array(z.object({ reporting_delivery_configs: z.array(z.number()).optional() }))
+});
+export const CoordinateSchema = z.tuple([z.number(), z.number()]);
+`;
+  const output = postProcessArrayMaxItems(typeSource, zodSource);
+
+  assert.match(output, /accepted_language_ranges: z\.array\(z\.string\(\)\)\.max\(50\)/);
+  assert.match(output, /reporting_delivery_configs: z\.array\(z\.number\(\)\)\.max\(16\)\.optional\(\)/);
+  assert.match(output, /CoordinateSchema = z\.tuple\(\[z\.number\(\), z\.number\(\)\]\)/);
+  assert.doesNotMatch(output, /CoordinateSchema = z\.tuple[^;]*\.max\(/);
+  assert.equal(postProcessArrayMaxItems(typeSource, output, 2), output);
+});
+
+test('postProcessArrayMaxItems keeps same-named root and nested paths distinct', () => {
+  const output = postProcessArrayMaxItems(
+    `
+export interface Collision {
+  /** @maxItems 2 */
+  values: string[];
+  nested: {
+    /** @maxItems 3 */
+    values: string[];
+  };
+  unbounded: { values: string[] };
+}
+`,
+    `
+export const CollisionSchema = z.object({
+  values: z.array(z.string()),
+  nested: z.object({ values: z.array(z.string()) }),
+  unbounded: z.object({ values: z.array(z.string()) })
+});
+`
+  );
+
+  assert.match(output, /^\s*values: z\.array\(z\.string\(\)\)\.max\(2\),$/m);
+  assert.match(output, /nested: z\.object\(\{ values: z\.array\(z\.string\(\)\)\.max\(3\) \}\)/);
+  assert.match(output, /unbounded: z\.object\(\{ values: z\.array\(z\.string\(\)\) \}\)/);
+});
+
+test('generated Zod schemas enforce maxItems at the boundary', () => {
+  const harnessDir = fs.mkdtempSync(path.join(REPO_ROOT, '.tmp-zod-maxitems-runtime-'));
+  const scriptPath = path.join(harnessDir, 'harness.ts');
+  const schemasPath = path.join(REPO_ROOT, 'src/lib/types/schemas.generated.ts');
+  fs.writeFileSync(
+    scriptPath,
+    `
+import assert from 'node:assert/strict';
+import { AccountSchema, CreativeLocalePolicySchema } from ${JSON.stringify(schemasPath)};
+
+const languages = (length: number) => Array.from({ length }, () => 'en');
+assert.equal(CreativeLocalePolicySchema.safeParse({ accepted_language_ranges: languages(50) }).success, true);
+assert.equal(CreativeLocalePolicySchema.safeParse({ accepted_language_ranges: languages(51) }).success, false);
+
+const reportingConfig = {
+  configuration: {
+    delivery_config_id: 'config',
+    delivery_config_version: 1,
+    offering_id: 'offering',
+    active: true,
+    feed_purpose: 'pacing',
+    report_definition_id: 'definition',
+    reporting_profile: 'profile',
+    scope: { all_media_buys: true },
+    coverage_requirement: 'full',
+    required_finality: 'snapshot',
+    reconciliation_mode: 'delivery_only',
+    schedule: { period_duration: 'P1D', alignment: 'utc', delivery_sla: 'P1D' }
+  },
+  state: 'ready'
+};
+const account = (count: number) => ({
+  account_id: 'account',
+  name: 'Account',
+  status: 'active',
+  reporting_delivery_configs: Array.from({ length: count }, () => reportingConfig)
+});
+assert.equal(AccountSchema.safeParse(account(16)).success, true);
+assert.equal(AccountSchema.safeParse(account(17)).success, false);
+`
+  );
+
+  try {
+    const result = spawnSync('npx', ['tsx', scriptPath], { cwd: REPO_ROOT, encoding: 'utf8' });
+    assert.equal(result.status, 0, `runtime boundary harness failed:\n${result.stderr}\n${result.stdout}`);
+  } finally {
+    fs.rmSync(harnessDir, { recursive: true, force: true });
+  }
 });
 
 test('postProcessTupleRestArrays handles differently-indented complex items only', () => {

--- a/test/jsdoc-constraints-codegen.test.js
+++ b/test/jsdoc-constraints-codegen.test.js
@@ -83,6 +83,7 @@ describe('injectJsdocConstraints — synthetic end-to-end', () => {
         score: { type: 'number', minimum: 0, maximum: 100 },
         slug: { type: 'string', pattern: '^[a-z0-9_]+$' },
         short: { type: 'string', minLength: 1, maxLength: 50 },
+        capped: { type: 'array', items: { type: 'string' }, maxItems: 16 },
         created_at: { type: 'string', format: 'date-time' },
         nested: {
           type: 'object',
@@ -104,6 +105,7 @@ describe('injectJsdocConstraints — synthetic end-to-end', () => {
     assert.match(ts, /@pattern \^\[a-z0-9_\]\+\$/);
     assert.match(ts, /@minLength 1/);
     assert.match(ts, /@maxLength 50/);
+    assert.match(ts, /@maxItems 16/);
     assert.match(ts, /@format date-time/);
     assert.match(ts, /@format int/);
     assert.match(ts, /@minimum 5/, 'nested inner minimum lost — recursion broken');


### PR DESCRIPTION
## Summary

- generate non-exact `maxItems` constraints as ordinary TypeScript arrays instead of fixed tuple unions
- preserve cardinality metadata and enforce upper bounds with generated Zod `.max(N)` validators
- retain exact tuple contracts and cover nested/same-named property paths

## Validation

- independent TypeScript/codegen and final correctness reviews
- targeted codegen and runtime boundary tests (49 passing)
- typecheck, library build, formatting, generated-file consistency, and strictness checks
- affected environment-sensitive test files pass in isolation under a clean environment

Fixes adcontextprotocol/adcp#7201