### PR TITLE
fix(cli): add parallel dispatch storyboard flag

### DIFF
--- a/.changeset/amber-otters-parallel-dispatch.md
+++ b/.changeset/amber-otters-parallel-dispatch.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Add the `adcp storyboard run --parallel-dispatch` opt-in for process-local parallel dispatch conformance grading.

--- a/bin/adcp.js
+++ b/bin/adcp.js
@@ -2164,6 +2164,15 @@ WEBHOOK OPTIONS:
                                   direct child only).
                                   HTTP-on-the-wire — spec-compliant.
 
+PARALLEL DISPATCH OPTIONS:
+  --parallel-dispatch             Enable process-local concurrent dispatches
+                                  for storyboards that require the
+                                  parallel_dispatch_runner contract. This
+                                  exercises event-loop concurrency, which is
+                                  sufficient for rule 9 / first-insert-wins.
+                                  Distributed mode is not implemented and
+                                  grades not_applicable.
+
 OPTIONS:
   --context JSON      Pass context from previous step (step only)
   --contributions JSON|CSV
@@ -2893,6 +2902,7 @@ async function handleStoryboardRun(args) {
   // conflicts surface in dry-run too.
   const webhookAutoTunnel = args.includes('--webhook-receiver-auto-tunnel');
   const webhookReceiverBase = extractWebhookReceiverOptions(args);
+  const parallelDispatchOpts = extractParallelDispatchOptions(args);
   validateAutoTunnelArgs(args, webhookReceiverBase);
 
   // Load invariants before the dry-run gate so `--dry-run --invariants` fails
@@ -2954,6 +2964,7 @@ async function handleStoryboardRun(args) {
       resolvedOauthClientCredentials,
     }),
     ...(webhookReceiverOpts ?? {}),
+    ...mergeStoryboardContracts(webhookReceiverOpts, parallelDispatchOpts),
     ...(fileComplianceOptions.complianceDir && { complianceDir: fileComplianceOptions.complianceDir }),
     ...(fileComplianceOptions.adcpVersion && { adcpVersion: fileComplianceOptions.adcpVersion }),
     ...(fileComplianceOptions.schemaRoot && { schemaRoot: fileComplianceOptions.schemaRoot }),
@@ -3231,6 +3242,27 @@ function extractWebhookReceiverOptions(args) {
     },
     contracts: ['webhook_receiver_runner'],
   };
+}
+
+/**
+ * Parse the opt-in `--parallel-dispatch` flag. The runner already implements
+ * the process-local fan-out contract, but only advertises it when an operator
+ * explicitly requests concurrent grading. This preserves the existing
+ * not_applicable skip for callers that omit the flag.
+ */
+function extractParallelDispatchOptions(args) {
+  return args.includes('--parallel-dispatch') ? { contracts: ['parallel_dispatch_runner'] } : null;
+}
+
+/**
+ * Combine independently requested storyboard-runner contracts. Both webhook
+ * receiver and parallel dispatch are opt-ins, so a run that requests both
+ * must advertise both rather than allowing the later object spread to replace
+ * the earlier contracts array.
+ */
+function mergeStoryboardContracts(...optionSets) {
+  const contracts = [...new Set(optionSets.flatMap(optionSet => optionSet?.contracts ?? []))];
+  return contracts.length > 0 ? { contracts } : {};
 }
 
 const MAX_WEBHOOK_TLS_FILE_BYTES = 1_048_576;
@@ -3906,6 +3938,7 @@ async function handleLocalAgentStoryboardRun(modulePath, args, opts) {
   }
 
   const storyboardsSpec = storyboardId ? [storyboardId] : 'all';
+  const parallelDispatchOpts = extractParallelDispatchOptions(args);
   const restoreLogs = jsonOutput ? captureStdoutLogs() : null;
   let result;
   try {
@@ -3923,6 +3956,7 @@ async function handleLocalAgentStoryboardRun(modulePath, args, opts) {
           mediaBuyLifecycleCompatibility: opts.mediaBuyLifecycleCompatibility,
         }),
         ...(opts.loadedTestKit !== undefined && { test_kit: opts.loadedTestKit }),
