### PR TITLE
fix(compliance): accept extension controller scenarios

### DIFF
--- a/.changeset/silly-tigers-allow.md
+++ b/.changeset/silly-tigers-allow.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Accept unknown `comply_test_controller` `list_scenarios` response names during compliance validation.

--- a/src/lib/utils/response-schemas.ts
+++ b/src/lib/utils/response-schemas.ts
@@ -56,6 +56,14 @@ const GetProductsResponseStrictSchema = schemas.GetProductsResponseSchema.superR
   }
 });
 
+// The protocol deliberately leaves `list_scenarios.scenarios` open-ended:
+// sellers can advertise scenarios introduced after this SDK's generated schema
+// snapshot (or vendor extensions). Keep the generated union for every other
+// controller response arm, while widening only this discovery response.
+const ComplyTestControllerResponseSchema = schemas.ComplyTestControllerResponseSchema.or(
+  schemas.ListScenariosSuccessSchema.extend({ scenarios: z.array(z.string()) })
+);
+
 export const TOOL_RESPONSE_SCHEMAS: Partial<Record<string, z.ZodType>> = {
   // Product discovery & media buy
   list_products: schemas.ListProductsResponseSchema,
@@ -160,7 +168,7 @@ export const TOOL_RESPONSE_SCHEMAS: Partial<Record<string, z.ZodType>> = {
   sync_principal: schemas.SyncPrincipalResponseSchema,
 
   // Test controller
-  comply_test_controller: schemas.ComplyTestControllerResponseSchema,
+  comply_test_controller: ComplyTestControllerResponseSchema,
 
   // Property governance
   validate_property_delivery: schemas.ValidatePropertyDeliveryResponseSchema,

--- a/test/lib/deterministic-scenarios.test.js
+++ b/test/lib/deterministic-scenarios.test.js
@@ -267,6 +267,18 @@ describe('Response schema registration', () => {
       'comply_test_controller should have a registered response schema'
     );
   });
+
+  test('comply_test_controller accepts unknown list_scenarios values', () => {
+    const { validateResponseSchema } = require('../../dist/lib/testing/client.js');
+
+    const result = validateResponseSchema('comply_test_controller', {
+      status: 'completed',
+      success: true,
+      scenarios: ['vendor_future_scenario'],
+    });
+
+    assert.strictEqual(result.passed, true, result.details);
+  });
 });
 
 // ============================================================


### PR DESCRIPTION
## Summary

- Accept open-ended scenario names returned by comply_test_controller list_scenarios.
- Retain generated validation for every other controller response arm.
- Add regression coverage for a future vendor scenario name.

## Testing

- npm run build:lib
- node --test test/lib/deterministic-scenarios.test.js
- node --test test/lib/inline-enum-arrays.test.js
- npm run lint -- --quiet
- npm run typecheck

Fixes adcontextprotocol/adcp#7202

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/1694201b-aa5d-4d4b-afec-4bae45dc8172)
