### PR TITLE
fix(security): resolve CodeQL scanning findings

### DIFF
--- a/.changeset/harden-codeql-findings.md
+++ b/.changeset/harden-codeql-findings.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Harden diagnostic parsing, Markdown escaping, OAuth logging, credential-derived MCP cache identifiers, and structured logger metadata against CodeQL-identified security risks. Logger handlers now receive credential-redacted, non-mutating metadata copies by default; custom handlers that provide equivalent protection can opt out with `redactCredentials: false`.

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,6 +1,8 @@
 name: "AdCP Client CodeQL Config"
 
 paths-ignore:
+  - .context/**
+  - dist/**
   - examples/**
   - scripts/manual-testing/**
   - test/**

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -74,7 +74,7 @@ jobs:
         config-file: ./.github/codeql/codeql-config.yml
         # Include CodeQL's language-native suppression query so narrowly scoped,
         # justified `codeql[...]` annotations are represented in uploaded SARIF.
-        queries: ${{ matrix.language == 'javascript-typescript' && '+codeql/javascript-queries:AlertSuppression.ql' || '' }}
+        packs: ${{ matrix.language == 'javascript-typescript' && '+codeql/javascript-queries:AlertSuppression.ql' || '' }}
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -72,6 +72,9 @@ jobs:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
         config-file: ./.github/codeql/codeql-config.yml
+        # Include CodeQL's language-native suppression query so narrowly scoped,
+        # justified `codeql[...]` annotations are represented in uploaded SARIF.
+        queries: ${{ matrix.language == 'javascript-typescript' && '+codeql/javascript-queries:AlertSuppression.ql' || '' }}
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.

--- a/bin/adcp-storyboard-summary.js
+++ b/bin/adcp-storyboard-summary.js
@@ -19,6 +19,7 @@ const { writeFileSync } = require('node:fs');
 
 function escapeMarkdownCell(s) {
   return String(s ?? '')
+    .replace(/\\/g, '\\\\')
     .replace(/\|/g, '\\|')
     .replace(/\n/g, ' ');
 }

--- a/scripts/smoke-wonderstruck-v2-5.ts
+++ b/scripts/smoke-wonderstruck-v2-5.ts
@@ -14,6 +14,7 @@
 import { config as loadEnv } from 'dotenv';
 loadEnv();
 import { ADCPMultiAgentClient } from '../src/lib';
+import { redactCredentialPatterns } from '../src/lib/server/redact';
 
 interface ToolProbe {
   label: string;
@@ -49,9 +50,12 @@ async function probeOne(label: string, fn: () => Promise<any>): Promise<void> {
         console.log(`      • ${i.pointer ?? ''}  ${i.keyword ?? ''}  ${i.message ?? ''}`);
       }
     }
-  } catch (err: any) {
+  } catch (err) {
     const elapsed = Date.now() - t0;
-    console.log(`   ❌ threw after ${elapsed}ms: ${err?.message ?? err}`);
+    const detail = redactCredentialPatterns(err instanceof Error ? err.message : String(err));
+    // Diagnostic detail is scrubbed before this development-only sink.
+    // codeql[js/clear-text-logging]
+    console.log(`   ❌ probe failed after ${elapsed}ms: ${detail}`);
   }
 }
 
@@ -103,7 +107,9 @@ async function main(): Promise<void> {
 }
 
 main().catch(err => {
-  console.error('❌ smoke test failed:', err?.message ?? err);
-  if (err?.stack) console.error(err.stack);
+  const detail = redactCredentialPatterns(err instanceof Error ? err.message : String(err));
+  // Diagnostic detail is scrubbed before this development-only sink.
+  // codeql[js/clear-text-logging]
+  console.error(`❌ smoke test failed: ${detail}`);
   process.exit(1);
 });

--- a/src/lib/auth/oauth/CLIFlowHandler.ts
+++ b/src/lib/auth/oauth/CLIFlowHandler.ts
@@ -186,6 +186,8 @@ export class CLIFlowHandler implements OAuthFlowHandler {
 
       this.server.listen(this.port, '127.0.0.1', () => {
         if (!this.quiet) {
+          // `port` is a numeric listener coordinate, not credential material.
+          // codeql[js/clear-text-logging]
           console.log(`Waiting for authorization callback on port ${this.port}...`);
           console.log('(Press Ctrl+C to cancel)');
           console.log('');

--- a/src/lib/conformance/oracle.ts
+++ b/src/lib/conformance/oracle.ts
@@ -41,17 +41,43 @@ const STACK_TRACE_REGEXES: readonly RegExp[] = [
   /\.go:\d+ \+0x[0-9a-f]+/,
   // PHP: `#7 /var/www/foo.php(42): Bar->baz()` — numbered frame with file:line
   /#\d+ [^\s]+\.php\(\d+\):/,
-  // JVM: `\n\tat com.foo.Bar.method(Bar.java:42)` — fully-qualified
-  // method with source:line. Anchored to whitespace/newline so an
-  // echoed Javadoc reference in prose (`"at com.foo.Bar(Bar.java:42)"`)
-  // doesn't trigger the detector — real stack frames sit on their own
-  // indented line.
-  /(?:\\n\s*|^\s+|\n\s+)at [\w$.]+\.[\w$]+\([\w$]+\.(?:java|kt|kts|scala|groovy):\d+\)/,
   // .NET: `at Foo.Bar.Baz() in /path/to/X.cs:line 42` — method invocation
   // followed by ` in ` and a file:line marker. The method-name charset
   // includes parens/brackets for generic and overloaded signatures.
   /at [\w.<>`,()[\]]+ in [^:\s]+\.(?:cs|vb|fs):line \d+/,
 ];
+
+const JVM_STACK_FRAME = /^at [\w$.]+\.[\w$]+\([\w$]+\.(?:java|kt|kts|scala|groovy):\d+\)\s*/;
+
+function isJsonFramingSuffix(value: string): boolean {
+  if (!value.startsWith('"')) return false;
+  for (let index = 1; index < value.length; index++) {
+    const char = value[index];
+    if (char !== '}' && char !== ']' && char !== ',' && char !== ' ' && char !== '\t') return false;
+  }
+  return true;
+}
+
+/**
+ * Detect an indented JVM frame without a regex that can repartition an
+ * arbitrary whitespace run. `safeStringify` encodes newlines as the two
+ * characters `\\n`, so normalize those separators before inspecting lines.
+ */
+function hasJvmStackFrame(haystack: string): boolean {
+  const lines = haystack.replaceAll('\\n', '\n').split('\n');
+  for (const [index, line] of lines.entries()) {
+    const candidate = line.trimStart();
+    // The JSON-escaped-newline branch of the previous detector intentionally
+    // accepted zero indentation; retain that coverage after normalization.
+    if (index > 0 || candidate !== line) {
+      const match = JVM_STACK_FRAME.exec(candidate);
+      if (match && (match[0].length === candidate.length || isJsonFramingSuffix(candidate.slice(match[0].length)))) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
 
 const FS_PATH_SIGNATURES = [/\/Users\/[^ "']+/, /\/home\/[^ "']+/, /[A-Z]:\\\\Users\\\\/];
 
@@ -201,6 +227,10 @@ function checkNoStackLeak(result: TaskResult<unknown>, failures: string[]): void
       failures.push(`stack trace leak (matched ${JSON.stringify(sig)})`);
       return;
     }
+  }
+  if (hasJvmStackFrame(haystack)) {
+    failures.push(`stack trace leak (matched ${JVM_STACK_FRAME.source})`);
+    return;
   }
   for (const rx of STACK_TRACE_REGEXES) {
     if (rx.test(haystack)) {

--- a/src/lib/core/TaskExecutor.ts
+++ b/src/lib/core/TaskExecutor.ts
@@ -2584,6 +2584,9 @@ export class TaskExecutor {
   private externalTaskObservationKey(observation: ExternalTaskSettlementObservation): string {
     return createHmac('sha256', EXTERNAL_TASK_OBSERVATION_HMAC_KEY)
       .update(
+        // This keyed digest deduplicates canonical task observations; it does
+        // not store or verify passwords. Agent responses are over-tainted.
+        // codeql[js/insufficient-password-hash]
         canonicalize({
           status: observation.status,
           serverTaskId: observation.serverTaskId ?? null,

--- a/src/lib/negotiation/verification.ts
+++ b/src/lib/negotiation/verification.ts
@@ -1682,6 +1682,9 @@ function canonicalProposalTerms(value: unknown): string {
 }
 
 function digestCanonicalTerms(canonical: string): string {
+  // The negotiation protocol requires a SHA-256 digest of canonical proposal
+  // terms. This is content integrity, not password storage or verification.
+  // codeql[js/insufficient-password-hash]
   return `sha256:${createHash('sha256').update(canonical).digest('base64url')}`;
 }
 

--- a/src/lib/protocols/mcp.ts
+++ b/src/lib/protocols/mcp.ts
@@ -8,7 +8,7 @@ import {
 import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
 import { UnauthorizedError } from '@modelcontextprotocol/sdk/client/auth.js';
 import type { OAuthClientProvider } from '@modelcontextprotocol/sdk/client/auth.js';
-import { createHmac } from 'node:crypto';
+import { createHmac, randomBytes } from 'node:crypto';
 import { createMCPRequestHeaders } from '../auth';
 import { is401Error } from '../errors';
 import type { DebugLogEntry } from '../types/adcp';
@@ -150,24 +150,18 @@ function connectionCacheKey(
   return parts.join('::');
 }
 
-/**
- * Produce a stable 64-bit Map-key disambiguator from credential material.
- *
- * This is NOT a password hash. The credential never leaves the process —
- * the cache is in-memory only, the LRU bounds total entries, and the cache
- * value (the cached MCP transport) closes over the full credential. A
- * collision would still send the right credential on the wire, just
- * possibly cache-miss and reconnect.
- *
- * HMAC-with-empty-key over SHA-256 produces a bit-pattern with the same
- * collision regime as raw SHA-256 but lives in a different dataflow class
- * — CodeQL's `js/insufficient-password-hash` query matches `createHash`
- * against credential-typed sources, not `createHmac`. The semantic shape is
- * what we want (deterministic, collision-resistant) without the
- * password-hash classification.
- */
+// Per-process key keeps credential-derived cache identifiers unlinkable
+// across process restarts and avoids treating a public digest as a password
+// verifier. The connection cache is process-local, so cross-run stability is
+// neither required nor desirable.
+const CACHE_DISAMBIGUATOR_KEY = randomBytes(32);
+
+/** Produce a stable-for-this-process Map-key disambiguator. */
 function cacheDisambiguator(value: string): string {
-  return createHmac('sha256', '').update(value).digest('hex').slice(0, 16);
+  // HMAC with a random per-process key is a credential cache identifier, not
+  // a persisted password verifier or authentication mechanism.
+  // codeql[js/insufficient-password-hash]
+  return createHmac('sha256', CACHE_DISAMBIGUATOR_KEY).update(value).digest('hex');
 }
 
 /**

--- a/src/lib/protocols/mcp.ts
+++ b/src/lib/protocols/mcp.ts
@@ -8,7 +8,7 @@ import {
 import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
 import { UnauthorizedError } from '@modelcontextprotocol/sdk/client/auth.js';
 import type { OAuthClientProvider } from '@modelcontextprotocol/sdk/client/auth.js';
-import { createHmac, randomBytes } from 'node:crypto';
+import { hkdfSync, randomBytes } from 'node:crypto';
 import { createMCPRequestHeaders } from '../auth';
 import { is401Error } from '../errors';
 import type { DebugLogEntry } from '../types/adcp';
@@ -154,14 +154,14 @@ function connectionCacheKey(
 // across process restarts and avoids treating a public digest as a password
 // verifier. The connection cache is process-local, so cross-run stability is
 // neither required nor desirable.
-const CACHE_DISAMBIGUATOR_KEY = randomBytes(32);
+const CACHE_DISAMBIGUATOR_SALT = randomBytes(32);
 
 /** Produce a stable-for-this-process Map-key disambiguator. */
 function cacheDisambiguator(value: string): string {
-  // HMAC with a random per-process key is a credential cache identifier, not
-  // a persisted password verifier or authentication mechanism.
-  // codeql[js/insufficient-password-hash]
-  return createHmac('sha256', CACHE_DISAMBIGUATOR_KEY).update(value).digest('hex');
+  // OAuth tokens and client secrets are high-entropy key material. HKDF with
+  // a random per-process salt yields a stable process-local identifier without
+  // exposing a portable credential digest or retaining the credential as a key.
+  return Buffer.from(hkdfSync('sha256', value, CACHE_DISAMBIGUATOR_SALT, 'adcp-mcp-cache-key', 32)).toString('hex');
 }
 
 /**

--- a/src/lib/server/redact.ts
+++ b/src/lib/server/redact.ts
@@ -1,89 +1,9 @@
 /**
- * Credential-shape redactor for diagnostic strings projected to the wire
- * via `error.details.reason`. Stage 4 of #1269 — defense-in-depth against
- * adopter-thrown errors whose `message` includes credential payloads
- * (raw bearer tokens, OAuth client secrets, signing keyids).
+ * Server compatibility export for the shared diagnostic credential redactor.
  *
- * **Production-default exposure is already gated** on
- * `exposeErrorDetails: process.env.NODE_ENV !== 'production'`. This
- * redactor closes the pre-production gap: adopters running in dev /
- * staging with `exposeErrorDetails: true` no longer leak credential
- * bytes when their resolver throws an error like
- * `Error('lookup failed for token=sk_live_abc')`.
+ * The server uses the conservative default, including unlabeled token-shaped
+ * values, before projecting adopter-thrown error messages onto the wire.
  *
- * The redactor is intentionally conservative — it produces false
- * positives (legitimate IDs that match a credential pattern get
- * redacted too) rather than false negatives. Adopters who need the
- * unredacted error log it server-side, where the framework's logger
- * forwards `err.message` unchanged.
- *
- * @internal — used by the dispatcher's `err.message → details.reason`
- * projections (`create-adcp-server.ts`). Not part of the adopter
- * surface; adopters who want to sanitize `error.details` for their own
- * pipelines reach for `pickSafeDetails` instead.
+ * @internal
  */
-
-// Credential-label alternation reused across multiple patterns. Captures
-// common credential field names with both `_` and `-` separators.
-// `key` is the bare form (e.g. `key=foo`); the underscored variants
-// (`api_key`, `key_id`, `signing_key`) are explicit alternation
-// branches because regex alternation matches left-to-right and the
-// longer labels would never match if `key` came first.
-const CREDENTIAL_LABEL =
-  '(api[_-]?key|key[_-]?id|signing[_-]?key|client[_-]?secret|client[_-]?id|password|passwd|pwd|secret|token|key|jwt|bearer)';
-
-/**
- * Patterns the redactor scrubs. Applied in order; each pattern replaces
- * the matched substring with a placeholder. Patterns are case-insensitive
- * where the match makes sense.
- *
- * 1. `Authorization: Bearer <token>` and similar HTTP-Auth shapes.
- * 2. URL-embedded basic-auth: `https://user:pass@host/` → strips the
- *    password component (preserves scheme + user for diagnostic value).
- * 3. JSON-quoted credential fields: `"token":"value"`,
- *    `"client_secret":"value"`, etc.
- * 4. Unquoted / single-quoted credential fields: `token=value`,
- *    `client_id: value`, `key=value` — varied separators and quoting.
- * 5. Long alphanumeric strings (length ≥ 32) that look like tokens
- *    (no spaces, hex / base64 / base64url charsets). Catches tokens
- *    appearing without a labeling prefix.
- *
- * The 32-character threshold for the unlabeled pattern balances
- * catching real tokens (most production tokens are ≥ 32 chars) against
- * false positives on shorter IDs (UUIDs at 36 chars match, which is
- * fine — a UUID embedded in an error message gets redacted, the
- * server-side log keeps it).
- *
- * Signature accepts `unknown` rather than `string` so the dispatcher
- * can pass `String(err)` results without coercing first; the runtime
- * guard returns the input unchanged for non-string values.
- */
-export function redactCredentialPatterns(message: unknown): unknown {
-  if (typeof message !== 'string' || message.length === 0) return message;
-  return (
-    message
-      // 1. Authorization headers — `Bearer <token>`.
-      .replace(/\bBearer\s+[A-Za-z0-9_\-.~+/=]{8,}/gi, 'Bearer <redacted>')
-      // 2. URL-embedded basic-auth: strip the password component.
-      //    Matches `scheme://user:password@host/...` and replaces just
-      //    the password, preserving scheme + user for diagnostic value.
-      .replace(/(https?:\/\/[^:/\s@]+:)[^@\s]+@/gi, '$1<redacted>@')
-      // 3. JSON-quoted credential properties: "token":"value",
-      //    "client_secret":"value", etc. Matches any non-empty quoted
-      //    value (including short ones — labeled credentials are always
-      //    secrets regardless of length).
-      .replace(new RegExp(`"${CREDENTIAL_LABEL}"\\s*:\\s*"[^"]+"`, 'gi'), '"$1":"<redacted>"')
-      // 4. Unquoted / single-quoted credential properties:
-      //    `token=value`, `client_id: value`. Allows optional quote
-      //    around both the label and the value.
-      .replace(
-        new RegExp(`\\b${CREDENTIAL_LABEL}['"]?\\s*[=:]\\s*['"]?[A-Za-z0-9_\\-.~+/=]{4,}['"]?`, 'gi'),
-        '$1=<redacted>'
-      )
-      // 5. Long token-shaped strings (≥ 32 chars of base64/hex/url-safe)
-      //    without an obvious label. Word-boundary anchored so legitimate
-      //    prose / sentence fragments don't match. The lower bound is 32
-      //    to avoid eating short hex IDs (8-char UUID prefixes etc.).
-      .replace(/\b[A-Za-z0-9_\-.~+/=]{32,}\b/g, '<redacted-token>')
-  );
-}
+export { redactCredentialPatterns } from '../utils/redact-credential-patterns';

--- a/src/lib/testing/compliance/summary.ts
+++ b/src/lib/testing/compliance/summary.ts
@@ -204,14 +204,39 @@ function extractMissingToolNames(warning: string): string[] {
   // Storyboard-level: `agent does not advertise any of [sync_accounts, list_accounts]`
   // Each tool is a separate gap — emit one cause per tool so dashboards see
   // the full list, not a single comma-joined "tool name".
-  const sbMatch = warning.match(/agent does not advertise any of \[([^\]]+)\]/i);
-  if (sbMatch) {
-    return sbMatch[1]!
-      .split(/,\s*/)
+  const prefix = 'agent does not advertise any of [';
+  const contentStart = indexOfAsciiCaseInsensitive(warning, prefix);
+  if (contentStart !== -1) {
+    // Lowercasing Unicode can change string length. Locate the ASCII `[` in
+    // the original warning so offsets never depend on the folded copy.
+    const valueStart = warning.indexOf('[', contentStart) + 1;
+    if (valueStart === 0) return [];
+    const valueEnd = warning.indexOf(']', valueStart);
+    if (valueEnd === -1) return [];
+    return warning
+      .slice(valueStart, valueEnd)
+      .split(',')
       .map(t => t.trim())
       .filter(Boolean);
   }
   return [];
+}
+
+function indexOfAsciiCaseInsensitive(value: string, needle: string): number {
+  const lastStart = value.length - needle.length;
+  for (let start = 0; start <= lastStart; start++) {
+    let matched = true;
+    for (let offset = 0; offset < needle.length; offset++) {
+      const code = value.charCodeAt(start + offset);
+      const folded = code >= 65 && code <= 90 ? code + 32 : code;
+      if (folded !== needle.charCodeAt(offset)) {
+        matched = false;
+        break;
+      }
+    }
+    if (matched) return start;
+  }
+  return -1;
 }
 
 function skipCauseDetail(reason: string): string {
@@ -312,9 +337,18 @@ function buildSkipCauses(result: ComplianceResult): ComplianceSummarySkipCause[]
 }
 
 function parseMissingRequiredToolFamilyCause(warning: string): string | null {
-  const match = warning.match(/^missing_required_tool_family: needs\s+([\s\S]*)$/);
-  if (!match) return null;
-  const family = match[1]!.replace(/\s*[;(][\s\S]*$/, '').trim();
+  const prefix = 'missing_required_tool_family: needs';
+  if (!warning.startsWith(prefix)) return null;
+
+  const suffix = warning.slice(prefix.length);
+  const familyStart = suffix.trimStart();
+  if (familyStart.length === suffix.length) return null;
+
+  const semicolon = familyStart.indexOf(';');
+  const parenthesis = familyStart.indexOf('(');
+  const terminators = [semicolon, parenthesis].filter(index => index !== -1);
+  const familyEnd = terminators.length > 0 ? Math.min(...terminators) : familyStart.length;
+  const family = familyStart.slice(0, familyEnd).trim();
   return family ? `missing_required_tool_family: needs ${family}` : null;
 }
 

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -8196,6 +8196,10 @@ function collectUpstreamIdentifierDigests(
 }
 
 function sha256Hex(value: string): string {
+  // Protocol-defined identifier proof: the receiver compares this exact
+  // SHA-256 value with `identifier_value_sha256`. It is not a credential or
+  // password verifier and cannot be replaced with a salted/KDF construction.
+  // codeql[js/insufficient-password-hash]
   return createHash('sha256').update(value, 'utf8').digest('hex');
 }
 

--- a/src/lib/utils/logger.test.ts
+++ b/src/lib/utils/logger.test.ts
@@ -1,9 +1,13 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createLogger, logger } from './logger';
 
 describe('Logger', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it('should create a logger with default config', () => {
@@ -52,6 +56,295 @@ describe('Logger', () => {
     testLogger.info('test message', meta);
 
     expect(mockHandler.info).toHaveBeenCalledWith('test message', meta);
+  });
+
+  it('allows custom handlers with equivalent protection to opt out of redaction', () => {
+    const mockHandler = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+    const testLogger = createLogger({ handler: mockHandler, redactCredentials: false });
+    const failure = new Error('token=custom-handler-owned');
+    const meta = { at: new Date('2026-09-05T12:00:00.000Z'), failure };
+
+    testLogger.error('token=custom-handler-owned', meta);
+
+    expect(mockHandler.error).toHaveBeenCalledWith('token=custom-handler-owned', meta);
+    expect(mockHandler.error.mock.calls[0]![1]).toBe(meta);
+    expect(meta.failure).toBe(failure);
+  });
+
+  it('rejects credential-redaction opt-out for the default console handler', () => {
+    expect(() => createLogger({ redactCredentials: false })).toThrow(/custom log handler/);
+
+    const testLogger = createLogger();
+    expect(() => testLogger.configure({ redactCredentials: false })).toThrow(/custom log handler/);
+  });
+
+  it('redacts credential-shaped metadata before writing to the default console', () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const testLogger = createLogger();
+
+    testLogger.error('request failed', {
+      oauth_client_credentials: {
+        client_id: 'public-client',
+        client_secret: 'do-not-log',
+      },
+      access_token: 'also-do-not-log',
+    });
+
+    expect(consoleError).toHaveBeenCalledWith('request failed', {
+      oauth_client_credentials: {
+        client_id: 'public-client',
+        client_secret: '[redacted]',
+      },
+      access_token: '[redacted]',
+    });
+  });
+
+  it('redacts credential material embedded in messages', () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const testLogger = createLogger();
+
+    testLogger.error('request failed with token=secret-token-value');
+
+    expect(consoleError).toHaveBeenCalledWith('request failed with token=<redacted>', '');
+  });
+
+  it('redacts alternate authorization and serialized credential shapes without changing benign escaping', () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const testLogger = createLogger();
+
+    testLogger.error('failure Authorization: Basic dXNlcjpwYXNz; realm=upstream');
+    testLogger.error(String.raw`payload={\"access_token\":\"secret.value\"}`);
+    testLogger.error('failure x-adcp-auth=raw.secret');
+    testLogger.error(String.raw`benign=\"quoted value\"`);
+
+    expect(consoleError).toHaveBeenNthCalledWith(1, 'failure Authorization=<redacted>', '');
+    expect(consoleError).toHaveBeenNthCalledWith(2, String.raw`payload={\"access_token\":\"<redacted>\"}`, '');
+    expect(consoleError).toHaveBeenNthCalledWith(3, 'failure x-adcp-auth=<redacted>', '');
+    expect(consoleError).toHaveBeenNthCalledWith(4, String.raw`benign=\"quoted value\"`, '');
+  });
+
+  it('fully redacts escaped quotes inside serialized credential values', () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const testLogger = createLogger();
+
+    testLogger.error(String.raw`payload={"token":"abc\"secret"} tail`);
+    testLogger.error(String.raw`payload={\"token\":\"abc\\\"secret\"} tail`);
+    testLogger.error('payload={"token":"unterminated');
+
+    expect(consoleError).toHaveBeenNthCalledWith(1, 'payload={"token":"<redacted>"} tail', '');
+    expect(consoleError).toHaveBeenNthCalledWith(2, String.raw`payload={\"token\":\"<redacted>\"} tail`, '');
+    expect(consoleError).toHaveBeenNthCalledWith(3, 'payload={"token":"<redacted>', '');
+  });
+
+  it('preserves useful Error metadata while redacting embedded credentials', () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const testLogger = createLogger();
+    const failure = new Error('connection failed with token=do-not-log');
+
+    testLogger.error('request failed', { error: failure });
+
+    expect(consoleError).toHaveBeenCalledWith('request failed', {
+      error: expect.objectContaining({
+        name: 'Error',
+        message: 'connection failed with token=<redacted>',
+        stack: expect.not.stringContaining('do-not-log'),
+      }),
+    });
+    const normalized = consoleError.mock.calls[0]![1] as { error: Record<string, unknown> };
+    expect(Object.keys(normalized.error)).toEqual(expect.arrayContaining(['name', 'message', 'stack']));
+  });
+
+  it('preserves built-in Error subclass names without invoking accessors', () => {
+    const mockHandler = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+    const testLogger = createLogger({ handler: mockHandler });
+
+    testLogger.error('request failed', new TypeError('bad argument'));
+
+    expect(mockHandler.error).toHaveBeenCalledWith(
+      'request failed',
+      expect.objectContaining({ name: 'TypeError', message: 'bad argument' })
+    );
+  });
+
+  it('redacts unlabeled token-shaped values at debug level', () => {
+    const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const testLogger = createLogger({ level: 'debug' });
+    const digest = 'a'.repeat(64);
+
+    testLogger.debug(`upstream rejected ${digest}`);
+
+    expect(consoleLog).toHaveBeenCalledWith('upstream rejected <redacted-token>', '');
+  });
+
+  it('redacts unlabeled token-shaped values above debug level', () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const testLogger = createLogger();
+
+    testLogger.error(`upstream rejected ${'a'.repeat(64)}`);
+
+    expect(consoleError).toHaveBeenCalledWith('upstream rejected <redacted-token>', '');
+  });
+
+  it('redacts padded Base64 tokens at explicit token-character boundaries', () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const testLogger = createLogger();
+
+    testLogger.error(`upstream rejected ${'a'.repeat(39)}=`);
+
+    expect(consoleError).toHaveBeenCalledWith('upstream rejected <redacted-token>', '');
+  });
+
+  it('preserves common structured metadata values', () => {
+    const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const testLogger = createLogger();
+    const at = new Date('2026-09-05T12:00:00.000Z');
+
+    testLogger.info('structured metadata', {
+      at,
+      ids: new Set(['one', 'two']),
+      values: new Map<string, unknown>([
+        ['count', 2],
+        ['access_token', 'do-not-log'],
+      ]),
+      pattern: /token=.*/i,
+    });
+
+    expect(consoleLog).toHaveBeenCalledWith('structured metadata', {
+      at,
+      ids: new Set(['one', 'two']),
+      values: new Map<string, unknown>([
+        ['count', 2],
+        ['access_token', '[redacted]'],
+      ]),
+      pattern: /token=<redacted>/i,
+    });
+  });
+
+  it('preserves Map entries when normalized keys collide', () => {
+    const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const testLogger = createLogger();
+    const values = new Map([
+      ['a'.repeat(64), 'first'],
+      ['b'.repeat(64), 'second'],
+    ]);
+
+    testLogger.info('structured metadata', values);
+
+    expect(consoleLog).toHaveBeenCalledWith(
+      'structured metadata',
+      new Map([
+        ['<redacted-token>', 'first'],
+        ['<redacted-token>#2', 'second'],
+      ])
+    );
+  });
+
+  it('redacts credential-shaped metadata keys and ignores accessors', () => {
+    const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const testLogger = createLogger();
+    const secretKey = 'a'.repeat(64);
+    const meta = Object.defineProperty({ [secretKey]: 'value' }, 'dangerous', {
+      enumerable: true,
+      get: () => {
+        throw new Error('getter must not run');
+      },
+    });
+
+    expect(() => testLogger.info('metadata', meta)).not.toThrow();
+    expect(consoleLog).toHaveBeenCalledWith('metadata', {
+      '<redacted-token>': 'value',
+      dangerous: '[Accessor]',
+    });
+  });
+
+  it('uses inert records for arbitrary objects without invoking inherited inspection hooks', () => {
+    const mockHandler = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+    let inspected = false;
+    const prototype = {
+      toJSON() {
+        inspected = true;
+        return { access_token: 'do-not-log' };
+      },
+    };
+    const meta = Object.assign(Object.create(prototype), { safe: 'value' });
+    const testLogger = createLogger({ handler: mockHandler });
+
+    testLogger.info('metadata', meta);
+
+    const normalized = mockHandler.info.mock.calls[0]![1] as Record<string, unknown>;
+    expect(Object.getPrototypeOf(normalized)).toBeNull();
+    expect(normalized.safe).toBe('value');
+    expect(inspected).toBe(false);
+  });
+
+  it('preserves metadata entries when redacted property names collide', () => {
+    const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const testLogger = createLogger();
+    const meta = {
+      ['a'.repeat(64)]: 'first',
+      ['b'.repeat(64)]: 'second',
+    };
+
+    testLogger.info('metadata', meta);
+
+    expect(consoleLog).toHaveBeenCalledWith(
+      'metadata',
+      expect.objectContaining({
+        '<redacted-token>': 'first',
+        '<redacted-token>#2': 'second',
+      })
+    );
+  });
+
+  it('redacts enumerable properties on function-valued console metadata', () => {
+    const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const testLogger = createLogger();
+    const callback = Object.assign(() => undefined, { access_token: 'do-not-log' });
+
+    testLogger.info('metadata', callback);
+
+    expect(consoleLog).toHaveBeenCalledWith('metadata', {
+      type: 'Function',
+      access_token: '[redacted]',
+    });
+  });
+
+  it('bounds large metadata collections', () => {
+    const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const testLogger = createLogger();
+
+    testLogger.info(
+      'large metadata',
+      Array.from({ length: 2_000 }, (_, index) => index)
+    );
+
+    const normalized = consoleLog.mock.calls[0]![1] as unknown[];
+    expect(normalized).toHaveLength(1_001);
+    expect(normalized.at(-1)).toBe('[Entry limit exceeded]');
+  });
+
+  it('fails closed for oversized diagnostic strings', () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const testLogger = createLogger();
+
+    testLogger.error(`prefix ${'x'.repeat(20_000)} token=secret`);
+
+    expect(consoleError).toHaveBeenCalledWith('[Oversized string redacted]', '');
   });
 
   it('should create child logger with context', () => {

--- a/src/lib/utils/logger.ts
+++ b/src/lib/utils/logger.ts
@@ -4,6 +4,9 @@
  * Provides structured logging with levels and contextual metadata.
  */
 
+import { SECRET_KEY_PATTERN, secretKeyPatternMatches } from './redact-secrets';
+import { redactCredentialPatterns } from './redact-credential-patterns';
+
 export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
 
 export interface LoggerConfig {
@@ -11,7 +14,15 @@ export interface LoggerConfig {
   level?: LogLevel;
   /** Enable/disable logging globally (default: true) */
   enabled?: boolean;
-  /** Custom log handler (default: console) */
+  /**
+   * Redact credential-shaped messages and metadata (default: true). Set to
+   * false only when a custom handler provides equivalent protection.
+   */
+  redactCredentials?: boolean;
+  /**
+   * Custom log handler (default: console). Redaction retains common collection
+   * and date types but returns non-mutating copies when enabled.
+   */
   handler?: {
     debug: (message: string, meta?: unknown) => void;
     info: (message: string, meta?: unknown) => void;
@@ -27,18 +38,213 @@ const LOG_LEVELS: Record<LogLevel, number> = {
   error: 3,
 };
 
+const MAX_LOG_DEPTH = 32;
+const MAX_LOG_NODES = 10_000;
+const MAX_LOG_COLLECTION_ENTRIES = 1_000;
+const MAX_LOG_STRING_LENGTH = 16_384;
+const MAX_LOG_TOTAL_STRING_UNITS = 1_048_576;
+
+interface LogNormalizationState {
+  nodes: number;
+  seen: WeakSet<object>;
+  stringUnits: number;
+}
+
+function redactLogMessage(message: string, state?: LogNormalizationState): string {
+  if (message.length > MAX_LOG_STRING_LENGTH) return '[Oversized string redacted]';
+  if (state) {
+    if (state.stringUnits + message.length > MAX_LOG_TOTAL_STRING_UNITS) return '[String unit limit exceeded]';
+    state.stringUnits += message.length;
+  }
+  return redactCredentialPatterns(message) as string;
+}
+
+function findErrorDataString(error: Error, key: 'name' | 'message' | 'stack', fallback: string): string {
+  let current: object | null = error;
+  for (let depth = 0; current && depth < 8; depth++) {
+    const descriptor = Object.getOwnPropertyDescriptor(current, key);
+    if (descriptor) return 'value' in descriptor && typeof descriptor.value === 'string' ? descriptor.value : fallback;
+    current = Object.getPrototypeOf(current) as object | null;
+  }
+  return fallback;
+}
+
+function normalizeLogMetadata(value: unknown, state: LogNormalizationState, depth = 0): unknown {
+  state.nodes += 1;
+  if (state.nodes > MAX_LOG_NODES) return '[Node limit exceeded]';
+  if (typeof value === 'string') return redactLogMessage(value, state);
+  if (!value || (typeof value !== 'object' && typeof value !== 'function')) return value;
+  if (depth > MAX_LOG_DEPTH) return '[Max depth exceeded]';
+  if (state.seen.has(value)) return '[Circular]';
+
+  state.seen.add(value);
+  let normalized: unknown;
+  if (value instanceof Error) {
+    const cause = Object.getOwnPropertyDescriptor(value, 'cause');
+    const name = findErrorDataString(value, 'name', 'Error');
+    const message = findErrorDataString(value, 'message', '');
+    const stack = findErrorDataString(value, 'stack', '');
+    const serialized = Object.create(null) as Record<string, unknown>;
+    Object.defineProperties(serialized, {
+      name: {
+        value: redactLogMessage(name, state),
+        configurable: true,
+        enumerable: true,
+        writable: true,
+      },
+      message: {
+        value: redactLogMessage(message, state),
+        configurable: true,
+        enumerable: true,
+        writable: true,
+      },
+    });
+    if (stack) {
+      Object.defineProperty(serialized, 'stack', {
+        value: redactLogMessage(stack, state),
+        configurable: true,
+        enumerable: true,
+        writable: true,
+      });
+    }
+    if (cause && 'value' in cause) {
+      Object.defineProperty(serialized, 'cause', {
+        value: normalizeLogMetadata(cause.value, state, depth + 1),
+        configurable: true,
+        enumerable: true,
+        writable: true,
+      });
+    }
+    copyEnumerableDataProperties(value, serialized, state, depth, new Set(['name', 'message', 'stack', 'cause']));
+    normalized = serialized;
+  } else if (value instanceof Date) {
+    normalized = new Date(value.getTime());
+  } else if (value instanceof Map) {
+    const entries = new Map<unknown, unknown>();
+    let count = 0;
+    for (const [key, entry] of value) {
+      if (count++ >= MAX_LOG_COLLECTION_ENTRIES) {
+        entries.set('[Entry limit exceeded]', true);
+        break;
+      }
+      const secretKey = typeof key === 'string' && secretKeyPatternMatches(SECRET_KEY_PATTERN, key);
+      const normalizedKey = normalizeLogMetadata(key, state, depth + 1);
+      entries.set(
+        collisionSafeMapKey(entries, normalizedKey),
+        secretKey ? '[redacted]' : normalizeLogMetadata(entry, state, depth + 1)
+      );
+    }
+    normalized = entries;
+  } else if (value instanceof Set) {
+    const values = new Set<unknown>();
+    let count = 0;
+    for (const entry of value) {
+      if (count++ >= MAX_LOG_COLLECTION_ENTRIES) {
+        values.add('[Entry limit exceeded]');
+        break;
+      }
+      values.add(normalizeLogMetadata(entry, state, depth + 1));
+    }
+    normalized = values;
+  } else if (value instanceof RegExp) {
+    normalized = new RegExp(redactLogMessage(value.source, state), value.flags);
+  } else if (Array.isArray(value)) {
+    const entries = value
+      .slice(0, MAX_LOG_COLLECTION_ENTRIES)
+      .map(entry => normalizeLogMetadata(entry, state, depth + 1));
+    if (value.length > MAX_LOG_COLLECTION_ENTRIES) entries.push('[Entry limit exceeded]');
+    normalized = entries;
+  } else if (typeof value === 'function') {
+    const object: Record<string, unknown> = { type: 'Function' };
+    copyEnumerableDataProperties(value, object, state, depth);
+    normalized = object;
+  } else {
+    const object = Object.create(null) as Record<string, unknown>;
+    copyEnumerableDataProperties(value, object, state, depth);
+    normalized = object;
+  }
+  state.seen.delete(value);
+  return normalized;
+}
+
+function collisionSafeMapKey(entries: ReadonlyMap<unknown, unknown>, key: unknown): unknown {
+  if (!entries.has(key) || typeof key !== 'string') return key;
+  let suffix = 2;
+  while (entries.has(`${key}#${suffix}`)) suffix++;
+  return `${key}#${suffix}`;
+}
+
+function copyEnumerableDataProperties(
+  source: object,
+  target: Record<string, unknown>,
+  state: LogNormalizationState,
+  depth: number,
+  excluded: ReadonlySet<string> = new Set()
+): void {
+  let examined = 0;
+  let copied = 0;
+  let truncated = false;
+  for (const key in source) {
+    if (examined++ >= MAX_LOG_COLLECTION_ENTRIES * 2) {
+      truncated = true;
+      break;
+    }
+    if (!Object.prototype.hasOwnProperty.call(source, key)) continue;
+    if (copied++ >= MAX_LOG_COLLECTION_ENTRIES) {
+      truncated = true;
+      break;
+    }
+    if (excluded.has(key)) continue;
+    const descriptor = Object.getOwnPropertyDescriptor(source, key);
+    const entry = descriptor && 'value' in descriptor ? descriptor.value : '[Accessor]';
+    const redactedKey = redactLogMessage(key, state);
+    let safeKey = redactedKey;
+    let suffix = 2;
+    while (Object.prototype.hasOwnProperty.call(target, safeKey)) safeKey = `${redactedKey}#${suffix++}`;
+    Object.defineProperty(target, safeKey, {
+      value: secretKeyPatternMatches(SECRET_KEY_PATTERN, key)
+        ? '[redacted]'
+        : normalizeLogMetadata(entry, state, depth + 1),
+      enumerable: true,
+      configurable: true,
+      writable: true,
+    });
+  }
+  if (truncated) target['[Entry limit exceeded]'] = true;
+}
+
+function prepareLogMetadata(value: unknown): unknown {
+  try {
+    return normalizeLogMetadata(value, { nodes: 0, seen: new WeakSet(), stringUnits: 0 });
+  } catch {
+    return '[Unserializable metadata]';
+  }
+}
+
 class Logger {
   private config: Required<LoggerConfig>;
+  private usingDefaultHandler: boolean;
 
   constructor(config: LoggerConfig = {}) {
+    if (config.redactCredentials === false && !config.handler) {
+      throw new Error('redactCredentials can only be disabled when a custom log handler is provided');
+    }
+    this.usingDefaultHandler = config.handler === undefined;
     this.config = {
       level: config.level || 'info',
       enabled: config.enabled !== false,
+      redactCredentials: config.redactCredentials !== false,
       handler: config.handler || {
-        debug: (msg, meta) => console.log(msg, meta ? meta : ''),
-        info: (msg, meta) => console.log(msg, meta ? meta : ''),
-        warn: (msg, meta) => console.warn(msg, meta ? meta : ''),
-        error: (msg, meta) => console.error(msg, meta ? meta : ''),
+        // Logger inputs are scrubbed immediately before handler dispatch. The
+        // generic logging API itself is not a credential-storage primitive.
+        // codeql[js/clear-text-logging]
+        debug: (msg, meta) => console.log(msg, meta ?? ''),
+        // codeql[js/clear-text-logging]
+        info: (msg, meta) => console.log(msg, meta ?? ''),
+        // codeql[js/clear-text-logging]
+        warn: (msg, meta) => console.warn(msg, meta ?? ''),
+        // codeql[js/clear-text-logging]
+        error: (msg, meta) => console.error(msg, meta ?? ''),
       },
     };
   }
@@ -53,7 +259,10 @@ class Logger {
    */
   debug(message: string, meta?: unknown): void {
     if (this.shouldLog('debug')) {
-      this.config.handler.debug(message, meta);
+      this.config.handler.debug(
+        this.config.redactCredentials ? redactLogMessage(message) : message,
+        this.config.redactCredentials ? prepareLogMetadata(meta) : meta
+      );
     }
   }
 
@@ -62,7 +271,10 @@ class Logger {
    */
   info(message: string, meta?: unknown): void {
     if (this.shouldLog('info')) {
-      this.config.handler.info(message, meta);
+      this.config.handler.info(
+        this.config.redactCredentials ? redactLogMessage(message) : message,
+        this.config.redactCredentials ? prepareLogMetadata(meta) : meta
+      );
     }
   }
 
@@ -71,7 +283,10 @@ class Logger {
    */
   warn(message: string, meta?: unknown): void {
     if (this.shouldLog('warn')) {
-      this.config.handler.warn(message, meta);
+      this.config.handler.warn(
+        this.config.redactCredentials ? redactLogMessage(message) : message,
+        this.config.redactCredentials ? prepareLogMetadata(meta) : meta
+      );
     }
   }
 
@@ -80,7 +295,10 @@ class Logger {
    */
   error(message: string, meta?: unknown): void {
     if (this.shouldLog('error')) {
-      this.config.handler.error(message, meta);
+      this.config.handler.error(
+        this.config.redactCredentials ? redactLogMessage(message) : message,
+        this.config.redactCredentials ? prepareLogMetadata(meta) : meta
+      );
     }
   }
 
@@ -104,7 +322,11 @@ class Logger {
    * Update logger configuration
    */
   configure(config: Partial<LoggerConfig>): void {
+    if (config.redactCredentials === false && !config.handler && this.usingDefaultHandler) {
+      throw new Error('redactCredentials can only be disabled when a custom log handler is provided');
+    }
     Object.assign(this.config, config);
+    if (config.handler) this.usingDefaultHandler = false;
   }
 }
 

--- a/src/lib/utils/logger.ts
+++ b/src/lib/utils/logger.ts
@@ -213,7 +213,7 @@ function copyEnumerableDataProperties(
   if (truncated) target['[Entry limit exceeded]'] = true;
 }
 
-function prepareLogMetadata(value: unknown): unknown {
+function redactLogMetadata(value: unknown): unknown {
   try {
     return normalizeLogMetadata(value, { nodes: 0, seen: new WeakSet(), stringUnits: 0 });
   } catch {
@@ -235,16 +235,12 @@ class Logger {
       enabled: config.enabled !== false,
       redactCredentials: config.redactCredentials !== false,
       handler: config.handler || {
-        // Logger inputs are scrubbed immediately before handler dispatch. The
-        // generic logging API itself is not a credential-storage primitive.
-        // codeql[js/clear-text-logging]
-        debug: (msg, meta) => console.log(msg, meta ?? ''),
-        // codeql[js/clear-text-logging]
-        info: (msg, meta) => console.log(msg, meta ?? ''),
-        // codeql[js/clear-text-logging]
-        warn: (msg, meta) => console.warn(msg, meta ?? ''),
-        // codeql[js/clear-text-logging]
-        error: (msg, meta) => console.error(msg, meta ?? ''),
+        // Scrub again at the concrete sink as defense in depth. This keeps the
+        // default handler safe even if a future call site bypasses dispatch.
+        debug: (msg, meta) => console.log(redactLogMessage(msg), redactLogMetadata(meta) ?? ''),
+        info: (msg, meta) => console.log(redactLogMessage(msg), redactLogMetadata(meta) ?? ''),
+        warn: (msg, meta) => console.warn(redactLogMessage(msg), redactLogMetadata(meta) ?? ''),
+        error: (msg, meta) => console.error(redactLogMessage(msg), redactLogMetadata(meta) ?? ''),
       },
     };
   }
@@ -261,7 +257,7 @@ class Logger {
     if (this.shouldLog('debug')) {
       this.config.handler.debug(
         this.config.redactCredentials ? redactLogMessage(message) : message,
-        this.config.redactCredentials ? prepareLogMetadata(meta) : meta
+        this.config.redactCredentials ? redactLogMetadata(meta) : meta
       );
     }
   }
@@ -273,7 +269,7 @@ class Logger {
     if (this.shouldLog('info')) {
       this.config.handler.info(
         this.config.redactCredentials ? redactLogMessage(message) : message,
-        this.config.redactCredentials ? prepareLogMetadata(meta) : meta
+        this.config.redactCredentials ? redactLogMetadata(meta) : meta
       );
     }
   }
@@ -285,7 +281,7 @@ class Logger {
     if (this.shouldLog('warn')) {
       this.config.handler.warn(
         this.config.redactCredentials ? redactLogMessage(message) : message,
-        this.config.redactCredentials ? prepareLogMetadata(meta) : meta
+        this.config.redactCredentials ? redactLogMetadata(meta) : meta
       );
     }
   }
@@ -297,7 +293,7 @@ class Logger {
     if (this.shouldLog('error')) {
       this.config.handler.error(
         this.config.redactCredentials ? redactLogMessage(message) : message,
-        this.config.redactCredentials ? prepareLogMetadata(meta) : meta
+        this.config.redactCredentials ? redactLogMetadata(meta) : meta
       );
     }
   }

--- a/src/lib/utils/redact-credential-patterns.ts
+++ b/src/lib/utils/redact-credential-patterns.ts
@@ -1,0 +1,58 @@
+/** Shared internal credential-shape redaction for diagnostic strings. */
+
+const CREDENTIAL_LABEL =
+  '(x[_-]?adcp[_-]?auth|authorization|credentials?|private[_-]?key|api[_-]?key|key[_-]?id|signing[_-]?key|signature|client[_-]?secret|client[_-]?id|refresh[_-]?token|access[_-]?token|session[_-]?token|offering[_-]?token|password|passwd|pwd|secret|token|key|jwt|bearer|set[_-]?cookie|cookie)';
+
+function findQuotedValueEnd(message: string, start: number, escapedWrapper: boolean): number {
+  for (let index = start; index < message.length; index++) {
+    if (message[index] !== '"') continue;
+    let slashCount = 0;
+    for (let cursor = index - 1; cursor >= start && message[cursor] === '\\'; cursor--) slashCount++;
+    if (escapedWrapper ? slashCount === 1 : slashCount % 2 === 0) {
+      return escapedWrapper ? index - 1 : index;
+    }
+  }
+  return -1;
+}
+
+function redactJsonCredentialFields(message: string, escapedWrapper: boolean): string {
+  const opening = escapedWrapper ? '\\\\"' : '"';
+  const fieldStart = new RegExp(`${opening}${CREDENTIAL_LABEL}${opening}\\s*:\\s*${opening}`, 'gi');
+  let cursor = 0;
+  let redacted = '';
+  for (let match = fieldStart.exec(message); match; match = fieldStart.exec(message)) {
+    const valueStart = fieldStart.lastIndex;
+    const valueEnd = findQuotedValueEnd(message, valueStart, escapedWrapper);
+    if (valueEnd === -1) return `${redacted}${message.slice(cursor, valueStart)}<redacted>`;
+    redacted += `${message.slice(cursor, valueStart)}<redacted>`;
+    cursor = valueEnd;
+    fieldStart.lastIndex = valueEnd + (escapedWrapper ? 2 : 1);
+  }
+  return cursor === 0 ? message : redacted + message.slice(cursor);
+}
+
+/**
+ * Scrub labelled credentials, Authorization headers, and URL basic-auth.
+ * Wire-facing callers retain the conservative unlabeled-token rule by
+ * default; callers can disable it when labelled credential matching is the
+ * intended contract.
+ *
+ * @internal
+ */
+export function redactCredentialPatterns(message: unknown, redactUnlabeledTokens = true): unknown {
+  if (typeof message !== 'string' || message.length === 0) return message;
+  const redacted = redactJsonCredentialFields(redactJsonCredentialFields(message, true), false)
+    .replace(/\bAuthorization\s*[=:]\s*[^\r\n]+/gi, 'Authorization=<redacted>')
+    .replace(/\bBearer\s+[A-Za-z0-9_\-.~+/=]{8,}/gi, 'Bearer <redacted>')
+    .replace(/(https?:\/\/[^:/\s@]+:)[^@\s]+@/gi, '$1<redacted>@')
+    .replace(
+      new RegExp(`(?<!["\\\\])\\b${CREDENTIAL_LABEL}['"]?\\s*[=:]\\s*(?:'[^']*'|"[^"]*"|[^\\s,;]+)`, 'gi'),
+      '$1=<redacted>'
+    );
+
+  if (!redactUnlabeledTokens) return redacted;
+  return redacted.replace(
+    /(?<![A-Za-z0-9_\-.~+/=])[A-Za-z0-9_\-.~+/=]{32,}(?![A-Za-z0-9_\-.~+/=])/g,
+    '<redacted-token>'
+  );
+}

--- a/src/lib/v2/projection/v1-to-v2.ts
+++ b/src/lib/v2/projection/v1-to-v2.ts
@@ -74,11 +74,15 @@ class CatalogRequirementConflict extends Error {}
 /**
  * Stable identity disambiguator, not a password hash. The input is a public
  * creative-format tuple and the output is a product-local routing label. As
- * with the transport cache disambiguators, HMAC-SHA256 with an empty key gives
- * deterministic collision resistance without placing this non-secret value
- * in CodeQL's password-storage dataflow class.
+ * HMAC-SHA256 with an empty key gives deterministic collision resistance
+ * without placing this non-secret value in CodeQL's password-storage dataflow
+ * class. Unlike the process-local transport cache key, this identity must stay
+ * stable across process restarts.
  */
 function formatIdentityDisambiguator(identity: string): string {
+  // This digest gives a public creative-format tuple a deterministic migration
+  // identity; it is not used to store or verify credentials.
+  // codeql[js/insufficient-password-hash]
   return createHmac('sha256', '').update(identity).digest('hex').slice(0, 32);
 }
 

--- a/test/lib/cli-summary-markdown.test.js
+++ b/test/lib/cli-summary-markdown.test.js
@@ -281,6 +281,10 @@ test('escapeMarkdownCell: pipes are backslash-escaped so they do not split cells
   assert.strictEqual(escapeMarkdownCell('a | b | c'), 'a \\| b \\| c');
 });
 
+test('escapeMarkdownCell: backslashes are escaped before pipes', () => {
+  assert.strictEqual(escapeMarkdownCell('sneaky \\| literal'), 'sneaky \\\\\\| literal');
+});
+
 test('escapeMarkdownCell: newlines collapse to spaces so a multi-line reason stays on one row', () => {
   assert.strictEqual(escapeMarkdownCell('first line\nsecond line'), 'first line second line');
 });

--- a/test/lib/compliance-summary.test.js
+++ b/test/lib/compliance-summary.test.js
@@ -763,6 +763,28 @@ describe('buildComplianceSummary — skip causes', () => {
     assert.ok(list, 'missing_tool: list_accounts should be present');
   });
 
+  test('malformed long missing-tool warning without a closing bracket stays ungrouped', () => {
+    const result = resultWithSkips();
+    result.tracks[0].scenarios[0].steps[0].warnings = [`agent does not advertise any of [${'\\'.repeat(100_000)}`];
+    const s = buildComplianceSummary(result, { sdkVersion: '6.9.0', adcpVersion: '3.0.6' });
+    assert.ok(s.skip_causes);
+    assert.equal(s.skip_causes[0].cause, 'missing_tool');
+  });
+
+  test('Unicode before a mixed-case missing-tool prefix does not shift parsing offsets', () => {
+    const result = resultWithSkips();
+    result.tracks[0].scenarios = [result.tracks[0].scenarios[0]];
+    result.tracks[0].scenarios[0].steps = [result.tracks[0].scenarios[0].steps[0]];
+    result.tracks[0].scenarios[0].steps[0].warnings = [
+      '\u0130 AGENT DOES NOT ADVERTISE ANY OF [sync_accounts, list_accounts]',
+    ];
+    const s = buildComplianceSummary(result, { sdkVersion: '6.9.0', adcpVersion: '3.0.6' });
+    assert.deepEqual(
+      s.skip_causes?.map(cause => cause.cause),
+      ['missing_tool: sync_accounts', 'missing_tool: list_accounts']
+    );
+  });
+
   test('detailed skip reasons normalize to canonical actionability (controller_seeding_failed)', () => {
     // The runner writes detailed RunnerDetailedSkipReason values directly
     // to step.skip_reason. The aggregator must map them through

--- a/test/lib/conformance-oracle.test.js
+++ b/test/lib/conformance-oracle.test.js
@@ -96,6 +96,47 @@ describe('conformance: oracle', () => {
     assert.ok(out.invariantFailures.some(f => f.includes('stack trace leak')));
   });
 
+  test('unindented JVM frame after an escaped newline → invariant failure', () => {
+    const out = accepted('get_signals', {
+      signals: [],
+      errors: [{ code: 'INTERNAL', message: 'failure\nat com.example.Handler.process(Handler.java:42)' }],
+    });
+    assert.equal(out.verdict, 'invalid');
+    assert.ok(out.invariantFailures.some(failure => failure.includes('stack trace leak')));
+  });
+
+  test('long indented non-frame lines do not trigger the JVM detector', () => {
+    const out = accepted('get_signals', {
+      signals: [],
+      errors: [{ code: 'NOTE', message: `documentation\n${' '.repeat(100_000)}not a stack frame` }],
+    });
+    assert.equal(out.verdict, 'accepted');
+    assert.deepEqual(out.invariantFailures, []);
+  });
+
+  test('JVM-looking prose with trailing text is not treated as a stack frame', () => {
+    const out = accepted('get_signals', {
+      signals: [],
+      errors: [
+        {
+          code: 'NOTE',
+          message: 'documentation\nat com.example.Handler.process(Handler.java:42) is shown as an example',
+        },
+      ],
+    });
+    assert.equal(out.verdict, 'accepted');
+    assert.deepEqual(out.invariantFailures, []);
+  });
+
+  test('JVM-looking prose punctuation is not mistaken for JSON framing', () => {
+    const out = accepted('get_signals', {
+      signals: [],
+      errors: [{ code: 'NOTE', message: 'documentation\nat com.example.Handler.process(Handler.java:42)},' }],
+    });
+    assert.equal(out.verdict, 'accepted');
+    assert.deepEqual(out.invariantFailures, []);
+  });
+
   test('.NET stack trace in response body → invariant failure', () => {
     const out = accepted('get_signals', {
       signals: [],


### PR DESCRIPTION
## Summary
- harden CodeQL-identified regex, logging, credential redaction, cache-key, and Markdown escaping paths
- distinguish protocol integrity digests from password hashing with narrowly scoped audited suppressions
- include CodeQL suppression metadata in SARIF and exclude generated/local artifacts from source analysis

## Validation
- local CodeQL 2.26.4: 0 unsuppressed findings across 702 JS/TS files and 16 Actions files
- expert review: DX, protocol, and security approved; independent Codex protocol/code/security review converged clean
- `npm run typecheck`
- `npm run build`
- `npm run lint` (0 errors; existing warnings only)
- `npm run lint:workflows`
- `npm run check:package`
- focused logger, conformance-oracle, compliance-summary, and Markdown-summary tests (81 passing)

## Release
- patch changeset included

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/63810d6c-114d-41a2-863c-c844bd964f6e)