+        ...mergeStoryboardContracts(parallelDispatchOpts),
       },
       onStoryboardComplete:
         jsonOutput || format === 'junit'
@@ -4133,6 +4167,7 @@ async function handleMultiInstanceStoryboardRun(args, opts, urls) {
   // up front — not after bundle resolution, connection setup, or dispatch.
   const webhookAutoTunnel = args.includes('--webhook-receiver-auto-tunnel');
   const webhookReceiverBase = extractWebhookReceiverOptions(args);
+  const parallelDispatchOpts = extractParallelDispatchOptions(args);
   validateAutoTunnelArgs(args, webhookReceiverBase);
   if ((webhookReceiverBase || webhookAutoTunnel) && strategy === 'multi-pass') {
     // The runner throws on this combination (each pass binds a fresh receiver
@@ -4348,6 +4383,7 @@ async function handleMultiInstanceStoryboardRun(args, opts, urls) {
     ...(opts.allowHttp && { allow_http: true }),
     multi_instance_strategy: strategy,
     ...(webhookReceiverOpts ?? {}),
+    ...mergeStoryboardContracts(webhookReceiverOpts, parallelDispatchOpts),
     ...(runComplianceDir && { complianceDir: runComplianceDir }),
     ...(runAdcpVersion && { adcpVersion: runAdcpVersion }),
     ...(runSchemaRoot && { schemaRoot: runSchemaRoot }),
@@ -4469,6 +4505,7 @@ async function handleAgentsRoutedStoryboardRun(args, opts, routing) {
 
   const webhookAutoTunnel = args.includes('--webhook-receiver-auto-tunnel');
   const webhookReceiverBase = extractWebhookReceiverOptions(args);
+  const parallelDispatchOpts = extractParallelDispatchOptions(args);
   validateAutoTunnelArgs(args, webhookReceiverBase);
 
   // Strip per-flag values that may have leaked into positionals via parseAgentOptions.
@@ -4632,6 +4669,7 @@ async function handleAgentsRoutedStoryboardRun(args, opts, routing) {
     agents: routing.agents,
     ...(routing.default_agent ? { default_agent: routing.default_agent } : {}),
     ...(webhookReceiverOpts ?? {}),
+    ...mergeStoryboardContracts(webhookReceiverOpts, parallelDispatchOpts),
     ...(runComplianceDir && { complianceDir: runComplianceDir }),
     ...(runAdcpVersion && { adcpVersion: runAdcpVersion }),
     ...(runSchemaRoot && { schemaRoot: runSchemaRoot }),
@@ -4838,6 +4876,7 @@ async function runFullAssessment(agentArg, rawArgs, parsedOpts) {
   });
 
   const webhookReceiverOpts = await resolveWebhookReceiverOptions(rawArgs, { jsonOutput: opts.jsonOutput });
+  const parallelDispatchOpts = extractParallelDispatchOptions(rawArgs);
 
   await loadInvariantModules(rawArgs);
 
@@ -4851,6 +4890,7 @@ async function runFullAssessment(agentArg, rawArgs, parsedOpts) {
     ...(authOption && { auth: authOption }),
     ...(opts.allowHttp && { allow_http: true }),
     ...(webhookReceiverOpts ?? {}),
+    ...mergeStoryboardContracts(webhookReceiverOpts, parallelDispatchOpts),
     ...sandboxRunOptions(opts),
     ...(opts.assertsSeededState && { assertsSeededState: true }),
     ...(opts.mediaBuyLifecycleCompatibility && {

--- a/test/lib/cli-parallel-dispatch-flag.test.js
+++ b/test/lib/cli-parallel-dispatch-flag.test.js
@@ -1,0 +1,123 @@
+/**
+ * CLI plumbing for `--parallel-dispatch` — closes adcontextprotocol/adcp-client#2826.
+ *
+ * The storyboard runner already implements process-local parallel dispatches.
+ * These tests verify that the CLI keeps that contract opt-in: omission retains
+ * the existing not_applicable skip, while the flag dispatches every requested
+ * concurrent call.
+ */
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { spawn } = require('node:child_process');
+const http = require('node:http');
+const { writeFileSync, mkdtempSync, rmSync } = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { McpServer } = require('@modelcontextprotocol/sdk/server/mcp.js');
+const { StreamableHTTPServerTransport } = require('@modelcontextprotocol/sdk/server/streamableHttp.js');
+
+const CLI = path.resolve(__dirname, '../../bin/adcp.js');
+
+function runCli(args, env = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [CLI, ...args], { env: { ...process.env, ...env } });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+    child.stdout.on('data', chunk => (stdout += chunk));
+    child.stderr.on('data', chunk => (stderr += chunk));
+    child.on('error', reject);
+    child.on('close', status => resolve({ status, stdout, stderr }));
+  });
+}
+
+test('--parallel-dispatch opts into process-local parallel dispatch grading', { timeout: 60_000 }, async t => {
+  const fixtureRoot = mkdtempSync(path.join(os.tmpdir(), 'adcp-cli-parallel-dispatch-'));
+  const storyboardPath = path.join(fixtureRoot, 'storyboard.yaml');
+  writeFileSync(
+    storyboardPath,
+    [
+      'id: cli-parallel-dispatch-contract',
+      'title: CLI parallel dispatch contract',
+      'protocol: media-buy',
+      'phases:',
+      '  - id: phase-1',
+      '    title: Concurrent capability probes',
+      '    steps:',
+      '      - id: concurrent-capabilities',
+      '        title: Concurrent capability probes',
+      '        task: get_adcp_capabilities',
+      '        request: {}',
+      '        parallel_dispatch:',
+      '          count: 2',
+      '',
+    ].join('\n')
+  );
+
+  let toolCalls = 0;
+  const server = http.createServer(async (req, res) => {
+    const mcp = new McpServer({ name: 'cli-parallel-dispatch', version: '1.0.0' });
+    mcp.registerTool('get_adcp_capabilities', { inputSchema: {} }, async () => {
+      toolCalls++;
+      return {
+        content: [{ type: 'text', text: '{}' }],
+        structuredContent: {
+          success: true,
+          adcp: { major_versions: [3], idempotency: { supported: true, replay_ttl_seconds: 86400 } },
+          supported_protocols: ['media_buy'],
+          specialisms: [],
+        },
+      };
+    });
+    const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+    try {
+      await mcp.connect(transport);
+      await transport.handleRequest(req, res);
+    } finally {
+      await mcp.close();
+    }
+  });
+  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+  t.after(async () => {
+    if (typeof server.closeAllConnections === 'function') server.closeAllConnections();
+    await new Promise(resolve => server.close(resolve));
+    rmSync(fixtureRoot, { recursive: true, force: true });
+  });
+
+  const command = extraArgs => [
+    'storyboard',
+    'run',
+    `http://127.0.0.1:${server.address().port}/mcp`,
+    '--protocol',
+    'mcp',
+    '--allow-http',
+    '--file',
+    storyboardPath,
+    '--json',
+    ...extraArgs,
+  ];
+
+  const withoutFlag = await runCli(command([]), { ADCP_SKIP_VERSION_CHECK: '1' });
+  assert.strictEqual(withoutFlag.status, 0, withoutFlag.stderr);
+  const skipped = JSON.parse(withoutFlag.stdout);
+  assert.strictEqual(skipped.phases[0].steps[0].skip_reason, 'not_applicable');
+  // Every storyboard run primes capabilities before evaluating its steps.
+  // The skipped step itself must add no second dispatch.
+  assert.strictEqual(toolCalls, 1, 'the gated step must not dispatch without the opt-in');
+
+  const withFlag = await runCli(command(['--parallel-dispatch']), { ADCP_SKIP_VERSION_CHECK: '1' });
+  assert.strictEqual(withFlag.status, 0, withFlag.stderr);
+  const graded = JSON.parse(withFlag.stdout);
+  assert.strictEqual(graded.phases[0].steps[0].skipped, undefined);
+  assert.strictEqual(toolCalls, 4, 'the opt-in must fan out every requested dispatch');
+});
+
+test('storyboard help describes the parallel dispatch opt-in and its mode limits', async () => {
+  const result = await runCli(['storyboard', '--help'], { ADCP_SKIP_VERSION_CHECK: '1' });
+  assert.strictEqual(result.status, 0, result.stderr);
+  assert.match(result.stdout, /--parallel-dispatch/);
+  assert.match(result.stdout, /process-local concurrent dispatches/);
+  assert.match(result.stdout, /Distributed mode is not implemented and/);
+});

--- a/test/lib/cli-parallel-dispatch-flag.test.js
+++ b/test/lib/cli-parallel-dispatch-flag.test.js
@@ -33,32 +33,10 @@ function runCli(args, env = {}) {
   });
 }
 
-test('--parallel-dispatch opts into process-local parallel dispatch grading', { timeout: 60_000 }, async t => {
-  const fixtureRoot = mkdtempSync(path.join(os.tmpdir(), 'adcp-cli-parallel-dispatch-'));
-  const storyboardPath = path.join(fixtureRoot, 'storyboard.yaml');
-  writeFileSync(
-    storyboardPath,
-    [
-      'id: cli-parallel-dispatch-contract',
-      'title: CLI parallel dispatch contract',
-      'protocol: media-buy',
-      'phases:',
-      '  - id: phase-1',
-      '    title: Concurrent capability probes',
-      '    steps:',
-      '      - id: concurrent-capabilities',
-      '        title: Concurrent capability probes',
-      '        task: get_adcp_capabilities',
-      '        request: {}',
-      '        parallel_dispatch:',
-      '          count: 2',
-      '',
-    ].join('\n')
-  );
-
+async function createCapabilityServer(t, name) {
   let toolCalls = 0;
   const server = http.createServer(async (req, res) => {
-    const mcp = new McpServer({ name: 'cli-parallel-dispatch', version: '1.0.0' });
+    const mcp = new McpServer({ name, version: '1.0.0' });
     mcp.registerTool('get_adcp_capabilities', { inputSchema: {} }, async () => {
       toolCalls++;
       return {
@@ -83,13 +61,46 @@ test('--parallel-dispatch opts into process-local parallel dispatch grading', { 
   t.after(async () => {
     if (typeof server.closeAllConnections === 'function') server.closeAllConnections();
     await new Promise(resolve => server.close(resolve));
+  });
+
+  return {
+    address: () => server.address().port,
+    toolCalls: () => toolCalls,
+  };
+}
+
+test('--parallel-dispatch opts into process-local parallel dispatch grading', { timeout: 60_000 }, async t => {
+  const fixtureRoot = mkdtempSync(path.join(os.tmpdir(), 'adcp-cli-parallel-dispatch-'));
+  const storyboardPath = path.join(fixtureRoot, 'storyboard.yaml');
+  writeFileSync(
+    storyboardPath,
+    [
+      'id: cli-parallel-dispatch-contract',
+      'title: CLI parallel dispatch contract',
+      'protocol: media-buy',
+      'phases:',
+      '  - id: phase-1',
+      '    title: Concurrent capability probes',
+      '    steps:',
+      '      - id: concurrent-capabilities',
+      '        title: Concurrent capability probes',
+      '        task: get_adcp_capabilities',
+      '        request: {}',
+      '        parallel_dispatch:',
+      '          count: 2',
+      '',
+    ].join('\n')
+  );
+
+  const capabilityServer = await createCapabilityServer(t, 'cli-parallel-dispatch');
+  t.after(async () => {
     rmSync(fixtureRoot, { recursive: true, force: true });
   });
 
   const command = extraArgs => [
     'storyboard',
     'run',
-    `http://127.0.0.1:${server.address().port}/mcp`,
+    `http://127.0.0.1:${capabilityServer.address()}/mcp`,
     '--protocol',
     'mcp',
     '--allow-http',
@@ -105,13 +116,77 @@ test('--parallel-dispatch opts into process-local parallel dispatch grading', { 
   assert.strictEqual(skipped.phases[0].steps[0].skip_reason, 'not_applicable');
   // Every storyboard run primes capabilities before evaluating its steps.
   // The skipped step itself must add no second dispatch.
-  assert.strictEqual(toolCalls, 1, 'the gated step must not dispatch without the opt-in');
+  assert.strictEqual(capabilityServer.toolCalls(), 1, 'the gated step must not dispatch without the opt-in');
 
+  const callsBeforeWithFlag = capabilityServer.toolCalls();
   const withFlag = await runCli(command(['--parallel-dispatch']), { ADCP_SKIP_VERSION_CHECK: '1' });
   assert.strictEqual(withFlag.status, 0, withFlag.stderr);
   const graded = JSON.parse(withFlag.stdout);
   assert.strictEqual(graded.phases[0].steps[0].skipped, undefined);
-  assert.strictEqual(toolCalls, 4, 'the opt-in must fan out every requested dispatch');
+  assert.strictEqual(
+    capabilityServer.toolCalls() - callsBeforeWithFlag,
+    3,
+    'the opt-in run must make one capability probe and fan out both requested dispatches'
+  );
+});
+
+test('--parallel-dispatch and --webhook-receiver retain both runner contracts', { timeout: 60_000 }, async t => {
+  const fixtureRoot = mkdtempSync(path.join(os.tmpdir(), 'adcp-cli-combined-runner-contracts-'));
+  const storyboardPath = path.join(fixtureRoot, 'storyboard.yaml');
+  writeFileSync(
+    storyboardPath,
+    [
+      'id: cli-combined-runner-contracts',
+      'title: CLI combined runner contracts',
+      'protocol: media-buy',
+      'phases:',
+      '  - id: phase-1',
+      '    title: Combined contracts',
+      '    steps:',
+      '      - id: webhook-contract',
+      '        title: Webhook contract probe',
+      '        task: get_adcp_capabilities',
+      '        request: {}',
+      '        requires_contract: webhook_receiver_runner',
+      '      - id: parallel-contract',
+      '        title: Parallel contract probe',
+      '        task: get_adcp_capabilities',
+      '        request: {}',
+      '        parallel_dispatch:',
+      '          count: 2',
+      '',
+    ].join('\n')
+  );
+  const capabilityServer = await createCapabilityServer(t, 'cli-combined-runner-contracts');
+  t.after(() => rmSync(fixtureRoot, { recursive: true, force: true }));
+
+  const callsBeforeRun = capabilityServer.toolCalls();
+  const result = await runCli(
+    [
+      'storyboard',
+      'run',
+      `http://127.0.0.1:${capabilityServer.address()}/mcp`,
+      '--protocol',
+      'mcp',
+      '--allow-http',
+      '--file',
+      storyboardPath,
+      '--json',
+      '--parallel-dispatch',
+      '--webhook-receiver',
+    ],
+    { ADCP_SKIP_VERSION_CHECK: '1' }
+  );
+
+  assert.strictEqual(result.status, 0, result.stderr);
+  const combined = JSON.parse(result.stdout);
+  assert.strictEqual(combined.phases[0].steps[0].skipped, undefined, 'webhook runner contract must remain in scope');
+  assert.strictEqual(combined.phases[0].steps[1].skipped, undefined, 'parallel runner contract must remain in scope');
+  assert.strictEqual(
+    capabilityServer.toolCalls() - callsBeforeRun,
+    4,
+    'the combined run must make one capability probe, one webhook-contract probe, and two parallel dispatches'
+  );
 });
 
 test('storyboard help describes the parallel dispatch opt-in and its mode limits', async () => {


### PR DESCRIPTION
## Summary\n- add an opt-in `--parallel-dispatch` flag for storyboard execution\n- forward the parallel dispatch contract without changing default skips, including combined webhook runs\n- document the process-local mode and cover opt-in behavior\n\nCloses #2826\n\n## Validation\n- `node --test --test-timeout=60000 test/lib/cli-parallel-dispatch-flag.test.js`\n- `npm run ci:quick`

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/da5d791e-7b31-4120-9c3f-28221ef1feb8)
