### PR TITLE
fix(codegen): parallelize gap schema compilation

### DIFF
--- a/.changeset/quick-gap-schemas.md
+++ b/.changeset/quick-gap-schemas.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Improve gap-schema type generation performance while preserving deterministic output.

--- a/scripts/generate-types.ts
+++ b/scripts/generate-types.ts
@@ -3949,8 +3949,62 @@ function schemaPathToTypeName(relativePath: string): string {
  * - Schemas whose type names were already generated via $ref resolution
  * - Async response variant schemas (working/submitted/input-required)
  */
-async function compileGapSchemas(generatedTypes: Set<string>, refResolver: any): Promise<string> {
-  const allFiles = discoverAllSchemaFiles(LATEST_CACHE_DIR);
+export const GAP_SCHEMA_COMPILE_CONCURRENCY = 10;
+export const GAP_SCHEMA_SLOW_COMPILE_MS = 2_000;
+
+type GapSchemaCompileInput = {
+  relPath: string;
+  typeName: string;
+  strictSchema: any;
+};
+
+type GapSchemaCompileDependencies = {
+  compileSchema?: (schema: any, typeName: string, options: any) => Promise<string>;
+  discoverSchemaFiles?: (directory: string) => string[];
+  log?: (message: string) => void;
+  now?: () => number;
+  readSchema?: (schemaPath: string) => Record<string, any>;
+  schemaDirectory?: string;
+  warn?: (message: string) => void;
+};
+
+/** Map in bounded parallelism while preserving the input order in the result. */
+export async function mapWithConcurrency<T, R>(
+  items: readonly T[],
+  concurrency: number,
+  mapper: (item: T, index: number) => Promise<R>
+): Promise<R[]> {
+  if (!Number.isInteger(concurrency) || concurrency < 1) {
+    throw new Error('concurrency must be a positive integer');
+  }
+
+  const results = new Array<R>(items.length);
+  let nextIndex = 0;
+  const worker = async () => {
+    while (nextIndex < items.length) {
+      const index = nextIndex++;
+      results[index] = await mapper(items[index], index);
+    }
+  };
+  await Promise.all(Array.from({ length: Math.min(concurrency, items.length) }, worker));
+  return results;
+}
+
+async function compileGapSchemas(
+  generatedTypes: Set<string>,
+  refResolver: any,
+  dependencies: GapSchemaCompileDependencies = {}
+): Promise<string> {
+  const schemaDirectory = dependencies.schemaDirectory ?? LATEST_CACHE_DIR;
+  const discoverSchemaFiles = dependencies.discoverSchemaFiles ?? discoverAllSchemaFiles;
+  const readSchema =
+    dependencies.readSchema ??
+    ((schemaPath: string) => JSON.parse(readFileSync(schemaPath, 'utf8')) as Record<string, any>);
+  const compileSchema = dependencies.compileSchema ?? compile;
+  const log = dependencies.log ?? console.log;
+  const warn = dependencies.warn ?? console.warn;
+  const now = dependencies.now ?? Date.now;
+  const gapStartedAt = now();
   const gapCode: string[] = [];
 
   // Directories that contain task request/response schemas (already covered by tool generation)
@@ -3976,9 +4030,10 @@ async function compileGapSchemas(generatedTypes: Set<string>, refResolver: any):
   // Top-level aggregation schemas (not standalone types)
   const skipFiles = new Set(['adagents.json', 'brand.json']);
 
-  let compiledCount = 0;
-
-  for (const relPath of allFiles.sort()) {
+  // Preparation is deliberately synchronous and ordered. Each schema is read exactly
+  // once so title-based dedupe and compile preprocessing share the same document.
+  const compileInputs: GapSchemaCompileInput[] = [];
+  for (const relPath of discoverSchemaFiles(schemaDirectory).sort()) {
     // Skip top-level aggregation files
     if (!relPath.includes('/') && skipFiles.has(relPath)) continue;
 
@@ -4004,29 +4059,19 @@ async function compileGapSchemas(generatedTypes: Set<string>, refResolver: any):
     // `CreativeRejected` — but the error-details file's title is "Creative
     // Rejected Details", so jsts would emit `CreativeRejectedDetails`, not a
     // duplicate. Tracked: adcp-client#1271.
-    let schemaForTypeName: Record<string, unknown> | null = null;
     try {
-      const schemaPath = path.join(LATEST_CACHE_DIR, relPath);
-      schemaForTypeName = JSON.parse(readFileSync(schemaPath, 'utf8'));
-    } catch {
-      // Fall through to the main compile attempt for consistent error logging
-      schemaForTypeName = null;
-    }
-    const titleDerivedTypeName =
-      typeof schemaForTypeName?.title === 'string' ? schemaForTypeName.title.replace(/[^A-Za-z0-9]/g, '') : '';
-    const typeName = titleDerivedTypeName || pathDerivedTypeName;
+      // Read once: title-based filtering and preprocessing use this same document.
+      let schema = readSchema(path.join(schemaDirectory, relPath));
+      const titleDerivedTypeName = typeof schema.title === 'string' ? schema.title.replace(/[^A-Za-z0-9]/g, '') : '';
+      const typeName = titleDerivedTypeName || pathDerivedTypeName;
 
-    // Skip if this type was already generated. The check uses the
-    // title-preferring name so two distinct schemas that share a kebab-name
-    // but have distinct titles can both emit (the previous behavior used
-    // path-only and silently dropped the second).
-    if (generatedTypes.has(typeName)) continue;
+      // Skip if this type was already generated. The check uses the
+      // title-preferring name so two distinct schemas that share a kebab-name
+      // but have distinct titles can both emit (the previous behavior used
+      // path-only and silently dropped the second).
+      if (generatedTypes.has(typeName)) continue;
 
-    try {
-      const schemaPath = path.join(LATEST_CACHE_DIR, relPath);
-      let schema = JSON.parse(readFileSync(schemaPath, 'utf8'));
-
-      // Apply same preprocessing as other schema passes
+      // Apply same preprocessing as other schema passes before fan-out.
       const fileName = path.basename(relPath, '.json');
       if (DEPRECATED_ENUM_VALUES[fileName]) {
         schema = removeDeprecatedFields(schema, fileName);
@@ -4041,32 +4086,67 @@ async function compileGapSchemas(generatedTypes: Set<string>, refResolver: any):
       schema = applyCodegenSchemaWorkarounds(schema, pascalName);
 
       const annotatedSchema = injectJsdocConstraints(schema);
-      const strictSchema = enforceStrictSchema(
-        typeName === 'RequestProposalsResponse' ? annotatedSchema : removeArrayLengthConstraints(annotatedSchema)
-      );
-      const types = await compile(strictSchema, typeName, {
-        bannerComment: '',
-        style: { semi: true, singleQuote: true },
-        additionalProperties: false,
-        strictIndexSignatures: true,
-        $refOptions: {
-          resolve: {
-            cache: refResolver,
-          },
-        },
+      compileInputs.push({
+        relPath,
+        typeName,
+        strictSchema: enforceStrictSchema(
+          typeName === 'RequestProposalsResponse' ? annotatedSchema : removeArrayLengthConstraints(annotatedSchema)
+        ),
       });
-
-      const filtered = filterDuplicateTypeDefinitions(types, generatedTypes);
-      if (filtered.trim()) {
-        gapCode.push(`// ${relPath}\n${filtered}`);
-        compiledCount++;
-      }
     } catch (error: any) {
-      console.warn(`⚠️  Failed to compile gap schema ${relPath}: ${error.message}`);
+      warn(`⚠️  Failed to compile gap schema ${relPath}: ${error.message}`);
     }
   }
 
-  console.log(`📦 Compiled ${compiledCount} gap schemas`);
+  const compileOptions = {
+    bannerComment: '',
+    style: { semi: true, singleQuote: true },
+    additionalProperties: false,
+    strictIndexSignatures: true,
+    $refOptions: {
+      resolve: {
+        cache: refResolver,
+      },
+    },
+  };
+  // json-schema-to-typescript clones its options and schema and creates a new
+  // ref parser per compile. Our resolver is stateless, so this shared config
+  // is safe to use across bounded concurrent workers.
+  const compileResults = await mapWithConcurrency(compileInputs, GAP_SCHEMA_COMPILE_CONCURRENCY, async input => {
+    const startedAt = now();
+    try {
+      const types = await compileSchema(input.strictSchema, input.typeName, compileOptions);
+      return { input, types };
+    } catch (error: any) {
+      warn(`⚠️  Failed to compile gap schema ${input.relPath}: ${error.message}`);
+      return { input, types: null };
+    } finally {
+      const elapsedMs = now() - startedAt;
+      if (elapsedMs > GAP_SCHEMA_SLOW_COMPILE_MS) {
+        log(`🐢 Slow gap schema compilation: ${input.relPath} (${elapsedMs}ms)`);
+      }
+    }
+  });
+
+  // Deduplication mutates generatedTypes, so it must remain sequential in the
+  // original sorted relPath order even though compilation is concurrent.
+  let compiledCount = 0;
+  for (const { input, types } of compileResults) {
+    if (types) {
+      // Preserve the serial generator's title-level output gate. We still
+      // compile every prepared schema above, but a prior sorted result may
+      // have claimed this document's root type while the workers ran.
+      if (generatedTypes.has(input.typeName)) continue;
+      const filtered = filterDuplicateTypeDefinitions(types, generatedTypes);
+      if (filtered.trim()) {
+        gapCode.push(`// ${input.relPath}\n${filtered}`);
+        compiledCount++;
+      }
+    }
+  }
+
+  log(`📦 Compiled ${compiledCount} gap schemas`);
+  log(`⏱️ Gap schema compilation completed in ${now() - gapStartedAt}ms`);
   return gapCode.join('\n\n');
 }
 
@@ -4108,6 +4188,7 @@ async function generateTypes() {
 
   // Track generated types across all core schemas to prevent duplicates
   const generatedCoreTypes = new Set<string>();
+  const rootSchemaCompilationStartedAt = Date.now();
 
   // Compile canonical enum documents before broad aggregate roots. Large
   // dereferenced 3.2 roots can narrow a shared enum in one context or make
@@ -4303,12 +4384,15 @@ async function generateTypes() {
       console.error(`❌ Failed to generate standalone types for ${schemaName}:`, error.message);
     }
   }
+  console.log(`⏱️ Root schema compilation completed in ${Date.now() - rootSchemaCompilationStartedAt}ms`);
 
   // Load AdCP tools from cached schemas
   const tools = loadAdCPTools();
 
   // Generate tool types
+  const toolGenerationStartedAt = Date.now();
   let toolTypes = await generateToolTypes(tools, CORE_AUTHORED_TOOL_SHARED_TYPES);
+  console.log(`⏱️ Tool type compilation completed in ${Date.now() - toolGenerationStartedAt}ms`);
 
   // Remove index signature types that were incorrectly generated from oneOf schemas
   // These occur when JSON Schema has additionalProperties: false but oneOf with only required constraints
@@ -4447,4 +4531,4 @@ if (require.main === module) {
   })();
 }
 
-export { discoverAllSchemaFiles, generateTypes };
+export { compileGapSchemas, discoverAllSchemaFiles, generateTypes };

--- a/test/generate-types-gap-schemas.test.js
+++ b/test/generate-types-gap-schemas.test.js
@@ -1,0 +1,153 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+
+function runHarness(source) {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'adcp-gap-schemas-'));
+  const script = path.join(directory, 'harness.ts');
+  const output = path.join(directory, 'output.json');
+  fs.writeFileSync(
+    script,
+    source
+      .replaceAll('__GENERATOR__', JSON.stringify(path.join(REPO_ROOT, 'scripts/generate-types.ts')))
+      .replaceAll('__OUTPUT__', JSON.stringify(output))
+  );
+  try {
+    const result = spawnSync('npx', ['tsx', script], { cwd: REPO_ROOT, encoding: 'utf8' });
+    assert.equal(result.status, 0, `harness failed:\n${result.stderr}\n${result.stdout}`);
+    return JSON.parse(fs.readFileSync(output, 'utf8'));
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+}
+
+test('gap schemas read once, compile with bounded parallelism, and deduplicate in sorted order', () => {
+  const result = runHarness(`
+import { writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { compileGapSchemas, GAP_SCHEMA_COMPILE_CONCURRENCY } from __GENERATOR__;
+
+async function main() {
+const relPaths = Array.from({ length: GAP_SCHEMA_COMPILE_CONCURRENCY + 2 }, (_, index) =>
+  'enums/schema-' + String(GAP_SCHEMA_COMPILE_CONCURRENCY + 1 - index).padStart(2, '0') + '.json'
+);
+const readCounts = new Map<string, number>();
+const compileOrder: string[] = [];
+let active = 0;
+let maximumActive = 0;
+const output = await compileGapSchemas(new Set(['Generated01']), {}, {
+  discoverSchemaFiles: () => relPaths,
+  readSchema: schemaPath => {
+    const relPath = schemaPath.slice(schemaPath.lastIndexOf('/enums/') + 1);
+    readCounts.set(relPath, (readCounts.get(relPath) ?? 0) + 1);
+    return { title: pathToTitle(relPath) };
+  },
+  compileSchema: async (_schema, typeName) => {
+    compileOrder.push(typeName);
+    active++;
+    maximumActive = Math.max(maximumActive, active);
+    await new Promise(resolve => setTimeout(resolve, 5));
+    active--;
+    return 'export type ' + typeName + ' = string;';
+  },
+  log: () => {},
+  warn: () => {},
+});
+function pathToTitle(relPath: string) {
+  return 'Generated ' + relPath.match(/schema-(\\d+)/)?.[1];
+}
+writeFileSync(__OUTPUT__, JSON.stringify({
+  compileOrder,
+  maximumActive,
+  cap: GAP_SCHEMA_COMPILE_CONCURRENCY,
+  readCounts: [...readCounts.entries()],
+  output,
+}));
+}
+main().catch(error => { console.error(error); process.exitCode = 1; });
+`);
+
+  assert.equal(result.maximumActive, result.cap);
+  assert.equal(result.compileOrder.length, result.cap + 1);
+  assert.ok(!result.compileOrder.includes('Generated01'));
+  assert.deepEqual(
+    result.readCounts.map(([, count]) => count),
+    Array(result.cap + 2).fill(1)
+  );
+  assert.match(result.output, /\/\/ enums\/schema-02\.json\nexport type Generated02 = string;/);
+  assert.ok(result.output.indexOf('schema-02') < result.output.indexOf('schema-03'));
+});
+
+test('gap compilation logs only schemas over the slow threshold and reports total timing', () => {
+  const result = runHarness(`
+import { writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { compileGapSchemas } from __GENERATOR__;
+
+async function main() {
+const logs: string[] = [];
+const nowValues = [0, 100, 2101, 2500];
+await compileGapSchemas(new Set(), {}, {
+  discoverSchemaFiles: () => ['enums/slow.json'],
+  readSchema: () => ({ title: 'Slow' }),
+  compileSchema: async () => 'export type Slow = string;',
+  now: () => nowValues.shift()!,
+  log: message => logs.push(message),
+  warn: message => logs.push(message),
+});
+writeFileSync(__OUTPUT__, JSON.stringify({ logs }));
+}
+main().catch(error => { console.error(error); process.exitCode = 1; });
+`);
+
+  assert.deepEqual(result.logs, [
+    '🐢 Slow gap schema compilation: enums/slow.json (2001ms)',
+    '📦 Compiled 1 gap schemas',
+    '⏱️ Gap schema compilation completed in 2500ms',
+  ]);
+});
+
+test('gap output keeps the first sorted title while compiling every duplicate schema', () => {
+  const result = runHarness(`
+import { writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { compileGapSchemas } from __GENERATOR__;
+
+async function main() {
+let compileCount = 0;
+const output = await compileGapSchemas(new Set(), {}, {
+  discoverSchemaFiles: () => ['enums/z.json', 'enums/a.json', 'enums/m.json'],
+  readSchema: schemaPath => ({
+    title: path.basename(schemaPath, '.json') === 'z' ? 'Unique' : 'Same',
+    description: path.basename(schemaPath, '.json'),
+  }),
+  compileSchema: async (schema, typeName) => {
+    compileCount++;
+    if (typeName === 'Same') {
+      if (schema.description === 'a') {
+        await new Promise(resolve => setTimeout(resolve, 20));
+        return "export type Same = string;";
+      }
+      return "export type Same = string;\\nexport type LeakedAuxiliary = 'm';";
+    }
+    return "export type Unique = 'z';";
+  },
+  log: () => {},
+  warn: () => {},
+});
+writeFileSync(__OUTPUT__, JSON.stringify({ compileCount, output }));
+}
+main().catch(error => { console.error(error); process.exitCode = 1; });
+`);
+
+  assert.equal(result.compileCount, 3);
+  assert.match(result.output, /\/\/ enums\/a\.json\nexport type Same = string;/);
+  assert.doesNotMatch(result.output, /enums\/m\.json/);
+  assert.doesNotMatch(result.output, /LeakedAuxiliary/);
+  assert.match(result.output, /\/\/ enums\/z\.json\nexport type Unique = 'z';/);
+});

--- a/test/generate-types-gap-schemas.test.js
+++ b/test/generate-types-gap-schemas.test.js
@@ -112,6 +112,39 @@ main().catch(error => { console.error(error); process.exitCode = 1; });
   ]);
 });
 
