### PR TITLE
test: batch local Node tests to bound VM memory

### DIFF
--- a/.changeset/wise-lemons-batch.md
+++ b/.changeset/wise-lemons-batch.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Run ordinary local Node test discovery in bounded fresh-process batches so test heap usage is reclaimed between batches while focused runs and CI shards retain their existing execution shape.

--- a/scripts/run-node-tests.mjs
+++ b/scripts/run-node-tests.mjs
@@ -7,6 +7,12 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+// Keep a local test-runner process well below the cumulative heap footprint of
+// the whole suite.  Each batch is a fresh Node process, so its heap is released
+// before the next batch starts.  This intentionally does not apply to CI
+// shards or focused-file runs, whose one-process behavior is useful and
+// established.
+export const LOCAL_TEST_BATCH_SIZE = 25;
 
 export const SLOW_NODE_TESTS = new Set([
   'test/canonical-creatives-a2a-e2e.test.js',
@@ -66,6 +72,10 @@ function parsePositiveInteger(value, label) {
   return parsed;
 }
 
+function isCiEnvironment(env) {
+  return env.CI !== undefined && !['', '0', 'false'].includes(String(env.CI).toLowerCase());
+}
+
 export function resolveTestConcurrency({
   cliValue,
   env = process.env,
@@ -79,8 +89,7 @@ export function resolveTestConcurrency({
 
   // Preserve CI's existing machine-derived behavior. Local runs are deliberately
   // conservative because many test files spawn their own tsc or CLI processes.
-  const isCi = env.CI !== undefined && !['', '0', 'false'].includes(String(env.CI).toLowerCase());
-  if (isCi) return undefined;
+  if (isCiEnvironment(env)) return undefined;
   if (group === 'slow') return 1;
   return Math.max(1, Math.min(2, parallelism));
 }
@@ -178,44 +187,136 @@ export function buildNodeTestArgs(options, env = process.env) {
     env,
     group: options.group,
   });
-  const args = [`--test-timeout=${timeoutMs}`, '--test-force-exit'];
-  if (concurrency !== undefined) args.push(`--test-concurrency=${concurrency}`);
-  if (options.shard !== undefined) args.push(`--test-shard=${options.shard}`);
-  args.push('--test', ...files);
+  const args = buildNodeTestArgsForFiles({ concurrency, files, shard: options.shard, timeoutMs });
 
   return { args, concurrency, files, timeoutMs };
 }
 
+export function buildNodeTestArgsForFiles({ concurrency, files, shard, timeoutMs }) {
+  const args = [`--test-timeout=${timeoutMs}`, '--test-force-exit'];
+  if (concurrency !== undefined) args.push(`--test-concurrency=${concurrency}`);
+  if (shard !== undefined) args.push(`--test-shard=${shard}`);
+  args.push('--test', ...files);
+
+  return args;
+}
+
+export function batchNodeTests(files, batchSize = LOCAL_TEST_BATCH_SIZE) {
+  const size = parsePositiveInteger(batchSize, 'batch size');
+  const batches = [];
+  for (let index = 0; index < files.length; index += size) {
+    batches.push(files.slice(index, index + size));
+  }
+  return batches;
+}
+
+export function shouldBatchNodeTests(options, env = process.env) {
+  return !isCiEnvironment(env) && options.shard === undefined && options.files.length === 0;
+}
+
+export function buildNodeTestPlan(options, env = process.env) {
+  const invocation = buildNodeTestArgs(options, env);
+  const batches = shouldBatchNodeTests(options, env)
+    ? batchNodeTests(invocation.files)
+    : [invocation.files];
+
+  return {
+    ...invocation,
+    batches,
+    batchArgs: batches.map(files => buildNodeTestArgsForFiles({
+      concurrency: invocation.concurrency,
+      files,
+      shard: options.shard,
+      timeoutMs: invocation.timeoutMs,
+    })),
+  };
+}
+
+// Run every planned batch even after a test failure, matching Node's normal
+// behavior of completing the requested files before returning a non-zero exit.
+// Exported separately so failure aggregation can be tested without subprocesses.
+export async function runBatches(batches, runBatch, { onFailure, shouldStop = () => false } = {}) {
+  let exitCode = 0;
+
+  for (let index = 0; index < batches.length && !shouldStop(); index += 1) {
+    try {
+      const batchExitCode = await runBatch(batches[index], index);
+      if (batchExitCode !== 0) {
+        if (exitCode === 0) exitCode = batchExitCode ?? 1;
+        onFailure?.(batchExitCode, index);
+      }
+    } catch (error) {
+      if (exitCode === 0) exitCode = 1;
+      onFailure?.(1, index, error);
+    }
+  }
+
+  return exitCode;
+}
+
+async function runNodeTestBatches(plan) {
+  let activeChild;
+  let interrupted;
+  const signalHandlers = new Map();
+
+  for (const signal of ['SIGINT', 'SIGTERM', 'SIGHUP']) {
+    const handler = () => {
+      interrupted = signal;
+      activeChild?.kill(signal);
+    };
+    signalHandlers.set(signal, handler);
+    process.on(signal, handler);
+  }
+
+  try {
+    const exitCode = await runBatches(plan.batchArgs, async args => {
+      const child = spawn(process.execPath, args, {
+        cwd: REPO_ROOT,
+        env: { ...process.env, NODE_ENV: 'test' },
+        stdio: 'inherit',
+      });
+      activeChild = child;
+
+      try {
+        return await new Promise((resolve, reject) => {
+          child.once('error', reject);
+          child.once('exit', (code, signal) => resolve(code ?? (signal ? 1 : 0)));
+        });
+      } finally {
+        if (activeChild === child) activeChild = undefined;
+      }
+    }, {
+      onFailure: (exitCode, index, error) => {
+        const details = error ? `: ${error.message}` : '';
+        console.error(`[node-tests] batch ${index + 1}/${plan.batchArgs.length} failed with exit ${exitCode}${details}`);
+      },
+      shouldStop: () => interrupted !== undefined,
+    });
+    return interrupted ? exitCode || 1 : exitCode;
+  } finally {
+    for (const [signal, handler] of signalHandlers) process.removeListener(signal, handler);
+  }
+}
+
 async function run() {
   const options = parseRunnerArgs(process.argv.slice(2));
-  const invocation = buildNodeTestArgs(options);
+  const plan = buildNodeTestPlan(options);
 
   if (options.list) {
-    process.stdout.write(`${invocation.files.join('\n')}\n`);
+    process.stdout.write(`${plan.files.join('\n')}\n`);
     return;
   }
 
-  const concurrencyLabel = invocation.concurrency ?? 'Node default (CI)';
+  const concurrencyLabel = plan.concurrency ?? 'Node default (CI)';
+  const batchingLabel = plan.batches.length > 1
+    ? `; ${plan.batches.length} local batches of up to ${LOCAL_TEST_BATCH_SIZE} files`
+    : '';
   console.log(
-    `[node-tests] ${invocation.files.length} files; group=${options.group}; ` +
-      `concurrency=${concurrencyLabel}; timeout=${invocation.timeoutMs}ms`
+    `[node-tests] ${plan.files.length} files; group=${options.group}; ` +
+      `concurrency=${concurrencyLabel}; timeout=${plan.timeoutMs}ms${batchingLabel}`
   );
 
-  const child = spawn(process.execPath, invocation.args, {
-    cwd: REPO_ROOT,
-    env: { ...process.env, NODE_ENV: 'test' },
-    stdio: 'inherit',
-  });
-
-  for (const signal of ['SIGINT', 'SIGTERM', 'SIGHUP']) {
-    process.once(signal, () => child.kill(signal));
-  }
-
-  const exitCode = await new Promise((resolve, reject) => {
-    child.once('error', reject);
-    child.once('exit', (code, signal) => resolve(code ?? (signal ? 1 : 0)));
-  });
-  process.exitCode = exitCode;
+  process.exitCode = await runNodeTestBatches(plan);
 }
 
 const isMain = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);

--- a/scripts/run-node-tests.mjs
+++ b/scripts/run-node-tests.mjs
@@ -216,19 +216,19 @@ export function shouldBatchNodeTests(options, env = process.env) {
 
 export function buildNodeTestPlan(options, env = process.env) {
   const invocation = buildNodeTestArgs(options, env);
-  const batches = shouldBatchNodeTests(options, env)
-    ? batchNodeTests(invocation.files)
-    : [invocation.files];
+  const batches = shouldBatchNodeTests(options, env) ? batchNodeTests(invocation.files) : [invocation.files];
 
   return {
     ...invocation,
     batches,
-    batchArgs: batches.map(files => buildNodeTestArgsForFiles({
-      concurrency: invocation.concurrency,
-      files,
-      shard: options.shard,
-      timeoutMs: invocation.timeoutMs,
-    })),
+    batchArgs: batches.map(files =>
+      buildNodeTestArgsForFiles({
+        concurrency: invocation.concurrency,
+        files,
+        shard: options.shard,
+        timeoutMs: invocation.timeoutMs,
+      })
+    ),
   };
 }
 
@@ -265,33 +265,42 @@ async function runNodeTestBatches(plan) {
       activeChild?.kill(signal);
     };
     signalHandlers.set(signal, handler);
-    process.on(signal, handler);
+    // Keep the prior one-shot forwarding semantics: after forwarding an
+    // interrupt to the active child, a repeated same signal can use Node's
+    // normal termination behavior instead of being swallowed by the runner.
+    process.once(signal, handler);
   }
 
   try {
-    const exitCode = await runBatches(plan.batchArgs, async args => {
-      const child = spawn(process.execPath, args, {
-        cwd: REPO_ROOT,
-        env: { ...process.env, NODE_ENV: 'test' },
-        stdio: 'inherit',
-      });
-      activeChild = child;
-
-      try {
-        return await new Promise((resolve, reject) => {
-          child.once('error', reject);
-          child.once('exit', (code, signal) => resolve(code ?? (signal ? 1 : 0)));
+    const exitCode = await runBatches(
+      plan.batchArgs,
+      async args => {
+        const child = spawn(process.execPath, args, {
+          cwd: REPO_ROOT,
+          env: { ...process.env, NODE_ENV: 'test' },
+          stdio: 'inherit',
         });
-      } finally {
-        if (activeChild === child) activeChild = undefined;
-      }
-    }, {
-      onFailure: (exitCode, index, error) => {
-        const details = error ? `: ${error.message}` : '';
-        console.error(`[node-tests] batch ${index + 1}/${plan.batchArgs.length} failed with exit ${exitCode}${details}`);
+        activeChild = child;
+
+        try {
+          return await new Promise((resolve, reject) => {
+            child.once('error', reject);
+            child.once('exit', (code, signal) => resolve(code ?? (signal ? 1 : 0)));
+          });
+        } finally {
+          if (activeChild === child) activeChild = undefined;
+        }
       },
-      shouldStop: () => interrupted !== undefined,
-    });
+      {
+        onFailure: (exitCode, index, error) => {
+          const details = error ? `: ${error.message}` : '';
+          console.error(
+            `[node-tests] batch ${index + 1}/${plan.batchArgs.length} failed with exit ${exitCode}${details}`
+          );
+        },
+        shouldStop: () => interrupted !== undefined,
+      }
+    );
     return interrupted ? exitCode || 1 : exitCode;
   } finally {
     for (const [signal, handler] of signalHandlers) process.removeListener(signal, handler);
@@ -308,9 +317,8 @@ async function run() {
   }
 
   const concurrencyLabel = plan.concurrency ?? 'Node default (CI)';
-  const batchingLabel = plan.batches.length > 1
-    ? `; ${plan.batches.length} local batches of up to ${LOCAL_TEST_BATCH_SIZE} files`
-    : '';
+  const batchingLabel =
+    plan.batches.length > 1 ? `; ${plan.batches.length} local batches of up to ${LOCAL_TEST_BATCH_SIZE} files` : '';
   console.log(
     `[node-tests] ${plan.files.length} files; group=${options.group}; ` +
       `concurrency=${concurrencyLabel}; timeout=${plan.timeoutMs}ms${batchingLabel}`

--- a/test/run-node-tests-script.test.js
+++ b/test/run-node-tests-script.test.js
@@ -74,6 +74,93 @@ test('runner arguments support CI sharding and focused files', async () => {
   assert.equal(invocation.args.includes('--test-concurrency=1'), true);
 });
 
+test('local discovery runs are deterministically split into fresh Node-process batches', async () => {
+  const { LOCAL_TEST_BATCH_SIZE, batchNodeTests, buildNodeTestPlan, parseRunnerArgs } = await import(runnerUrl);
+  const files = Array.from({ length: LOCAL_TEST_BATCH_SIZE * 2 + 1 }, (_, index) => `test/example-${index}.test.js`);
+
+  assert.deepEqual(batchNodeTests(files), [
+    files.slice(0, LOCAL_TEST_BATCH_SIZE),
+    files.slice(LOCAL_TEST_BATCH_SIZE, LOCAL_TEST_BATCH_SIZE * 2),
+    files.slice(LOCAL_TEST_BATCH_SIZE * 2),
+  ]);
+  assert.throws(() => batchNodeTests(files, 0), /positive integer/);
+
+  const localPlan = buildNodeTestPlan(parseRunnerArgs(['--group', 'fast', '--concurrency', '3']), {});
+  assert.equal(localPlan.batches.length, Math.ceil(localPlan.files.length / LOCAL_TEST_BATCH_SIZE));
+  assert.deepEqual(localPlan.batches.flat(), localPlan.files);
+  assert.equal(
+    localPlan.batchArgs.every(args => args.includes('--test-concurrency=3')),
+    true
+  );
+  assert.equal(
+    localPlan.batchArgs.every(args => !args.some(arg => arg.startsWith('--test-shard='))),
+    true
+  );
+});
+
+test('focused files and shards remain one Node invocation', async () => {
+  const { buildNodeTestPlan, parseRunnerArgs } = await import(runnerUrl);
+
+  const focusedPlan = buildNodeTestPlan(parseRunnerArgs(['test/lib/pagination.test.js']), {});
+  assert.deepEqual(focusedPlan.batches, [['test/lib/pagination.test.js']]);
+
+  const localShardPlan = buildNodeTestPlan(parseRunnerArgs(['--group', 'fast', '--shard', '2/3']), {});
+  assert.equal(localShardPlan.batches.length, 1);
+  assert.equal(localShardPlan.batchArgs[0].includes('--test-shard=2/3'), true);
+
+  const ciPlan = buildNodeTestPlan(parseRunnerArgs(['--group', 'fast']), { CI: 'true' });
+  assert.equal(ciPlan.batches.length, 1);
+  assert.equal(
+    ciPlan.batchArgs[0].some(arg => arg.startsWith('--test-concurrency=')),
+    false
+  );
+});
+
+test('batch execution completes planned coverage and preserves the first failure status', async () => {
+  const { runBatches } = await import(runnerUrl);
+  const seen = [];
+  const failures = [];
+
+  const exitCode = await runBatches(
+    [['first'], ['second'], ['third']],
+    async (batch, index) => {
+      seen.push(batch[0]);
+      if (index === 1) return 7;
+      if (index === 2) throw new Error('spawn failed');
+      return 0;
+    },
+    {
+      onFailure: (code, index, error) => failures.push({ code, index, message: error?.message }),
+    }
+  );
+
+  assert.equal(exitCode, 7);
+  assert.deepEqual(seen, ['first', 'second', 'third']);
+  assert.deepEqual(failures, [
+    { code: 7, index: 1, message: undefined },
+    { code: 1, index: 2, message: 'spawn failed' },
+  ]);
+});
+
+test('batch execution stops before a new batch when interrupted', async () => {
+  const { runBatches } = await import(runnerUrl);
+  const seen = [];
+  let interrupted = false;
+
+  const exitCode = await runBatches(
+    [['first'], ['second']],
+    async batch => {
+      seen.push(batch[0]);
+      interrupted = true;
+      return 0;
+    },
+    { shouldStop: () => interrupted }
+  );
+
+  assert.equal(exitCode, 0);
+  assert.deepEqual(seen, ['first']);
+});
+
 test('focused slow tests retain the extended timeout', async () => {
   const { buildNodeTestArgs, parseRunnerArgs } = await import(runnerUrl);
   const options = parseRunnerArgs(['test/examples/hello-seller-adapter-guaranteed.test.js']);


### PR DESCRIPTION
## Summary

- run ordinary local Node test discovery in deterministic 25-file subprocess batches
- reclaim each batch heap before starting the next batch
- preserve CI shard, focused-file, concurrency, timeout, failure, and signal behavior
- add runner planning, batching, failure, shard, and interruption tests

## Validation

- `node --test test/run-node-tests-script.test.js` — 10 passed
- focused runner execution — passed
- `npm run typecheck` — passed
- `npm run build` — passed
- `npm run lint` — 0 errors (526 pre-existing warnings)
- 75-file / 567-test, three-batch benchmark — passed; peak RSS 1,668,972 KiB (~1.59 GiB), elapsed 1:53.75
- independent Sol/medium review — approved after a Terra/high follow-up fixed one-shot signal semantics

## Tradeoff

Local full-suite execution adds subprocess startup overhead in exchange for bounded heap. CI sharding and focused runs are unchanged.
