### PR TITLE
fix(server): report HITL webhook availability accurately

### DIFF
--- a/.changeset/calm-webhooks-report-truthfully.md
+++ b/.changeset/calm-webhooks-report-truthfully.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Report HITL task webhook availability only when both a buyer URL and delivery emitter are configured.

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -4574,7 +4574,8 @@ async function projectSync<TResult, TWire, TCtxMeta = unknown>(
  *
  * **Webhook delivery on terminal state.** When the buyer passed
  * `push_notification_config: { url, token? }` in the request and the host
- * wired `webhooks` on `serve()`, the framework emits a signed RFC 9421
+ * wired an `emitWebhook` callback (normally by configuring `webhooks` on
+ * `serve()`), the framework emits a signed RFC 9421
  * webhook to that URL on terminal state with the task lifecycle payload.
  * Buyers don't need to poll — they receive completion via push. Polling via
  * `server.getTaskState(taskId, scope)` continues to work for harnesses + the
@@ -4767,7 +4768,10 @@ async function dispatchHitl<TResult>(
     tool: opts.tool,
     accountId: opts.accountId,
     ownerScope: opts.ownerScope ?? `account:${opts.accountId}`,
-    hasWebhook: opts.pushNotificationUrl !== undefined,
+    // `tasks_get.has_webhook` promises a usable completion-delivery path,
+    // not merely that the buyer supplied a destination. Keep accepting the
+    // request without an emitter, but report false when nothing can emit it.
+    hasWebhook: opts.pushNotificationUrl !== undefined && typeof opts.emitWebhook === 'function',
     ...(overrideTaskId !== undefined && { overrideTaskId }),
   });
   if (

--- a/src/lib/server/decisioning/runtime/task-registry.ts
+++ b/src/lib/server/decisioning/runtime/task-registry.ts
@@ -146,8 +146,9 @@ export interface TaskRecord<TResult = unknown, TError extends AdcpStructuredErro
    */
   progress?: TaskHandoffProgress;
   /**
-   * Whether the buyer wired `push_notification_config.url` on the original
-   * request. Surfaced to the buyer via `tasks_get`'s spec-defined
+   * Whether the buyer wired `push_notification_config.url` and the dispatch
+   * had an emitter capable of delivering it. Surfaced to the buyer via
+   * `tasks_get`'s spec-defined
    * `has_webhook: boolean` field so they can decide between long-poll vs.
    * single-shot polling.
    */
@@ -239,7 +240,8 @@ export interface TaskRegistry {
    * Allocate a new task record. Returns the complete scoped reference the
    * framework passes to the handoff context. Initial status is `submitted`.
    *
-   * `hasWebhook: true` when the buyer wired `push_notification_config.url`
+   * `hasWebhook: true` when dispatch has both a buyer
+   * `push_notification_config.url` and an emitter capable of delivering it
    * — surfaced via `tasks_get`'s `has_webhook` field. Defaults to `false`.
    *
    * `overrideTaskId` — when set, the registry uses this exact string as the

--- a/test/server-decisioning-from-platform.test.js
+++ b/test/server-decisioning-from-platform.test.js
@@ -8190,7 +8190,20 @@ describe('tasks_get wire tool (B9)', () => {
         await unblockTask;
         return { media_buy_id: 'mb_42', status: 'active' };
       }),
-      { name: 'p', version: '0.0.1', validation: { requests: 'off', responses: 'off' } }
+      {
+        name: 'p',
+        version: '0.0.1',
+        validation: { requests: 'off', responses: 'off' },
+        taskWebhookEmitter: {
+          emit: async params => ({
+            delivery_id: params.delivery_id,
+            idempotency_key: 'k',
+            attempts: 1,
+            delivered: true,
+            errors: [],
+          }),
+        },
+      }
     );
     let taskId;
 

--- a/test/server-tasks-get-agent-forwarding.test.js
+++ b/test/server-tasks-get-agent-forwarding.test.js
@@ -79,6 +79,29 @@ async function createCompletedTask(server, accountId) {
   return result.structuredContent.task_id;
 }
 
+async function createTaskWithPushConfig(server, accountId) {
+  const result = await server.dispatchTestRequest({
+    method: 'tools/call',
+    params: {
+      name: 'create_media_buy',
+      arguments: {
+        buyer_ref: 'b1',
+        idempotency_key: '11111111-1111-1111-1111-111111111111',
+        packages: [],
+        start_time: '2026-05-01T00:00:00Z',
+        end_time: '2026-06-01T00:00:00Z',
+        account: { account_id: accountId },
+        push_notification_config: {
+          url: 'https://buyer.example.com/webhook',
+          operation_id: 'op_has_webhook',
+        },
+      },
+    },
+  });
+  assert.notStrictEqual(result.isError, true, JSON.stringify(result.structuredContent));
+  return result.structuredContent.task_id;
+}
+
 const dispatchTasksGet = (server, taskId, accountId) =>
   server.dispatchTestRequest({
     method: 'tools/call',
@@ -298,6 +321,43 @@ describe('tasks_get — agent forwarding to accounts.resolve', () => {
     });
     assert.strictEqual(result.isError, true);
     assert.strictEqual(result.structuredContent.adcp_error.code, 'PERMISSION_DENIED');
+  });
+});
+
+describe('tasks_get — webhook availability', () => {
+  it('reports has_webhook false when a push URL is accepted without an emitter (#2836)', async () => {
+    const server = createAdcpServerFromPlatform(buildHitlPlatform({}), {
+      name: 'p',
+      version: '0.0.1',
+      validation: { requests: 'off', responses: 'off' },
+    });
+    const taskId = await createTaskWithPushConfig(server, 'acc_owner');
+
+    const result = await dispatchTasksGet(server, taskId, 'acc_owner');
+    assert.notStrictEqual(result.isError, true, JSON.stringify(result.structuredContent));
+    assert.strictEqual(result.structuredContent.has_webhook, false);
+  });
+
+  it('reports has_webhook true when a push URL and emitter are configured (#2836)', async () => {
+    const server = createAdcpServerFromPlatform(buildHitlPlatform({}), {
+      name: 'p',
+      version: '0.0.1',
+      validation: { requests: 'off', responses: 'off' },
+      taskWebhookEmitter: {
+        emit: async params => ({
+          delivery_id: params.delivery_id,
+          idempotency_key: 'k',
+          attempts: 1,
+          delivered: true,
+          errors: [],
+        }),
+      },
+    });
+    const taskId = await createTaskWithPushConfig(server, 'acc_owner');
+
+    const result = await dispatchTasksGet(server, taskId, 'acc_owner');
+    assert.notStrictEqual(result.isError, true, JSON.stringify(result.structuredContent));
+    assert.strictEqual(result.structuredContent.has_webhook, true);
   });
 });
 


### PR DESCRIPTION
## Summary

Partially addresses #2836 by making `tasks_get.has_webhook` true only when `dispatchHitl` has both a buyer push-notification URL and a callable webhook emitter.

- preserves acceptance of requests that include a push URL without an emitter
- does not add the breaking UNSUPPORTED_FEATURE boundary rejection or a new config flag
- adds regression coverage for no-emitter and configured-emitter cases

## Validation

- PASS: `NODE_ENV=test node --test --test-timeout=60000 --test-force-exit test/server-tasks-get-agent-forwarding.test.js` (13/13)
- PASS: formatting, typecheck, build, commitlint, changeset, and pre-push checks
- INFRA-LIMITED: local `ci:quick` reached the full suite, then the ephemeral Postgres service refused connections at `127.0.0.1:58433`; the affected Postgres suites were unrelated to this patch. GitHub CI supplies the authoritative provisioned run.

## Review

Manual diff review completed. Independent expert review and GitHub CI are in progress.
