### PR TITLE
fix(server): align decisioning notification config types

### DIFF
--- a/.changeset/fresh-eggs-report.md
+++ b/.changeset/fresh-eggs-report.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Fix decisioning account notification types to accept current AdCP 3.2 reporting events.

--- a/scripts/check-adopter-types.ts
+++ b/scripts/check-adopter-types.ts
@@ -82,6 +82,7 @@ const ADOPTER_SOURCE = `
 // payload typing surface that adopters consume from a packed SDK tarball.
 import type {
   AdcpServer,
+  Account,
   AccountStore,
   ActivateSignalPayload,
   LegacyBuildCreativePayload,
@@ -115,6 +116,7 @@ import type {
   SIGetOfferingPayload,
   SyncAudiencesPayload,
   SyncAccountsHandlerResult,
+  SyncAccountsResultRow,
   SyncCreativesPayload,
   SyncCreativesHandlerResult,
   SyncEventSourcesPayload,
@@ -184,6 +186,7 @@ import type {
   CommercialTerms,
   ExplicitPackagesWithFixedAllocation,
   ListCreativesResponse,
+  NotificationConfig,
   Placement,
   PostalCountrySystem,
   PublisherPropertySelector,
@@ -260,6 +263,30 @@ const _accountChangeStore: AccountStore = {
   },
 };
 void _accountChangeStore;
+
+// Issue #2831: decisioning Account surfaces must accept the current generated
+// 3.2 notification contract, including reporting lifecycle subscriptions.
+const _reportingStatusNotification: NotificationConfig = {
+  subscriber_id: 'reporting-status',
+  url: 'https://buyer.example/webhooks/adcp/reporting',
+  event_types: ['reporting.status_changed'],
+};
+const _accountWithReportingStatusNotification: Account = {
+  id: 'acct_1',
+  name: 'Acme',
+  status: 'active',
+  ctx_metadata: {},
+  notification_configs: [_reportingStatusNotification],
+};
+const _syncRowWithReportingStatusNotification: SyncAccountsResultRow = {
+  brand: { domain: 'acme.example' },
+  operator: 'acme-direct',
+  action: 'updated',
+  status: 'active',
+  notification_configs: [_reportingStatusNotification],
+};
+void _accountWithReportingStatusNotification;
+void _syncRowWithReportingStatusNotification;
 
 // Public schema declarations must retain their object helpers and complete
 // parse outputs after packing, not just while compiling inside the repository.

--- a/src/lib/server/decisioning/account.ts
+++ b/src/lib/server/decisioning/account.ts
@@ -29,6 +29,7 @@ import type {
   ListAccountChangesRequest,
   ListAccountChangesResponse,
   ListAccountsRequest,
+  NotificationConfig,
   PaymentTerms,
   ReportingDeliveryConfigurationState,
   ListAccountsResponse,
@@ -44,7 +45,6 @@ import type {
   GetAccountFinancialsSuccess,
 } from '../../types/tools.generated';
 import type { ServerPayload } from '../../types/server-payload';
-import type { NotificationConfig } from '../../types/v3-1-beta';
 import { projectReportingDeliveryConfigStates } from '../reporting-delivery-config';
 import type { CursorPage } from './pagination';
 import type { AccountMode } from '../account-mode';


### PR DESCRIPTION
## Summary
- Align decisioning `Account` and `SyncAccountsResultRow` with the current generated `NotificationConfig`.
- Add packed-adopter declaration coverage for the AdCP 3.2 `reporting.status_changed` notification event.
- Include a patch changeset.

## Validation
- `npm run typecheck`
- `npm run build:lib`
- `npm run test:file -- test/lib/account-notification-config-projection.test.js`
- `npm run check:adopter-types`
- `npm run ci:quick` *(all non-PostgreSQL suites passed; PostgreSQL integration suites require a local service and failed with `ECONNREFUSED 127.0.0.1:5432`)*

Fixes #2831