+test('gap compilation continues after a rejected compile and preserves sorted output', () => {
+  const result = runHarness(`
+import { writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { compileGapSchemas } from __GENERATOR__;
+
+async function main() {
+const warnings: string[] = [];
+const compileOrder: string[] = [];
+const output = await compileGapSchemas(new Set(), {}, {
+  discoverSchemaFiles: () => ['enums/z.json', 'enums/a.json', 'enums/m.json'],
+  readSchema: schemaPath => ({ title: path.basename(schemaPath, '.json') }),
+  compileSchema: async (_schema, typeName) => {
+    compileOrder.push(typeName);
+    if (typeName === 'm') throw new Error('intentional compile failure');
+    return 'export type ' + typeName + " = '" + typeName + "';";
+  },
+  log: () => {},
+  warn: message => warnings.push(message),
+});
+writeFileSync(__OUTPUT__, JSON.stringify({ compileOrder, output, warnings }));
+}
+main().catch(error => { console.error(error); process.exitCode = 1; });
+`);
+
+  assert.deepEqual(result.compileOrder, ['a', 'm', 'z']);
+  assert.match(result.output, /\/\/ enums\/a\.json\nexport type a = 'a';/);
+  assert.match(result.output, /\/\/ enums\/z\.json\nexport type z = 'z';/);
+  assert.ok(result.output.indexOf('enums/a.json') < result.output.indexOf('enums/z.json'));
+  assert.doesNotMatch(result.output, /enums\/m\.json/);
+  assert.deepEqual(result.warnings, ['⚠️  Failed to compile gap schema enums/m.json: intentional compile failure']);
+});
+
 test('gap output keeps the first sorted title while compiling every duplicate schema', () => {
   const result = runHarness(`
 import { writeFileSync } from 'node:fs';


### PR DESCRIPTION
## Summary

- compile every eligible prepared gap schema with a bounded concurrency of 10 after a single synchronous read/preprocessing pass
- preserve sorted sequential duplicate filtering and generated output identity
- add phase and slow-schema timings plus deterministic coverage for bounded concurrency, duplicate auxiliary suppression, and compile-failure isolation

## Validation

- `node --test test/generate-types-gap-schemas.test.js` (4 passing)
- `npm run generate-types` (baseline/output identity and idempotence)
- `npm run typecheck`
- `npm run build`
- comparable full generation: 140.516s baseline → 86.984s optimized (38.1% faster)
- `core.generated.ts` and `tools.generated.ts` matched baseline SHA-256 after normalizing only the volatile generated-at header
- the same AdCP 3.2 beta release PR later passed its upstream `Generate TypeScript SDK` gate in about 16 minutes: https://github.com/adcontextprotocol/adcp/actions/runs/33523063790/job/99907961015
- after merge, the exact upstream gate passed against optimized `main` in 3m40s: https://github.com/adcontextprotocol/adcp/actions/runs/33523063790/job/101192921184

`npm run ci:quick` completed but is not green in this VM (35 failures, 185 cancelled). A concurrent pre-push `build:lib` temporarily rewrote `dist/lib/schemas-data`, causing three lifecycle-test `ENOENT` failures. The remaining failures are predominantly PostgreSQL test cascades because no service was available at `127.0.0.1:58433`, plus environment-sensitive CLI/compliance cascades. Focused tests, typecheck, build, and generator validation passed. GitHub CI passed on the clean checkout; one fast-test shard needed an isolated rerun after `conformance-integration.test.js` completed all assertions but crossed the 60-second file timeout during teardown, and the rerun passed.

Closes #2788

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/de4348d4-6319-4518-a359-5f4e5a905e70)
