### PR TITLE
feat(server): add persistent notification runtime

### DIFF
--- a/.changeset/steady-hooks-authorize.md
+++ b/.changeset/steady-hooks-authorize.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': minor
+---
+
+Add a durable persistent notification subscription runtime with caller/account isolation, generation-fenced declarative replacement, exact-tuple activation proof, write-only credential bindings, PostgreSQL storage and migrations, anchor-safe fanout, and live authorization on every webhook attempt and recovered retry.

--- a/.changeset/steady-hooks-authorize.md
+++ b/.changeset/steady-hooks-authorize.md
@@ -2,4 +2,4 @@
 '@adcp/sdk': minor
 ---
 
-Add a durable persistent notification subscription runtime with caller/account isolation, generation-fenced declarative replacement, exact-tuple activation proof, write-only credential bindings, PostgreSQL storage and migrations, anchor-safe fanout, and live authorization on every webhook attempt and recovered retry.
+Add a durable persistent notification subscription runtime with caller/account isolation, generation-fenced declarative replacement, exact-tuple activation proof, staged immutable write-only credential bindings, PostgreSQL storage and migrations, bounded concurrent anchor-safe fanout, timed adopter callbacks, and live authorization on every webhook attempt and recovered retry.

--- a/docs/TYPE-SUMMARY.md
+++ b/docs/TYPE-SUMMARY.md
@@ -1,6 +1,6 @@
 # AdCP Type Summary
 
-> Generated at: 2026-09-05
+> Generated at: 2026-09-06
 > @adcp/sdk v14.0.0-rc.32
 
 Curated reference of the types that matter for using the AdCP client. For full generated types see `src/lib/types/tools.generated.ts` and `src/lib/types/core.generated.ts`.
@@ -292,6 +292,29 @@ await webhooks.recoverOnce({ ownerToken: instanceId });
 ```
 
 `createPostgresWebhookRuntime()` assembles the durable delivery store, encrypted recovery outbox, emitter, ready-to-pass server configuration, probes, migrations, fenced poller, and `WebhookEmitResult`-to-disposition mapping. Pass `webhooks.serverConfig` as the framework's `webhooks` option and schedule bounded `recoverOnce()` calls. Direct multi-tenant sends bind with `webhooks.emitter.forTenantScope(trustedTenant)`.
+
+## Persistent Notification Subscription Runtime
+
+```typescript
+const notifications = createPostgresPersistentNotificationRuntime({
+  db: pool, publisherScope: 'seller-production',
+  subscriptions: { tableName: 'seller_notification_subscriptions' },
+  webhooks: {
+    deliveries: { tableName: 'seller_webhook_deliveries' },
+    outbox: { tableName: 'seller_webhook_outbox' },
+    signerProvider,
+  },
+  proofAdapter, credentialAdapter,
+  authorizeDelivery: liveApplicationAuthorization,
+  // Optional allowlist for invalidation-only later-version caller events:
+  futureCallerInvalidationEventTypes: ['catalog.invalidated'],
+});
+for (const sql of notifications.migrations.all) await pool.query(sql);
+await notifications.probe();
+await notifications.recoverOnce({ ownerToken: stableWorkerId });
+```
+
+The runtime keeps caller and caller+account anchors separate, applies full-set replacement with generation CAS, proves the exact normalized destination tuple before activation, and keeps legacy credentials behind an opaque application binding. Its non-secret subscription generation is stored in the webhook outbox; every live and recovered attempt re-reads subscription state and calls the required application authorization callback before network access. Pause, removal, authorization loss, or destination replacement terminally suppresses unclaimed old-generation work. `include_future_event_types` remains fail closed unless the server explicitly classifies invalidation-only later-version caller events with `futureCallerInvalidationEventTypes`. See `docs/guides/PERSISTENT-NOTIFICATION-RUNTIME.md`.
 
 ## Production Webhook Tenant Binding
 

--- a/docs/guides/BUILD-AN-AGENT.md
+++ b/docs/guides/BUILD-AN-AGENT.md
@@ -29,6 +29,13 @@ before runtime. The `definePlatform` / `defineSalesCorePlatform` /
 sibling helpers let you write inline platform literals without
 `req: unknown` casts.
 
+Standing caller- and account-level notification subscribers need durable
+control-plane state in addition to the webhook delivery outbox. Use
+`createPostgresPersistentNotificationRuntime()`; it owns declarative
+replacement, proof generations, and per-attempt authorization while composing
+with the existing delivery kernel. See
+[Persistent notification subscriptions](./PERSISTENT-NOTIFICATION-RUNTIME.md).
+
 For multi-specialism production agents (sales + creative + governance +
 brand-rights), the `examples/hello_*` family is the copy-paste
 starting point for each specialism.

--- a/docs/guides/PERSISTENT-NOTIFICATION-RUNTIME.md
+++ b/docs/guides/PERSISTENT-NOTIFICATION-RUNTIME.md
@@ -44,16 +44,22 @@ const notifications = createPostgresPersistentNotificationRuntime({
     },
   },
   credentialAdapter: {
-    async preview({ credential, ...context }) {
-      // Return the same stable handle as bind(), without writing or rotating
-      // anything. This keeps dry-run would_change exact and side-effect free.
-      return vault.previewBinding(credential, context);
+    async preview({ credential, previousBindingId, signal, ...context }) {
+      // Compare inside the secret manager. Do not hash or persist the secret.
+      return (await vault.matches(previousBindingId, credential, { ...context, signal }))
+        ? { outcome: 'unchanged' }
+        : { outcome: 'changed' };
     },
-    async bind({ credential, ...context }) {
-      // Store through KMS/secret manager. Return a stable opaque handle, not
-      // the credential and not a diagnostic string containing it. For the
-      // same tuple, this must equal previewBinding()'s handle.
-      return vault.bind(credential, context);
+    async stage({ credential, previousBindingId, signal, ...context }) {
+      // Never rotate previousBindingId in place. Stage changed material under
+      // a fresh random opaque binding and return an idempotent stage token.
+      return vault.stageVersion(credential, { ...context, previousBindingId, signal });
+    },
+    async commit(stage) {
+      await vault.commitStage(stage);
+    },
+    async discard(stage) {
+      await vault.discardStage(stage);
     },
     async resolve(binding) {
       return vault.resolveForWebhookAttempt(binding);
@@ -66,6 +72,9 @@ const notifications = createPostgresPersistentNotificationRuntime({
   // Optional. Only list later-version caller events whose payload is
   // invalidation-only; this is the allowlist behind include_future_event_types.
   futureCallerInvalidationEventTypes: ['catalog.invalidated'],
+  adopterCallbackTimeoutMs: 30_000,
+  fanoutConcurrency: 8,
+  onCredentialStageError: event => monitorCredentialVault(event),
 });
 
 for (const sql of notifications.migrations.all) await pool.query(sql);
@@ -76,14 +85,42 @@ The default registration validator resolves DNS and applies the strict webhook
 SSRF policy even for inactive entries. Delivery independently re-resolves and
 pins the connection on every attempt.
 
+Legacy binding IDs are random opaque credential-version handles, never secret
+hashes. `stage()` must keep a new version durable and resolvable for endpoint
+proof and delivery without changing the old binding. The runtime calls
+`commit()` only after subscription CAS succeeds and calls `discard()` after
+validation, proof, or CAS failure. All three operations must be idempotent.
+`commit()` is bookkeeping: the successful CAS makes the staged binding live,
+so a commit timeout or failure cannot roll back the replacement. Reapers for
+stages abandoned by a process crash must check the durable subscription store
+before deleting them. Retire a superseded binding only after no generation
+references it and after a bounded grace period for already-authorized in-flight
+deliveries. Never share one staged binding between concurrent staging
+operations, even if they happen to carry the same credential; a losing CAS may
+discard only its own stage. Use `onCredentialStageError` for non-blocking
+visibility into failed commit/discard bookkeeping; the observer cannot change
+the replacement result.
+
+Every adopter callback receives an `AbortSignal` and is bounded by
+`adopterCallbackTimeoutMs`. Honor the signal so a timed-out staging operation
+cannot complete late. Configure the subscription store's database/query
+deadline transactionally; the runtime deliberately does not race a mutating
+CAS against a timer because that could commit after its credential stage was
+discarded. Fanout runs at most `fanoutConcurrency` independent
+subscriber retry cycles simultaneously and preserves result ordering. An
+exception in one subscriber's delivery kernel is isolated as
+`failure.reason === 'delivery_runtime_error'`; it does not detach or hide the
+other subscribers' results.
+
 `include_future_event_types` is fail closed. It has no effect unless the server
 classifies a later-version caller event in
 `futureCallerInvalidationEventTypes`; account-anchored or payload-bearing event
 types must never be placed in that allowlist.
 
-## Specialized caller-level task
+## Specialized caller-level compatibility task
 
-Wire `sync_agent_notification_configs` with one handler owner:
+The supplied protocol handler is a compatibility-only owner for
+`sync_agent_notification_configs`:
 
 ```ts
 const protocol = createPersistentNotificationProtocolHandlers(
@@ -111,9 +148,13 @@ ordinary task callbacks do not carry subscription authorization context. If
 the server also emits task or media-buy callbacks, configure their webhook
 runtime separately, with a distinct outbox namespace or table set.
 
-`sync_principal` can atomically replace other principal sections too. Its
-application transaction should call `notifications.replace()` for the caller
-scope and use the returned generation as the notification-section version.
+This helper cannot atomically update the broader `sync_principal` document or
+advance its shared `configuration_version`. When both surfaces coexist, AdCP
+requires the application-owned `sync_principal` transaction to update all
+principal sections and the shared version together. That transaction should
+call `notifications.replace()` for the caller scope and use the returned
+generation as the notification-section version; do not compose the
+compatibility handler into that transaction.
 Likewise, an account `sync_accounts` handler calls `replace()` with:
 
 ```ts

--- a/docs/guides/PERSISTENT-NOTIFICATION-RUNTIME.md
+++ b/docs/guides/PERSISTENT-NOTIFICATION-RUNTIME.md
@@ -44,9 +44,15 @@ const notifications = createPostgresPersistentNotificationRuntime({
     },
   },
   credentialAdapter: {
+    async preview({ credential, ...context }) {
+      // Return the same stable handle as bind(), without writing or rotating
+      // anything. This keeps dry-run would_change exact and side-effect free.
+      return vault.previewBinding(credential, context);
+    },
     async bind({ credential, ...context }) {
       // Store through KMS/secret manager. Return a stable opaque handle, not
-      // the credential and not a diagnostic string containing it.
+      // the credential and not a diagnostic string containing it. For the
+      // same tuple, this must equal previewBinding()'s handle.
       return vault.bind(credential, context);
     },
     async resolve(binding) {

--- a/docs/guides/PERSISTENT-NOTIFICATION-RUNTIME.md
+++ b/docs/guides/PERSISTENT-NOTIFICATION-RUNTIME.md
@@ -1,0 +1,167 @@
+# Persistent notification subscriptions
+
+Use the persistent notification runtime for standing caller- or account-level
+subscriptions. It composes subscription state with the SDK webhook delivery
+kernel; it does not replace task `push_notification_config` registration.
+
+The runtime owns:
+
+- caller and caller+account isolation;
+- atomic full-set replacement with generation CAS;
+- exact destination-tuple proof state;
+- write-only legacy credential bindings;
+- anchor-safe event matching and fanout; and
+- live authorization before every external attempt and retry.
+
+Your application still decides when a domain event exists and whether the
+subscriber remains authorized for its account at delivery time.
+
+## PostgreSQL setup
+
+Use one pool for subscription state, delivery identity, and the recovery
+outbox:
+
+```ts
+import {
+  createPersistentNotificationProtocolHandlers,
+  createPostgresPersistentNotificationRuntime,
+} from '@adcp/sdk/server';
+
+const notifications = createPostgresPersistentNotificationRuntime({
+  db: pool,
+  publisherScope: 'seller-production',
+  subscriptions: { tableName: 'seller_notification_subscriptions' },
+  webhooks: {
+    deliveries: { tableName: 'seller_webhook_deliveries' },
+    outbox: { tableName: 'seller_webhook_outbox' },
+    signerProvider,
+  },
+  proofAdapter: {
+    async prove(candidate) {
+      // POST the AdCP proof challenge using a pin-and-bind client. Bind the
+      // proof to candidate.destinationGeneration and return no credentials.
+      return endpointProof(candidate);
+    },
+  },
+  credentialAdapter: {
+    async bind({ credential, ...context }) {
+      // Store through KMS/secret manager. Return a stable opaque handle, not
+      // the credential and not a diagnostic string containing it.
+      return vault.bind(credential, context);
+    },
+    async resolve(binding) {
+      return vault.resolveForWebhookAttempt(binding);
+    },
+  },
+  async authorizeDelivery({ scope, eventAnchor, accountId, subscriberId }) {
+    // This runs immediately before every POST, including recovered retries.
+    return grants.mayReceive({ scope, eventAnchor, accountId, subscriberId });
+  },
+  // Optional. Only list later-version caller events whose payload is
+  // invalidation-only; this is the allowlist behind include_future_event_types.
+  futureCallerInvalidationEventTypes: ['catalog.invalidated'],
+});
+
+for (const sql of notifications.migrations.all) await pool.query(sql);
+await notifications.probe();
+```
+
+The default registration validator resolves DNS and applies the strict webhook
+SSRF policy even for inactive entries. Delivery independently re-resolves and
+pins the connection on every attempt.
+
+`include_future_event_types` is fail closed. It has no effect unless the server
+classifies a later-version caller event in
+`futureCallerInvalidationEventTypes`; account-anchored or payload-bearing event
+types must never be placed in that allowlist.
+
+## Specialized caller-level task
+
+Wire `sync_agent_notification_configs` with one handler owner:
+
+```ts
+const protocol = createPersistentNotificationProtocolHandlers(
+  notifications,
+  async ctx => ({
+    tenant_id: trustedTenantFrom(ctx),
+    principal_id: trustedPrincipalFrom(ctx),
+  }),
+);
+
+const server = createAdcpServerFromPlatform(platform, {
+  name: 'seller-production',
+  version: '1.0.0',
+  protocol,
+});
+```
+
+Do not also configure a separate `syncAgentNotificationConfigs` writer. The
+helper is the handler and applies declarative replacement only inside the
+authenticated caller scope.
+
+The notification runtime's webhook kernel is private to standing
+subscriptions. Do not reuse it as the server-wide `webhooks` configuration:
+ordinary task callbacks do not carry subscription authorization context. If
+the server also emits task or media-buy callbacks, configure their webhook
+runtime separately, with a distinct outbox namespace or table set.
+
+`sync_principal` can atomically replace other principal sections too. Its
+application transaction should call `notifications.replace()` for the caller
+scope and use the returned generation as the notification-section version.
+Likewise, an account `sync_accounts` handler calls `replace()` with:
+
+```ts
+const scope = {
+  kind: 'account' as const,
+  tenantId: trustedTenant,
+  principalId: authenticatedPrincipal,
+  accountId: resolvedSellerAccountId,
+};
+const applied = await notifications.replace(scope, request.notification_configs ?? []);
+```
+
+Project `notificationConfigs` into `get_principal` or `list_accounts` with
+`projectNotificationSubscriptionReadback()`. It removes the SDK-only
+`destination_generation` and `proof_generation` fields. Those fields remain
+available as safe operational readback for the owning application; legacy
+authentication credentials are never returned.
+
+## Fire an event
+
+```ts
+await notifications.emit({
+  emissionId: durableOutboxEvent.id,
+  notificationId: change.change_id,
+  notificationType: 'account.change_recorded',
+  anchor: 'account',
+  tenantId: trustedTenant,
+  accountId: change.account_id,
+  payload: {
+    change_id: change.change_id,
+    fired_at: new Date().toISOString(),
+    recorded_at: change.recorded_at,
+    resource: {
+      type: change.resource_type,
+      resource_id: change.resource_id,
+    },
+    action: change.action,
+    through_cursor: change.through_cursor,
+  },
+});
+```
+
+Persist `emissionId` with the domain event. Reuse it after an ambiguous crash;
+rotate it only when intentionally re-emitting the same logical
+`notificationId` as a new delivery event. Each matched subscriber receives an
+independent transport `idempotency_key` while the logical `notification_id`
+stays stable.
+
+Run bounded recovery passes from a scheduler:
+
+```ts
+await notifications.recoverOnce({ ownerToken: stableWorkerId });
+```
+
+Removal, pause, destination replacement, or authorization loss terminally
+suppresses unclaimed old work. A POST already authorized and in flight cannot
+be retracted; delivery remains at least once.

--- a/docs/guides/PRODUCTION-DURABILITY.md
+++ b/docs/guides/PRODUCTION-DURABILITY.md
@@ -15,6 +15,11 @@ Use this after the compact seller works locally.
   checkpoint only after it returns `settled`.
 - Protect webhook bearer/HMAC material through a
   `WebhookAuthenticationAdapter`. The SDK does not own KMS keys.
+- For standing caller/account notification subscribers, use
+  `createPostgresPersistentNotificationRuntime()` and run its subscription,
+  delivery, and outbox migrations from one PostgreSQL pool. The runtime
+  re-authorizes every retry; see
+  [persistent notification subscriptions](./PERSISTENT-NOTIFICATION-RUNTIME.md).
 - Re-derive credentials per request. Never put secrets in `ctx_metadata`; see
   [ctx_metadata safety](./CTX-METADATA-SAFETY.md).
 - Configure RFC 9421 signing and SSRF-safe webhook delivery using the

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,6 +1,6 @@
 # Ad Context Protocol (AdCP)
 
-> Generated at: 2026-09-05
+> Generated at: 2026-09-06
 > Library: @adcp/sdk v14.0.0-rc.32
 > AdCP major version: 3
 > Canonical URL: https://adcontextprotocol.github.io/adcp-client/llms.txt
@@ -58,6 +58,8 @@ serve(() => createAdcpServerFromPlatform(platform, {
 ```
 
 Compile-time enforcement: `RequiredPlatformsFor<S>` catches missing specialism methods. Capability projection auto-derives `get_adcp_capabilities` blocks (`audience_targeting`, `conversion_tracking`, `compliance_testing.scenarios`, etc.). Idempotency, RFC 9421 signing, async tasks, and status normalization are framework-owned. Under AdCP 3.2, synchronous terminal responses remain silent on the task-webhook channel; the deprecated `autoEmitCompletionWebhooks` option is ignored.
+
+Standing caller- and account-level notification subscribers require a durable control plane in addition to webhook delivery. Use `createPostgresPersistentNotificationRuntime()` for declarative replacement, exact-tuple proof generations, write-only credential bindings, anchor-safe fanout, and live authorization before every attempt/retry. See `docs/guides/PERSISTENT-NOTIFICATION-RUNTIME.md`; do not implement a second subscriber writer behind the raw `syncAgentNotificationConfigs` hook.
 
 Lower-level option: `createAdcpServer({ signals: { getSignals: ... } })` from `@adcp/sdk/server/legacy/v5` — handler-bag API. Still fully supported, the substrate the platform path calls into. Use when you need fine control over individual handlers, mid-migration from a v5 codebase, or custom-shaped tools the platform interface doesn't yet model. `wrapEnvelope(inner, { replayed, context, operationId })` from `@adcp/sdk/server` attaches protocol envelope fields with the per-error-code allowlist (IDEMPOTENCY_CONFLICT drops `replayed`).
 
@@ -2030,6 +2032,7 @@ These docs are available locally in the repo and hosted at https://adcontextprot
 | Buyer quick start (AdCP 3.2) | docs/guides/BUYER-QUICKSTART-3.2.md | [link](https://adcontextprotocol.github.io/adcp-client/guides/BUYER-QUICKSTART-3.2.md) |
 | Seller quick start (AdCP 3.2) | docs/guides/SELLER-QUICKSTART-3.2.md | [link](https://adcontextprotocol.github.io/adcp-client/guides/SELLER-QUICKSTART-3.2.md) |
 | Production durability checklist | docs/guides/PRODUCTION-DURABILITY.md | [link](https://adcontextprotocol.github.io/adcp-client/guides/PRODUCTION-DURABILITY.md) |
+| Persistent notification subscriptions | docs/guides/PERSISTENT-NOTIFICATION-RUNTIME.md | [link](https://adcontextprotocol.github.io/adcp-client/guides/PERSISTENT-NOTIFICATION-RUNTIME.md) |
 | Migrating SDK 13 → 14 | docs/migration-13-to-14.md | [link](https://adcontextprotocol.github.io/adcp-client/migration-13-to-14.md) |
 | Getting started / install | docs/getting-started.md | [link](https://adcontextprotocol.github.io/adcp-client/getting-started.md) |
 | Build a server-side agent | docs/guides/BUILD-AN-AGENT.md | [link](https://adcontextprotocol.github.io/adcp-client/guides/BUILD-AN-AGENT.md) |

--- a/scripts/generate-agent-docs.ts
+++ b/scripts/generate-agent-docs.ts
@@ -655,6 +655,10 @@ function generateLlmsTxt(
   );
   ln();
   ln(
+    `Standing caller- and account-level notification subscribers require a durable control plane in addition to webhook delivery. Use \`createPostgresPersistentNotificationRuntime()\` for declarative replacement, exact-tuple proof generations, write-only credential bindings, anchor-safe fanout, and live authorization before every attempt/retry. See \`docs/guides/PERSISTENT-NOTIFICATION-RUNTIME.md\`; do not implement a second subscriber writer behind the raw \`syncAgentNotificationConfigs\` hook.`
+  );
+  ln();
+  ln(
     `Lower-level option: \`createAdcpServer({ signals: { getSignals: ... } })\` from \`@adcp/sdk/server/legacy/v5\` — handler-bag API. Still fully supported, the substrate the platform path calls into. Use when you need fine control over individual handlers, mid-migration from a v5 codebase, or custom-shaped tools the platform interface doesn't yet model. \`wrapEnvelope(inner, { replayed, context, operationId })\` from \`@adcp/sdk/server\` attaches protocol envelope fields with the per-error-code allowlist (IDEMPOTENCY_CONFLICT drops \`replayed\`).`
   );
   ln();
@@ -1270,6 +1274,7 @@ function generateLlmsTxt(
     ['Buyer quick start (AdCP 3.2)', 'guides/BUYER-QUICKSTART-3.2.md'],
     ['Seller quick start (AdCP 3.2)', 'guides/SELLER-QUICKSTART-3.2.md'],
     ['Production durability checklist', 'guides/PRODUCTION-DURABILITY.md'],
+    ['Persistent notification subscriptions', 'guides/PERSISTENT-NOTIFICATION-RUNTIME.md'],
     ['Migrating SDK 13 → 14', 'migration-13-to-14.md'],
     ['Getting started / install', 'getting-started.md'],
     ['Build a server-side agent', 'guides/BUILD-AN-AGENT.md'],
@@ -1689,6 +1694,32 @@ function generateTypeSummary(index: SchemaIndex, tools: ToolInfo[]): string {
   ln();
   ln(
     `\`createPostgresWebhookRuntime()\` assembles the durable delivery store, encrypted recovery outbox, emitter, ready-to-pass server configuration, probes, migrations, fenced poller, and \`WebhookEmitResult\`-to-disposition mapping. Pass \`webhooks.serverConfig\` as the framework's \`webhooks\` option and schedule bounded \`recoverOnce()\` calls. Direct multi-tenant sends bind with \`webhooks.emitter.forTenantScope(trustedTenant)\`.`
+  );
+  ln();
+
+  ln(`## Persistent Notification Subscription Runtime`);
+  ln();
+  ln('```typescript');
+  ln(`const notifications = createPostgresPersistentNotificationRuntime({`);
+  ln(`  db: pool, publisherScope: 'seller-production',`);
+  ln(`  subscriptions: { tableName: 'seller_notification_subscriptions' },`);
+  ln(`  webhooks: {`);
+  ln(`    deliveries: { tableName: 'seller_webhook_deliveries' },`);
+  ln(`    outbox: { tableName: 'seller_webhook_outbox' },`);
+  ln(`    signerProvider,`);
+  ln(`  },`);
+  ln(`  proofAdapter, credentialAdapter,`);
+  ln(`  authorizeDelivery: liveApplicationAuthorization,`);
+  ln(`  // Optional allowlist for invalidation-only later-version caller events:`);
+  ln(`  futureCallerInvalidationEventTypes: ['catalog.invalidated'],`);
+  ln(`});`);
+  ln(`for (const sql of notifications.migrations.all) await pool.query(sql);`);
+  ln(`await notifications.probe();`);
+  ln(`await notifications.recoverOnce({ ownerToken: stableWorkerId });`);
+  ln('```');
+  ln();
+  ln(
+    `The runtime keeps caller and caller+account anchors separate, applies full-set replacement with generation CAS, proves the exact normalized destination tuple before activation, and keeps legacy credentials behind an opaque application binding. Its non-secret subscription generation is stored in the webhook outbox; every live and recovered attempt re-reads subscription state and calls the required application authorization callback before network access. Pause, removal, authorization loss, or destination replacement terminally suppresses unclaimed old-generation work. \`include_future_event_types\` remains fail closed unless the server explicitly classifies invalidation-only later-version caller events with \`futureCallerInvalidationEventTypes\`. See \`docs/guides/PERSISTENT-NOTIFICATION-RUNTIME.md\`.`
   );
   ln();
 

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -1642,8 +1642,8 @@ export interface AdcpCustomToolConfig<
  *
  * Subset of {@link WebhookEmitterOptions} the framework lifts to the
  * server config: signing key/provider, retry policy, immutable delivery
- * store, fetch override, user-agent + tag, and the per-emit observability
- * hooks. Other emitter-internal knobs (rate limits, transport pool
+ * store, fetch override, user-agent + tag, per-attempt authorization, and
+ * the per-emit observability hooks. Other emitter-internal knobs (rate limits, transport pool
  * sizing) stay on `WebhookEmitterOptions` for direct emitter callers.
  *
  * @public
@@ -1658,6 +1658,7 @@ export type WebhooksConfig = Pick<
   | 'deliveryRetryHorizonSeconds'
   | 'deliveryRecovery'
   | 'generateIdempotencyKey'
+  | 'authorizeAttempt'
   | 'fetch'
   | 'userAgent'
   | 'tag'

--- a/src/lib/server/index.ts
+++ b/src/lib/server/index.ts
@@ -531,8 +531,53 @@ export type {
   WebhookIdempotencyKeyStore,
   WebhookRetryOptions,
   WebhookAuthentication,
+  WebhookAttemptAuthorizer,
+  WebhookAttemptAuthorizationDecision,
+  WebhookAttemptSuppressionReason,
 } from './webhook-emitter';
 export type { SigningProvider } from '../signing/provider';
+
+export {
+  ACCOUNT_NOTIFICATION_TYPES,
+  CALLER_NOTIFICATION_TYPES,
+  NOTIFICATION_SUBSCRIPTION_MIGRATION,
+  NotificationSubscriptionValidationError,
+  createPersistentNotificationRuntime,
+  createPersistentNotificationProtocolHandlers,
+  createPostgresPersistentNotificationRuntime,
+  getNotificationSubscriptionMigration,
+  memoryNotificationSubscriptionStore,
+  pgNotificationSubscriptionStore,
+  projectNotificationSubscriptionReadback,
+  validatePersistentNotificationDestination,
+} from './notification-subscriptions';
+export type {
+  CreatePostgresPersistentNotificationRuntimeOptions,
+  NotificationAuthenticationMode,
+  NotificationCredentialBindingAdapter,
+  NotificationDeliveryAuthorizationInput,
+  NotificationDeliveryAuthorizer,
+  NotificationDestinationValidator,
+  NotificationEvent,
+  NotificationEventAnchor,
+  NotificationFanoutDelivery,
+  NotificationFanoutResult,
+  NotificationProofAdapter,
+  NotificationReplacementResult,
+  NotificationSubscriptionConfigInput,
+  NotificationSubscriptionMatch,
+  NotificationSubscriptionScope,
+  NotificationSubscriptionSet,
+  NotificationSubscriptionStore,
+  NotificationSubscriptionStoreReplaceResult,
+  NotificationSubscriptionView,
+  PersistentNotificationRuntime,
+  PersistentNotificationRuntimeOptions,
+  PostgresNotificationSubscriptionStoreOptions,
+  PostgresPersistentNotificationRuntime,
+  StoredNotificationAuthentication,
+  StoredNotificationSubscription,
+} from './notification-subscriptions';
 
 export { createPinAndBindFetch, WEBHOOK_SSRF_POLICY, LOOPBACK_OK_WEBHOOK_SSRF_POLICY } from './pin-and-bind-fetch';
 export type { PinAndBindFetchOptions, DnsLookupAll } from './pin-and-bind-fetch';

--- a/src/lib/server/notification-subscriptions/index.ts
+++ b/src/lib/server/notification-subscriptions/index.ts
@@ -1,0 +1,45 @@
+export {
+  ACCOUNT_NOTIFICATION_TYPES,
+  CALLER_NOTIFICATION_TYPES,
+  createPersistentNotificationRuntime,
+  projectNotificationSubscriptionReadback,
+  validatePersistentNotificationDestination,
+} from './runtime';
+export { memoryNotificationSubscriptionStore } from './memory-store';
+export {
+  NOTIFICATION_SUBSCRIPTION_MIGRATION,
+  getNotificationSubscriptionMigration,
+  pgNotificationSubscriptionStore,
+} from './postgres-store';
+export type { PostgresNotificationSubscriptionStoreOptions } from './postgres-store';
+export { createPostgresPersistentNotificationRuntime } from './postgres-runtime';
+export { createPersistentNotificationProtocolHandlers } from './protocol-handlers';
+export type {
+  CreatePostgresPersistentNotificationRuntimeOptions,
+  PostgresPersistentNotificationRuntime,
+} from './postgres-runtime';
+export { NotificationSubscriptionValidationError } from './types';
+export type {
+  NotificationAuthenticationMode,
+  NotificationCredentialBindingAdapter,
+  NotificationDeliveryAuthorizationInput,
+  NotificationDeliveryAuthorizer,
+  NotificationDestinationValidator,
+  NotificationEvent,
+  NotificationEventAnchor,
+  NotificationFanoutDelivery,
+  NotificationFanoutResult,
+  NotificationProofAdapter,
+  NotificationReplacementResult,
+  NotificationSubscriptionConfigInput,
+  NotificationSubscriptionMatch,
+  NotificationSubscriptionScope,
+  NotificationSubscriptionSet,
+  NotificationSubscriptionStore,
+  NotificationSubscriptionStoreReplaceResult,
+  NotificationSubscriptionView,
+  PersistentNotificationRuntime,
+  PersistentNotificationRuntimeOptions,
+  StoredNotificationAuthentication,
+  StoredNotificationSubscription,
+} from './types';

--- a/src/lib/server/notification-subscriptions/memory-store.ts
+++ b/src/lib/server/notification-subscriptions/memory-store.ts
@@ -1,0 +1,90 @@
+import { canonicalJsonSha256 } from '../../utils/jcs';
+import type {
+  NotificationSubscriptionMatch,
+  NotificationSubscriptionScope,
+  NotificationSubscriptionSet,
+  NotificationSubscriptionStore,
+  NotificationSubscriptionStoreReplaceResult,
+  StoredNotificationSubscription,
+} from './types';
+
+function scopeKey(scope: Readonly<NotificationSubscriptionScope>): string {
+  return JSON.stringify([
+    scope.kind,
+    scope.tenantId,
+    scope.principalId,
+    scope.kind === 'account' ? scope.accountId : '',
+  ]);
+}
+
+function cloneSet(set: Readonly<NotificationSubscriptionSet>): NotificationSubscriptionSet {
+  return structuredClone(set);
+}
+
+function subscriptionsFingerprint(subscriptions: readonly StoredNotificationSubscription[]): string {
+  return canonicalJsonSha256(subscriptions);
+}
+
+/** Process-local reference store for tests and single-process development. */
+export function memoryNotificationSubscriptionStore(): NotificationSubscriptionStore {
+  const rows = new Map<string, { set: NotificationSubscriptionSet; fingerprint: string }>();
+  return {
+    durability: 'process-local',
+    async probe() {},
+    get(scope) {
+      const row = rows.get(scopeKey(scope));
+      return row ? cloneSet(row.set) : null;
+    },
+    replace(args): NotificationSubscriptionStoreReplaceResult {
+      const key = scopeKey(args.scope);
+      const current = rows.get(key);
+      if ((current?.set.generation ?? null) !== args.expectedGeneration) {
+        return {
+          outcome: 'conflict',
+          ...(current && { currentGeneration: current.set.generation }),
+        };
+      }
+      const fingerprint = subscriptionsFingerprint(args.subscriptions);
+      if (current?.fingerprint === fingerprint) {
+        return { outcome: 'unchanged', set: cloneSet(current.set) };
+      }
+      const set: NotificationSubscriptionSet = {
+        scope: structuredClone(args.scope),
+        generation: args.nextGeneration,
+        subscriptions: args.subscriptions.map(subscription => structuredClone(subscription)),
+      };
+      rows.set(key, { set, fingerprint });
+      return { outcome: 'applied', set: cloneSet(set) };
+    },
+    findCandidates(match, limit) {
+      const matches: NotificationSubscriptionSet[] = [];
+      for (const { set } of rows.values()) {
+        if (!scopeMatches(set.scope, match)) continue;
+        if (
+          !set.subscriptions.some(
+            subscription =>
+              subscription.active &&
+              subscription.proofGeneration === subscription.destinationGeneration &&
+              (subscription.eventTypes.includes(match.eventType) ||
+                (match.futureCallerInvalidation === true && subscription.includeFutureEventTypes))
+          )
+        )
+          continue;
+        matches.push(cloneSet(set));
+        if (matches.length > limit) break;
+      }
+      return matches;
+    },
+  };
+}
+
+function scopeMatches(
+  scope: Readonly<NotificationSubscriptionScope>,
+  match: Readonly<NotificationSubscriptionMatch>
+): boolean {
+  if (scope.tenantId !== match.tenantId) return false;
+  if (match.principalId !== undefined && scope.principalId !== match.principalId) return false;
+  if (match.anchor === 'caller') return scope.kind === 'caller';
+  if (match.accountId === undefined) return false;
+  return scope.kind === 'caller' || scope.accountId === match.accountId;
+}

--- a/src/lib/server/notification-subscriptions/postgres-runtime.ts
+++ b/src/lib/server/notification-subscriptions/postgres-runtime.ts
@@ -1,0 +1,116 @@
+import type { PgQueryable } from '../postgres-task-store';
+import {
+  createPostgresWebhookRuntime,
+  type CreatePostgresWebhookRuntimeOptions,
+  type PostgresWebhookRecoveryPollOptions,
+  type PostgresWebhookRuntime,
+} from '../webhook-delivery/postgres-runtime';
+import { createPersistentNotificationRuntime } from './runtime';
+import {
+  getNotificationSubscriptionMigration,
+  pgNotificationSubscriptionStore,
+  type PostgresNotificationSubscriptionStoreOptions,
+} from './postgres-store';
+import type {
+  NotificationCredentialBindingAdapter,
+  NotificationDestinationValidator,
+  NotificationDeliveryAuthorizer,
+  NotificationProofAdapter,
+  PersistentNotificationRuntime,
+} from './types';
+
+export interface CreatePostgresPersistentNotificationRuntimeOptions {
+  db: PgQueryable;
+  publisherScope: string;
+  subscriptions?: PostgresNotificationSubscriptionStoreOptions;
+  webhooks: Omit<CreatePostgresWebhookRuntimeOptions, 'db' | 'publisherScope' | 'authorizeAttempt'>;
+  proofAdapter: NotificationProofAdapter;
+  credentialAdapter?: NotificationCredentialBindingAdapter;
+  authorizeDelivery: NotificationDeliveryAuthorizer;
+  validateDestination?: NotificationDestinationValidator;
+  supportedCallerEventTypes?: readonly string[];
+  supportedAccountEventTypes?: readonly string[];
+  futureCallerInvalidationEventTypes?: readonly string[];
+  maxFanoutCandidates?: number;
+}
+
+export interface PostgresPersistentNotificationRuntime extends PersistentNotificationRuntime {
+  /**
+   * Delivery/recovery kernel dedicated to standing subscriptions. It
+   * deliberately omits `serverConfig`: its mandatory subscription authorizer
+   * must never become the server-wide task-webhook authorizer.
+   */
+  webhooks: Omit<PostgresWebhookRuntime, 'serverConfig'>;
+  migrations: {
+    subscriptions: string;
+    webhookDeliveries: string;
+    webhookOutbox: string;
+    all: readonly string[];
+  };
+  probe(): Promise<void>;
+  recoverOnce(options?: PostgresWebhookRecoveryPollOptions): ReturnType<PostgresWebhookRuntime['recoverOnce']>;
+}
+
+/**
+ * Opinionated PostgreSQL assembly: durable subscription CAS state plus the
+ * existing durable webhook delivery/recovery kernel, sharing one pool.
+ */
+export function createPostgresPersistentNotificationRuntime(
+  options: CreatePostgresPersistentNotificationRuntimeOptions
+): PostgresPersistentNotificationRuntime {
+  if (!options?.db) throw new TypeError('createPostgresPersistentNotificationRuntime requires db');
+  const store = pgNotificationSubscriptionStore(options.db, options.subscriptions);
+  let webhooks: PostgresWebhookRuntime | undefined;
+  const runtime = createPersistentNotificationRuntime({
+    store,
+    proofAdapter: options.proofAdapter,
+    ...(options.credentialAdapter === undefined ? {} : { credentialAdapter: options.credentialAdapter }),
+    authorizeDelivery: options.authorizeDelivery,
+    ...(options.validateDestination === undefined ? {} : { validateDestination: options.validateDestination }),
+    ...(options.supportedCallerEventTypes === undefined
+      ? {}
+      : { supportedCallerEventTypes: options.supportedCallerEventTypes }),
+    ...(options.supportedAccountEventTypes === undefined
+      ? {}
+      : { supportedAccountEventTypes: options.supportedAccountEventTypes }),
+    ...(options.futureCallerInvalidationEventTypes === undefined
+      ? {}
+      : { futureCallerInvalidationEventTypes: options.futureCallerInvalidationEventTypes }),
+    ...(options.maxFanoutCandidates === undefined ? {} : { maxFanoutCandidates: options.maxFanoutCandidates }),
+    createEmitter(authorizeAttempt) {
+      webhooks = createPostgresWebhookRuntime({
+        ...options.webhooks,
+        db: options.db,
+        publisherScope: options.publisherScope,
+        authorizeAttempt,
+      });
+      return webhooks.emitter;
+    },
+  });
+  if (!webhooks) throw new Error('Persistent notification webhook runtime was not initialized');
+  const initializedWebhooks = webhooks as PostgresWebhookRuntime;
+  const notificationWebhooks: Omit<PostgresWebhookRuntime, 'serverConfig'> = {
+    emitter: initializedWebhooks.emitter,
+    migrations: initializedWebhooks.migrations,
+    probe: () => initializedWebhooks.probe(),
+    recoverOnce: recoverOptions => initializedWebhooks.recoverOnce(recoverOptions),
+  };
+  const subscriptionsMigration = getNotificationSubscriptionMigration(options.subscriptions);
+  return {
+    ...runtime,
+    webhooks: notificationWebhooks,
+    migrations: {
+      subscriptions: subscriptionsMigration,
+      webhookDeliveries: initializedWebhooks.migrations.deliveries,
+      webhookOutbox: initializedWebhooks.migrations.outbox,
+      all: [subscriptionsMigration, ...initializedWebhooks.migrations.all],
+    },
+    async probe() {
+      await store.probe?.();
+      await initializedWebhooks.probe();
+    },
+    recoverOnce(recoverOptions) {
+      return initializedWebhooks.recoverOnce(recoverOptions);
+    },
+  };
+}

--- a/src/lib/server/notification-subscriptions/postgres-runtime.ts
+++ b/src/lib/server/notification-subscriptions/postgres-runtime.ts
@@ -17,6 +17,7 @@ import type {
   NotificationDeliveryAuthorizer,
   NotificationProofAdapter,
   PersistentNotificationRuntime,
+  PersistentNotificationRuntimeOptions,
 } from './types';
 
 export interface CreatePostgresPersistentNotificationRuntimeOptions {
@@ -32,6 +33,9 @@ export interface CreatePostgresPersistentNotificationRuntimeOptions {
   supportedAccountEventTypes?: readonly string[];
   futureCallerInvalidationEventTypes?: readonly string[];
   maxFanoutCandidates?: number;
+  fanoutConcurrency?: number;
+  adopterCallbackTimeoutMs?: number;
+  onCredentialStageError?: PersistentNotificationRuntimeOptions['onCredentialStageError'];
 }
 
 export interface PostgresPersistentNotificationRuntime extends PersistentNotificationRuntime {
@@ -77,6 +81,11 @@ export function createPostgresPersistentNotificationRuntime(
       ? {}
       : { futureCallerInvalidationEventTypes: options.futureCallerInvalidationEventTypes }),
     ...(options.maxFanoutCandidates === undefined ? {} : { maxFanoutCandidates: options.maxFanoutCandidates }),
+    ...(options.fanoutConcurrency === undefined ? {} : { fanoutConcurrency: options.fanoutConcurrency }),
+    ...(options.adopterCallbackTimeoutMs === undefined
+      ? {}
+      : { adopterCallbackTimeoutMs: options.adopterCallbackTimeoutMs }),
+    ...(options.onCredentialStageError === undefined ? {} : { onCredentialStageError: options.onCredentialStageError }),
     createEmitter(authorizeAttempt) {
       webhooks = createPostgresWebhookRuntime({
         ...options.webhooks,

--- a/src/lib/server/notification-subscriptions/postgres-store.ts
+++ b/src/lib/server/notification-subscriptions/postgres-store.ts
@@ -1,0 +1,233 @@
+import { canonicalJsonSha256 } from '../../utils/jcs';
+import type { PgQueryable } from '../postgres-task-store';
+import type {
+  NotificationSubscriptionMatch,
+  NotificationSubscriptionScope,
+  NotificationSubscriptionSet,
+  NotificationSubscriptionStore,
+  NotificationSubscriptionStoreReplaceResult,
+  StoredNotificationSubscription,
+} from './types';
+
+const DEFAULT_TABLE = 'adcp_notification_subscriptions';
+const VALID_IDENTIFIER = /^[a-z_][a-z0-9_]*$/;
+
+export interface PostgresNotificationSubscriptionStoreOptions {
+  tableName?: string;
+  /** Assert that the database/schema is dedicated to this deployment. */
+  acknowledgeIsolatedDatabase?: boolean;
+}
+
+function quoteTable(raw: string): string {
+  if (!VALID_IDENTIFIER.test(raw) || Buffer.byteLength(raw, 'utf8') > 42) {
+    throw new Error(`Invalid notification subscription table name ${JSON.stringify(raw)}`);
+  }
+  return `"${raw}"`;
+}
+
+export function getNotificationSubscriptionMigration(
+  options: PostgresNotificationSubscriptionStoreOptions = {}
+): string {
+  const raw = options.tableName ?? DEFAULT_TABLE;
+  const table = quoteTable(raw);
+  return `
+CREATE TABLE IF NOT EXISTS ${table} (
+  tenant_scope        TEXT NOT NULL,
+  principal_id       TEXT NOT NULL,
+  anchor_kind        TEXT NOT NULL CHECK (anchor_kind IN ('caller','account')),
+  account_id         TEXT NOT NULL DEFAULT '',
+  generation         TEXT NOT NULL,
+  subscriptions      JSONB NOT NULL,
+  content_fingerprint TEXT NOT NULL,
+  created_at          TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp(),
+  updated_at          TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp(),
+  PRIMARY KEY (tenant_scope, principal_id, anchor_kind, account_id),
+  CONSTRAINT ${raw}_account_anchor CHECK (
+    (anchor_kind = 'caller' AND account_id = '') OR
+    (anchor_kind = 'account' AND account_id <> '')
+  ),
+  CONSTRAINT ${raw}_subscriptions_array CHECK (jsonb_typeof(subscriptions) = 'array')
+);
+
+CREATE INDEX IF NOT EXISTS idx_${raw}_account_fanout
+  ON ${table}(tenant_scope, account_id, principal_id) WHERE anchor_kind = 'account';
+CREATE INDEX IF NOT EXISTS idx_${raw}_caller_fanout
+  ON ${table}(tenant_scope, principal_id) WHERE anchor_kind = 'caller';
+`.trim();
+}
+
+export const NOTIFICATION_SUBSCRIPTION_MIGRATION = getNotificationSubscriptionMigration();
+
+export function pgNotificationSubscriptionStore(
+  db: PgQueryable,
+  options: PostgresNotificationSubscriptionStoreOptions = {}
+): NotificationSubscriptionStore {
+  const tableName = options.tableName ?? DEFAULT_TABLE;
+  const table = quoteTable(tableName);
+  const development = process.env.NODE_ENV === 'test' || process.env.NODE_ENV === 'development';
+  if (!development && tableName === DEFAULT_TABLE && !options.acknowledgeIsolatedDatabase) {
+    throw new Error(
+      'pgNotificationSubscriptionStore: production requires a deployment-unique tableName or acknowledgeIsolatedDatabase: true'
+    );
+  }
+
+  async function query(operation: string, text: string, values?: unknown[]) {
+    try {
+      return await db.query(text, values);
+    } catch (cause) {
+      throw new Error(`pgNotificationSubscriptionStore.${operation}: database operation failed`, { cause });
+    }
+  }
+
+  return {
+    durability: 'durable',
+    async probe() {
+      try {
+        await db.query(
+          `SELECT tenant_scope, principal_id, anchor_kind, account_id, generation,
+                  subscriptions, content_fingerprint FROM ${table} LIMIT 0`
+        );
+      } catch (cause) {
+        throw new Error(
+          `Notification subscription store probe failed: run getNotificationSubscriptionMigration() for "${tableName}" before serving`,
+          { cause }
+        );
+      }
+    },
+    async get(scope) {
+      const key = scopeValues(scope);
+      const result = await query(
+        'get',
+        `SELECT tenant_scope, principal_id, anchor_kind, account_id, generation,
+                subscriptions, content_fingerprint
+         FROM ${table}
+         WHERE tenant_scope=$1 AND principal_id=$2 AND anchor_kind=$3 AND account_id=$4`,
+        key
+      );
+      return result.rows[0] ? rowToSet(result.rows[0]) : null;
+    },
+    async replace(args): Promise<NotificationSubscriptionStoreReplaceResult> {
+      const key = scopeValues(args.scope);
+      const subscriptions = structuredClone(args.subscriptions);
+      const contentFingerprint = canonicalJsonSha256(subscriptions);
+      const result = await query(
+        'replace',
+        `INSERT INTO ${table} (
+           tenant_scope, principal_id, anchor_kind, account_id,
+           generation, subscriptions, content_fingerprint
+         )
+         SELECT $1, $2, $3, $4, $5, $6::jsonb, $7
+         WHERE $8::text IS NULL OR EXISTS (
+           SELECT 1 FROM ${table}
+           WHERE tenant_scope=$1 AND principal_id=$2 AND anchor_kind=$3 AND account_id=$4
+             AND generation=$8
+         )
+         ON CONFLICT (tenant_scope, principal_id, anchor_kind, account_id) DO UPDATE SET
+           generation = CASE
+             WHEN ${table}.content_fingerprint = EXCLUDED.content_fingerprint THEN ${table}.generation
+             ELSE EXCLUDED.generation
+           END,
+           subscriptions = CASE
+             WHEN ${table}.content_fingerprint = EXCLUDED.content_fingerprint THEN ${table}.subscriptions
+             ELSE EXCLUDED.subscriptions
+           END,
+           content_fingerprint = EXCLUDED.content_fingerprint,
+           updated_at = CASE
+             WHEN ${table}.content_fingerprint = EXCLUDED.content_fingerprint THEN ${table}.updated_at
+             ELSE clock_timestamp()
+           END
+         WHERE $8::text IS NOT NULL AND ${table}.generation=$8
+         RETURNING tenant_scope, principal_id, anchor_kind, account_id, generation,
+                   subscriptions, content_fingerprint`,
+        [...key, args.nextGeneration, JSON.stringify(subscriptions), contentFingerprint, args.expectedGeneration]
+      );
+      const row = result.rows[0];
+      if (!row) {
+        const current = await this.get(args.scope);
+        return {
+          outcome: 'conflict',
+          ...(current && { currentGeneration: current.generation }),
+        };
+      }
+      const set = rowToSet(row);
+      return {
+        outcome: set.generation === args.nextGeneration ? 'applied' : 'unchanged',
+        set,
+      };
+    },
+    async findCandidates(match, limit) {
+      if (!Number.isSafeInteger(limit) || limit < 1 || limit > 10_000) {
+        throw new TypeError('notification subscription candidate limit must be 1 through 10000');
+      }
+      const values: unknown[] = [match.tenantId, match.eventType, limit + 1, match.futureCallerInvalidation === true];
+      let scopePredicate: string;
+      if (match.anchor === 'caller') {
+        scopePredicate = `anchor_kind='caller'`;
+      } else {
+        if (!match.accountId) throw new TypeError('accountId is required for account notification matching');
+        values.push(match.accountId);
+        scopePredicate = `(anchor_kind='caller' OR (anchor_kind='account' AND account_id=$${values.length}))`;
+      }
+      if (match.principalId !== undefined) {
+        values.push(match.principalId);
+        scopePredicate += ` AND principal_id=$${values.length}`;
+      }
+      const result = await query(
+        'findCandidates',
+        `SELECT tenant_scope, principal_id, anchor_kind, account_id, generation,
+                subscriptions, content_fingerprint
+         FROM ${table}
+         WHERE tenant_scope=$1 AND ${scopePredicate}
+           AND EXISTS (
+             SELECT 1 FROM jsonb_array_elements(subscriptions) AS subscription
+             WHERE subscription->>'active' = 'true'
+               AND subscription->>'proofGeneration' = subscription->>'destinationGeneration'
+               AND (
+                 subscription->'eventTypes' ? $2
+                 OR ($4::boolean AND subscription->>'includeFutureEventTypes' = 'true')
+               )
+           )
+         ORDER BY principal_id, anchor_kind, account_id
+         LIMIT $3`,
+        values
+      );
+      return result.rows.map(rowToSet);
+    },
+  };
+}
+
+function scopeValues(scope: Readonly<NotificationSubscriptionScope>): [string, string, 'caller' | 'account', string] {
+  return [scope.tenantId, scope.principalId, scope.kind, scope.kind === 'account' ? scope.accountId : ''];
+}
+
+function rowToSet(row: Record<string, unknown>): NotificationSubscriptionSet {
+  if (row.anchor_kind !== 'caller' && row.anchor_kind !== 'account') {
+    throw new Error('pgNotificationSubscriptionStore: corrupt anchor kind');
+  }
+  if (!Array.isArray(row.subscriptions)) {
+    throw new Error('pgNotificationSubscriptionStore: corrupt subscriptions document');
+  }
+  const subscriptions = row.subscriptions as StoredNotificationSubscription[];
+  const fingerprint = canonicalJsonSha256(subscriptions);
+  if (typeof row.content_fingerprint !== 'string' || fingerprint !== row.content_fingerprint) {
+    throw new Error('pgNotificationSubscriptionStore: subscription fingerprint mismatch');
+  }
+  const scope: NotificationSubscriptionScope =
+    row.anchor_kind === 'account'
+      ? {
+          kind: 'account',
+          tenantId: String(row.tenant_scope),
+          principalId: String(row.principal_id),
+          accountId: String(row.account_id),
+        }
+      : {
+          kind: 'caller',
+          tenantId: String(row.tenant_scope),
+          principalId: String(row.principal_id),
+        };
+  return {
+    scope,
+    generation: String(row.generation),
+    subscriptions: structuredClone(subscriptions),
+  };
+}

--- a/src/lib/server/notification-subscriptions/protocol-handlers.ts
+++ b/src/lib/server/notification-subscriptions/protocol-handlers.ts
@@ -16,8 +16,10 @@ type SyncNotificationPayload = ServerPayload<SyncAgentNotificationConfigsRespons
  * double-write race created by layering it behind an adopter handler.
  *
  * `sync_principal` may replace several sections atomically, so applications
- * should call `runtime.replace()` from their broader principal transaction
- * rather than use this single-section helper for that task.
+ * must call `runtime.replace()` from their broader principal transaction and
+ * advance the shared `configuration_version` there. This compatibility helper
+ * cannot make that multi-section update atomic and must not be used as its
+ * notification sub-transaction.
  */
 export function createPersistentNotificationProtocolHandlers<TAccount = unknown>(
   runtime: PersistentNotificationRuntime,

--- a/src/lib/server/notification-subscriptions/protocol-handlers.ts
+++ b/src/lib/server/notification-subscriptions/protocol-handlers.ts
@@ -1,0 +1,122 @@
+import type { ServerPayload } from '../../types/server-payload';
+import type { AgentNotificationConfig, SyncAgentNotificationConfigsResponse } from '../../types/tools.generated';
+import type { ProtocolHandlers } from '../create-adcp-server';
+import type {
+  NotificationReplacementResult,
+  NotificationSubscriptionView,
+  PersistentNotificationRuntime,
+} from './types';
+import { NotificationSubscriptionValidationError } from './types';
+
+type SyncNotificationPayload = ServerPayload<SyncAgentNotificationConfigsResponse>;
+
+/**
+ * Wire the specialized compatibility task to one persistent runtime. Passing
+ * this object as `protocol` makes the runtime the sole writer, avoiding the
+ * double-write race created by layering it behind an adopter handler.
+ *
+ * `sync_principal` may replace several sections atomically, so applications
+ * should call `runtime.replace()` from their broader principal transaction
+ * rather than use this single-section helper for that task.
+ */
+export function createPersistentNotificationProtocolHandlers<TAccount = unknown>(
+  runtime: PersistentNotificationRuntime,
+  resolveScope: NonNullable<ProtocolHandlers<TAccount>['resolveScope']>
+): Pick<ProtocolHandlers<TAccount>, 'resolveScope' | 'syncAgentNotificationConfigs'> {
+  return {
+    resolveScope,
+    async syncAgentNotificationConfigs(params, ctx): Promise<SyncNotificationPayload> {
+      const resolved = ctx.callerMutationScope ?? (await resolveScope(ctx, params));
+      if (!resolved?.tenant_id || !resolved.principal_id) {
+        return failedPayload('INVALID_REQUEST', 'Authenticated caller scope is incomplete');
+      }
+      const scope = {
+        kind: 'caller' as const,
+        tenantId: resolved.tenant_id,
+        principalId: resolved.principal_id,
+      };
+      let result: NotificationReplacementResult;
+      try {
+        result = await runtime.replace(scope, params.notification_configs, {
+          dryRun: params.dry_run === true,
+        });
+      } catch (error) {
+        if (error instanceof NotificationSubscriptionValidationError) {
+          const current = await runtime.read(scope);
+          return failedPayload('INVALID_REQUEST', error.message, current.notificationConfigs, params.dry_run === true);
+        }
+        throw error;
+      }
+      return replacementPayload(runtime, scope, result, params.dry_run === true);
+    },
+  };
+}
+
+async function replacementPayload(
+  runtime: PersistentNotificationRuntime,
+  scope: Parameters<PersistentNotificationRuntime['read']>[0],
+  result: NotificationReplacementResult,
+  dryRun: boolean
+): Promise<SyncNotificationPayload> {
+  if (result.outcome === 'conflict') {
+    const current = await runtime.read(scope);
+    return failedPayload(
+      'INVALID_STATE',
+      'The subscriber set changed concurrently; read current state and retry the full replacement',
+      current.notificationConfigs,
+      dryRun
+    );
+  }
+  if (result.outcome === 'proof_failed') {
+    const current = await runtime.read(scope);
+    return failedPayload(
+      'VALIDATION_ERROR',
+      `Endpoint proof failed for subscriber ${JSON.stringify(result.subscriberId)}`,
+      current.notificationConfigs,
+      dryRun
+    );
+  }
+  const action =
+    result.outcome === 'validated'
+      ? result.wouldChange
+        ? result.notificationConfigs.length === 0
+          ? 'cleared'
+          : 'updated'
+        : 'unchanged'
+      : result.outcome === 'applied'
+        ? 'updated'
+        : result.outcome;
+  return {
+    action,
+    dry_run: dryRun,
+    notification_configs: result.notificationConfigs.map(toWireConfig),
+  };
+}
+
+function failedPayload(
+  code: 'INVALID_REQUEST' | 'INVALID_STATE' | 'VALIDATION_ERROR',
+  message: string,
+  configs: readonly NotificationSubscriptionView[] = [],
+  dryRun = false
+): SyncNotificationPayload {
+  return {
+    action: 'failed',
+    dry_run: dryRun,
+    notification_configs: configs.map(toWireConfig),
+    errors: [{ code, message }],
+  };
+}
+
+function toWireConfig(view: Readonly<NotificationSubscriptionView>): AgentNotificationConfig {
+  return {
+    subscriber_id: view.subscriber_id,
+    url: view.url,
+    event_types: view.event_types as AgentNotificationConfig['event_types'],
+    ...(view.all_authorized_accounts === undefined ? {} : { all_authorized_accounts: view.all_authorized_accounts }),
+    ...(view.include_future_event_types === undefined
+      ? {}
+      : { include_future_event_types: view.include_future_event_types }),
+    ...(view.authentication === undefined ? {} : { authentication: view.authentication }),
+    active: view.active,
+  };
+}

--- a/src/lib/server/notification-subscriptions/runtime.ts
+++ b/src/lib/server/notification-subscriptions/runtime.ts
@@ -1,0 +1,772 @@
+import { randomUUID } from 'node:crypto';
+import { lookup } from 'node:dns/promises';
+import { canonicalJsonSha256 } from '../../utils/jcs';
+import { enforceSsrfPolicy, enforceSsrfPolicyResolved } from '../../substitution/observer/ssrf';
+import { WEBHOOK_SSRF_POLICY } from '../pin-and-bind-fetch';
+import type {
+  WebhookAttemptAuthorizationDecision,
+  WebhookEmitAttempt,
+  WebhookAuthentication,
+} from '../webhook-emitter';
+import type {
+  NotificationAuthenticationMode,
+  NotificationEvent,
+  NotificationFanoutDelivery,
+  NotificationReplacementResult,
+  NotificationSubscriptionConfigInput,
+  NotificationSubscriptionScope,
+  NotificationSubscriptionSet,
+  NotificationSubscriptionView,
+  PersistentNotificationRuntime,
+  PersistentNotificationRuntimeOptions,
+  StoredNotificationAuthentication,
+  StoredNotificationSubscription,
+} from './types';
+import { NotificationSubscriptionValidationError } from './types';
+
+export const CALLER_NOTIFICATION_TYPES = Object.freeze(['capabilities.changed', 'principal.changed'] as const);
+
+export const ACCOUNT_NOTIFICATION_TYPES = Object.freeze([
+  'creative.status_changed',
+  'creative.assignment_changed',
+  'indicators.changed',
+  'creative.purged',
+  'account.status_changed',
+  'account.change_recorded',
+  'product.created',
+  'product.updated',
+  'product.priced',
+  'product.removed',
+  'signal.created',
+  'signal.updated',
+  'signal.priced',
+  'signal.removed',
+  'wholesale_feed.bulk_change',
+  'reporting.delivery_ready',
+  'reporting.status_changed',
+  'reporting.ledger_changed',
+] as const);
+
+interface NotificationAttemptContext {
+  kind: 'adcp_notification_subscription';
+  version: 1;
+  scope: NotificationSubscriptionScope;
+  eventAnchor: 'caller' | 'account';
+  accountId?: string;
+  subscriberId: string;
+  destinationGeneration: string;
+  eventType: string;
+  futureCallerInvalidation?: true;
+  notificationId: string;
+}
+
+/**
+ * Durable subscription control plane. The supplied emitter factory is called
+ * exactly once with the runtime's mandatory live authorizer, preventing a
+ * recovery worker from accidentally bypassing subscription generation and
+ * application authority checks.
+ */
+export function createPersistentNotificationRuntime(
+  options: PersistentNotificationRuntimeOptions
+): PersistentNotificationRuntime {
+  if (!options?.store) throw new TypeError('createPersistentNotificationRuntime requires store');
+  if (!options.proofAdapter?.prove) {
+    throw new TypeError('createPersistentNotificationRuntime requires proofAdapter.prove');
+  }
+  if (typeof options.authorizeDelivery !== 'function') {
+    throw new TypeError('createPersistentNotificationRuntime requires authorizeDelivery');
+  }
+  if (typeof options.createEmitter !== 'function') {
+    throw new TypeError('createPersistentNotificationRuntime requires createEmitter');
+  }
+  const production = process.env.NODE_ENV !== 'test' && process.env.NODE_ENV !== 'development';
+  if (production && options.store.durability !== 'durable') {
+    throw new TypeError('Production persistent notifications require a durable NotificationSubscriptionStore');
+  }
+  const maxFanoutCandidates = options.maxFanoutCandidates ?? 1000;
+  if (!Number.isSafeInteger(maxFanoutCandidates) || maxFanoutCandidates < 1 || maxFanoutCandidates > 10_000) {
+    throw new TypeError('maxFanoutCandidates must be an integer from 1 through 10000');
+  }
+
+  const accountEventTypes = new Set(options.supportedAccountEventTypes ?? ACCOUNT_NOTIFICATION_TYPES);
+  const futureCallerInvalidationEventTypes = new Set(options.futureCallerInvalidationEventTypes ?? []);
+  for (const eventType of futureCallerInvalidationEventTypes) {
+    if (accountEventTypes.has(eventType)) {
+      throw new TypeError('futureCallerInvalidationEventTypes must not contain account-anchored event types');
+    }
+  }
+  const callerEventTypes = new Set([
+    ...(options.supportedCallerEventTypes ?? CALLER_NOTIFICATION_TYPES),
+    ...accountEventTypes,
+    ...futureCallerInvalidationEventTypes,
+  ]);
+  const callerOnlyEventTypes = new Set([
+    ...(options.supportedCallerEventTypes ?? CALLER_NOTIFICATION_TYPES),
+    ...futureCallerInvalidationEventTypes,
+  ]);
+  const validateDestination = options.validateDestination ?? validatePersistentNotificationDestination;
+
+  const authorizeWebhookAttempt = async (
+    attempt: Readonly<WebhookEmitAttempt>
+  ): Promise<WebhookAttemptAuthorizationDecision> => {
+    const context = parseAttemptContext(attempt.attemptAuthorizationContext);
+    if (!context) return { decision: 'suppress', reason: 'authorization_error' };
+
+    let set: NotificationSubscriptionSet | null;
+    try {
+      set = await options.store.get(context.scope);
+    } catch {
+      return { decision: 'suppress', reason: 'authorization_error' };
+    }
+    if (!set) return { decision: 'suppress', reason: 'subscription_missing' };
+    const subscription = set.subscriptions.find(item => item.subscriberId === context.subscriberId);
+    if (!subscription) return { decision: 'suppress', reason: 'subscription_missing' };
+    if (subscription.destinationGeneration !== context.destinationGeneration) {
+      return { decision: 'suppress', reason: 'subscription_stale' };
+    }
+    if (!subscription.active || subscription.proofGeneration !== subscription.destinationGeneration) {
+      return { decision: 'suppress', reason: 'subscription_inactive' };
+    }
+    if (
+      !subscription.eventTypes.includes(context.eventType) &&
+      !(
+        context.futureCallerInvalidation === true &&
+        futureCallerInvalidationEventTypes.has(context.eventType) &&
+        subscription.includeFutureEventTypes
+      )
+    ) {
+      return { decision: 'suppress', reason: 'event_not_allowed' };
+    }
+    if (
+      (context.eventAnchor === 'account' && !context.accountId) ||
+      (context.eventAnchor === 'caller' && context.accountId !== undefined) ||
+      (context.scope.kind === 'account' &&
+        (context.eventAnchor !== 'account' || context.scope.accountId !== context.accountId)) ||
+      (context.scope.kind === 'caller' && context.eventAnchor === 'account' && !subscription.allAuthorizedAccounts)
+    ) {
+      return { decision: 'suppress', reason: 'event_not_allowed' };
+    }
+
+    let decision: { authorized: true } | { authorized: false };
+    try {
+      decision = await options.authorizeDelivery({
+        scope: structuredClone(context.scope),
+        eventAnchor: context.eventAnchor,
+        ...(context.accountId === undefined ? {} : { accountId: context.accountId }),
+        subscriberId: context.subscriberId,
+        destinationGeneration: context.destinationGeneration,
+        eventType: context.eventType,
+        notificationId: context.notificationId,
+      });
+    } catch {
+      return { decision: 'suppress', reason: 'authorization_error' };
+    }
+    if (decision?.authorized !== true) return { decision: 'suppress', reason: 'authorization_denied' };
+
+    if (subscription.authentication.mode === 'rfc9421') {
+      return { decision: 'allow', authentication: null };
+    }
+    const bindingId = subscription.authentication.bindingId;
+    if (!bindingId || !options.credentialAdapter) {
+      return { decision: 'suppress', reason: 'credential_unavailable' };
+    }
+    try {
+      const authentication = await options.credentialAdapter.resolve({
+        scope: structuredClone(context.scope),
+        subscriberId: context.subscriberId,
+        destinationGeneration: context.destinationGeneration,
+        mode: subscription.authentication.mode,
+        bindingId,
+      });
+      if (!resolvedAuthenticationMatches(subscription.authentication.mode, authentication)) {
+        return { decision: 'suppress', reason: 'credential_unavailable' };
+      }
+      return { decision: 'allow', authentication };
+    } catch {
+      return { decision: 'suppress', reason: 'credential_unavailable' };
+    }
+  };
+
+  const emitter = options.createEmitter(authorizeWebhookAttempt);
+  if (!emitter?.emit || !emitter.emitRecovered || !emitter.forTenantScope) {
+    throw new TypeError('createEmitter must return a RecoverableWebhookEmitter');
+  }
+
+  return {
+    store: options.store,
+    emitter,
+    authorizeWebhookAttempt,
+    async replace(scope, configs, replaceOptions = {}): Promise<NotificationReplacementResult> {
+      assertScope(scope);
+      assertUniqueSubscribers(configs);
+      const current = await options.store.get(scope);
+      if (
+        replaceOptions.expectedGeneration !== undefined &&
+        current?.generation !== replaceOptions.expectedGeneration
+      ) {
+        return {
+          outcome: 'conflict',
+          ...(current && { currentGeneration: current.generation }),
+        };
+      }
+      const previous = new Map(current?.subscriptions.map(item => [item.subscriberId, item]));
+      const normalized: StoredNotificationSubscription[] = [];
+      for (let index = 0; index < configs.length; index++) {
+        normalized.push(
+          await normalizeConfig({
+            scope,
+            config: configs[index]!,
+            previous: previous.get(configs[index]!.subscriber_id),
+            index,
+            dryRun: replaceOptions.dryRun === true,
+            accountEventTypes,
+            callerEventTypes,
+            callerOnlyEventTypes,
+            credentialAdapter: options.credentialAdapter,
+            validateDestination,
+          })
+        );
+      }
+      normalized.sort((a, b) => a.subscriberId.localeCompare(b.subscriberId));
+
+      if (replaceOptions.dryRun === true) {
+        return {
+          outcome: 'validated',
+          notificationConfigs: normalized.map(item => projectSubscription(item, false)),
+          wouldChange:
+            canonicalJsonSha256(normalized.map(withoutProofGeneration)) !==
+            canonicalJsonSha256((current?.subscriptions ?? []).map(withoutProofGeneration)),
+        };
+      }
+
+      for (const subscription of normalized) {
+        const prior = previous.get(subscription.subscriberId);
+        if (!subscription.active) {
+          if (prior?.destinationGeneration === subscription.destinationGeneration && prior.proofGeneration) {
+            subscription.proofGeneration = prior.proofGeneration;
+          }
+          continue;
+        }
+        if (
+          prior?.destinationGeneration === subscription.destinationGeneration &&
+          prior.proofGeneration === subscription.destinationGeneration
+        ) {
+          subscription.proofGeneration = prior.proofGeneration;
+          continue;
+        }
+        let proof: { proved: true } | { proved: false };
+        try {
+          proof = await options.proofAdapter.prove({
+            scope: structuredClone(scope),
+            subscriberId: subscription.subscriberId,
+            url: subscription.url,
+            eventTypes: [...subscription.eventTypes],
+            authentication: { ...subscription.authentication },
+            destinationGeneration: subscription.destinationGeneration,
+          });
+        } catch {
+          proof = { proved: false };
+        }
+        if (proof?.proved !== true) {
+          return { outcome: 'proof_failed', subscriberId: subscription.subscriberId };
+        }
+        subscription.proofGeneration = subscription.destinationGeneration;
+      }
+
+      const result = await options.store.replace({
+        scope,
+        expectedGeneration: current?.generation ?? null,
+        nextGeneration: `cfg_${randomUUID()}`,
+        subscriptions: normalized,
+      });
+      if (result.outcome === 'conflict') return result;
+      return {
+        outcome:
+          result.outcome === 'unchanged' ? 'unchanged' : result.set.subscriptions.length === 0 ? 'cleared' : 'applied',
+        generation: result.set.generation,
+        notificationConfigs: result.set.subscriptions.map(item => projectSubscription(item, true)),
+      };
+    },
+    async read(scope) {
+      assertScope(scope);
+      const set = await options.store.get(scope);
+      return {
+        ...(set && { generation: set.generation }),
+        notificationConfigs: set?.subscriptions.map(item => projectSubscription(item, true)) ?? [],
+      };
+    },
+    async emit(event) {
+      assertEvent(event, accountEventTypes, callerOnlyEventTypes);
+      const futureCallerInvalidation = futureCallerInvalidationEventTypes.has(event.notificationType);
+      const candidateSets = await options.store.findCandidates(
+        {
+          anchor: event.anchor,
+          tenantId: event.tenantId,
+          ...(event.principalId === undefined ? {} : { principalId: event.principalId }),
+          ...(event.accountId === undefined ? {} : { accountId: event.accountId }),
+          eventType: event.notificationType,
+          ...(futureCallerInvalidation ? { futureCallerInvalidation: true } : {}),
+        },
+        maxFanoutCandidates
+      );
+      if (candidateSets.length > maxFanoutCandidates) {
+        throw new Error('Persistent notification fanout exceeded maxFanoutCandidates; no deliveries were attempted');
+      }
+
+      const targets = candidateSets.flatMap(set =>
+        set.subscriptions
+          .filter(
+            subscription =>
+              subscription.active &&
+              subscription.proofGeneration === subscription.destinationGeneration &&
+              (subscription.eventTypes.includes(event.notificationType) ||
+                (futureCallerInvalidation && subscription.includeFutureEventTypes)) &&
+              (set.scope.kind !== 'caller' || event.anchor !== 'account' || subscription.allAuthorizedAccounts)
+          )
+          .map(subscription => ({ set, subscription }))
+      );
+      if (targets.length > maxFanoutCandidates) {
+        throw new Error('Persistent notification fanout exceeded maxFanoutCandidates; no deliveries were attempted');
+      }
+      const deliveries: NotificationFanoutDelivery[] = [];
+      for (const { set, subscription } of targets) {
+        const deliveryId = deliveryIdentity(event.emissionId, set.scope, subscription);
+        const payload = notificationPayload(event, subscription.subscriberId);
+        const context: NotificationAttemptContext = {
+          kind: 'adcp_notification_subscription',
+          version: 1,
+          scope: structuredClone(set.scope),
+          eventAnchor: event.anchor,
+          ...(event.accountId === undefined ? {} : { accountId: event.accountId }),
+          subscriberId: subscription.subscriberId,
+          destinationGeneration: subscription.destinationGeneration,
+          eventType: event.notificationType,
+          ...(futureCallerInvalidation ? { futureCallerInvalidation: true } : {}),
+          notificationId: event.notificationId,
+        };
+        const result = await emitter.forTenantScope(set.scope.tenantId).emit({
+          url: subscription.url,
+          payload,
+          delivery_id: deliveryId,
+          authentication: null,
+          attemptAuthorizationContext: context as unknown as Record<string, unknown>,
+        });
+        deliveries.push({
+          scope: structuredClone(set.scope),
+          subscriberId: subscription.subscriberId,
+          destinationGeneration: subscription.destinationGeneration,
+          result,
+        });
+      }
+      return {
+        notificationId: event.notificationId,
+        emissionId: event.emissionId,
+        matched: targets.length,
+        deliveries,
+      };
+    },
+  };
+}
+
+function withoutProofGeneration(subscription: Readonly<StoredNotificationSubscription>): Record<string, unknown> {
+  const { proofGeneration: _proofGeneration, ...rest } = subscription;
+  return rest;
+}
+
+interface NormalizeConfigInput {
+  scope: Readonly<NotificationSubscriptionScope>;
+  config: Readonly<NotificationSubscriptionConfigInput>;
+  previous?: Readonly<StoredNotificationSubscription>;
+  index: number;
+  dryRun: boolean;
+  accountEventTypes: ReadonlySet<string>;
+  callerEventTypes: ReadonlySet<string>;
+  callerOnlyEventTypes: ReadonlySet<string>;
+  credentialAdapter?: PersistentNotificationRuntimeOptions['credentialAdapter'];
+  validateDestination: NonNullable<PersistentNotificationRuntimeOptions['validateDestination']>;
+}
+
+async function normalizeConfig(input: NormalizeConfigInput): Promise<StoredNotificationSubscription> {
+  const { config, scope } = input;
+  assertIdentifier(config.subscriber_id, `notification_configs[${input.index}].subscriber_id`, 255);
+  const url = normalizeWebhookUrl(config.url, `notification_configs[${input.index}].url`);
+  let destinationValidation: { allowed: true } | { allowed: false };
+  try {
+    destinationValidation = await input.validateDestination({
+      scope: structuredClone(scope),
+      subscriberId: config.subscriber_id,
+      url,
+    });
+  } catch {
+    destinationValidation = { allowed: false };
+  }
+  if (destinationValidation?.allowed !== true) {
+    throw validation('webhook URL failed DNS and reserved-range validation', input.index, 'url');
+  }
+  if (!Array.isArray(config.event_types) || config.event_types.length === 0) {
+    throw validation('event_types must contain at least one event type', input.index, 'event_types');
+  }
+  const eventTypes = [...new Set(config.event_types)].sort();
+  for (let eventIndex = 0; eventIndex < eventTypes.length; eventIndex++) {
+    const eventType = eventTypes[eventIndex];
+    if (typeof eventType !== 'string' || eventType.length === 0) {
+      throw validation('event type must be a non-empty string', input.index, `event_types[${eventIndex}]`);
+    }
+    const supported = scope.kind === 'account' ? input.accountEventTypes : input.callerEventTypes;
+    if (!supported.has(eventType)) {
+      throw validation(
+        `event type ${JSON.stringify(eventType)} is not supported on this anchor`,
+        input.index,
+        `event_types[${eventIndex}]`
+      );
+    }
+    if (scope.kind === 'account' && input.callerOnlyEventTypes.has(eventType)) {
+      throw validation(
+        `event type ${JSON.stringify(eventType)} is caller-anchored`,
+        input.index,
+        `event_types[${eventIndex}]`
+      );
+    }
+  }
+  if (
+    scope.kind === 'caller' &&
+    eventTypes.some(eventType => input.accountEventTypes.has(eventType)) &&
+    config.all_authorized_accounts !== true
+  ) {
+    throw validation(
+      'all_authorized_accounts must be true for account-anchored caller subscriptions',
+      input.index,
+      'all_authorized_accounts'
+    );
+  }
+  if (config.product_payload_view !== undefined && !eventTypes.some(eventType => eventType.startsWith('product.'))) {
+    throw validation('product_payload_view requires a product.* event type', input.index, 'product_payload_view');
+  }
+
+  const authentication = await normalizeAuthentication(input);
+  const destinationGeneration = `dest_${canonicalJsonSha256({
+    scope,
+    subscriberId: config.subscriber_id,
+    url,
+    authentication,
+    eventTypes,
+    allAuthorizedAccounts: config.all_authorized_accounts === true,
+    includeFutureEventTypes: config.include_future_event_types === true,
+    productPayloadView: config.product_payload_view ?? null,
+  })}`;
+  return {
+    subscriberId: config.subscriber_id,
+    url,
+    eventTypes,
+    active: config.active !== false,
+    allAuthorizedAccounts: config.all_authorized_accounts === true,
+    includeFutureEventTypes: config.include_future_event_types === true,
+    ...(config.product_payload_view === undefined ? {} : { productPayloadView: config.product_payload_view }),
+    authentication,
+    destinationGeneration,
+  };
+}
+
+async function normalizeAuthentication(input: NormalizeConfigInput): Promise<StoredNotificationAuthentication> {
+  const auth = input.config.authentication;
+  if (auth === undefined) return { mode: 'rfc9421' };
+  if (!Array.isArray(auth.schemes) || auth.schemes.length !== 1) {
+    throw validation('authentication.schemes must contain exactly one scheme', input.index, 'authentication.schemes');
+  }
+  const scheme = auth.schemes[0];
+  const mode: Exclude<NotificationAuthenticationMode, 'rfc9421'> =
+    scheme === 'Bearer'
+      ? 'bearer'
+      : scheme === 'HMAC-SHA256'
+        ? 'hmac_sha256'
+        : (() => {
+            throw validation('unsupported authentication scheme', input.index, 'authentication.schemes[0]');
+          })();
+  const previous = input.previous?.authentication.mode === mode ? input.previous.authentication : undefined;
+  if (auth.credentials === undefined) {
+    if (previous?.bindingId) return { mode, bindingId: previous.bindingId };
+    if (input.dryRun && input.credentialAdapter) return { mode, bindingId: 'dry-run-unissued-binding' };
+    throw validation(
+      'credentials are required for a new legacy authentication binding',
+      input.index,
+      'authentication.credentials'
+    );
+  }
+  if (typeof auth.credentials !== 'string' || auth.credentials.length < 32) {
+    throw validation(
+      'authentication.credentials must contain at least 32 characters',
+      input.index,
+      'authentication.credentials'
+    );
+  }
+  if (!input.credentialAdapter) {
+    throw validation('legacy authentication requires a credentialAdapter', input.index, 'authentication');
+  }
+  if (input.dryRun) return { mode, bindingId: 'dry-run-unissued-binding' };
+  let bound: { bindingId: string };
+  try {
+    bound = await input.credentialAdapter.bind({
+      scope: structuredClone(input.scope),
+      subscriberId: input.config.subscriber_id,
+      mode,
+      credential: auth.credentials,
+      ...(previous?.bindingId === undefined ? {} : { previousBindingId: previous.bindingId }),
+    });
+  } catch {
+    throw validation('credential binding failed', input.index, 'authentication');
+  }
+  if (
+    !bound ||
+    typeof bound.bindingId !== 'string' ||
+    bound.bindingId.length < 1 ||
+    Buffer.byteLength(bound.bindingId, 'utf8') > 512 ||
+    bound.bindingId.includes(auth.credentials)
+  ) {
+    throw validation(
+      'credentialAdapter.bind must return an opaque non-secret bindingId of at most 512 bytes',
+      input.index,
+      'authentication'
+    );
+  }
+  return { mode, bindingId: bound.bindingId };
+}
+
+function projectSubscription(
+  subscription: Readonly<StoredNotificationSubscription>,
+  includeGenerations: boolean
+): NotificationSubscriptionView {
+  return {
+    subscriber_id: subscription.subscriberId,
+    url: subscription.url,
+    event_types: [...subscription.eventTypes],
+    active: subscription.active,
+    ...(subscription.allAuthorizedAccounts && { all_authorized_accounts: true }),
+    ...(subscription.includeFutureEventTypes && { include_future_event_types: true }),
+    ...(subscription.productPayloadView === undefined ? {} : { product_payload_view: subscription.productPayloadView }),
+    ...(subscription.authentication.mode === 'bearer'
+      ? { authentication: { schemes: ['Bearer'] } as const }
+      : subscription.authentication.mode === 'hmac_sha256'
+        ? { authentication: { schemes: ['HMAC-SHA256'] } as const }
+        : {}),
+    ...(includeGenerations ? { destination_generation: subscription.destinationGeneration } : {}),
+    ...(includeGenerations && subscription.proofGeneration ? { proof_generation: subscription.proofGeneration } : {}),
+  };
+}
+
+/** Strip SDK operational generations for generated AdCP response projections. */
+export function projectNotificationSubscriptionReadback(
+  views: readonly NotificationSubscriptionView[]
+): NotificationSubscriptionConfigInput[] {
+  return views.map(view => ({
+    subscriber_id: view.subscriber_id,
+    url: view.url,
+    event_types: [...view.event_types],
+    active: view.active,
+    ...(view.all_authorized_accounts === undefined ? {} : { all_authorized_accounts: view.all_authorized_accounts }),
+    ...(view.include_future_event_types === undefined
+      ? {}
+      : { include_future_event_types: view.include_future_event_types }),
+    ...(view.product_payload_view === undefined ? {} : { product_payload_view: view.product_payload_view }),
+    ...(view.authentication === undefined ? {} : { authentication: view.authentication }),
+  }));
+}
+
+function notificationPayload(event: Readonly<NotificationEvent>, subscriberId: string): Record<string, unknown> {
+  const payload = structuredClone(event.payload);
+  canonicalJsonSha256(payload);
+  assertPayloadField(payload, 'notification_type', event.notificationType);
+  assertPayloadField(payload, 'notification_id', event.notificationId);
+  assertPayloadField(payload, 'subscriber_id', subscriberId);
+  if (event.accountId !== undefined) assertPayloadField(payload, 'account_id', event.accountId);
+  return {
+    ...payload,
+    notification_type: event.notificationType,
+    notification_id: event.notificationId,
+    subscriber_id: subscriberId,
+    ...(event.accountId === undefined ? {} : { account_id: event.accountId }),
+  };
+}
+
+function assertPayloadField(payload: Record<string, unknown>, field: string, expected: string): void {
+  if (payload[field] !== undefined && payload[field] !== expected) {
+    throw new NotificationSubscriptionValidationError(
+      `payload.${field} conflicts with the trusted notification event`,
+      `payload.${field}`
+    );
+  }
+}
+
+function deliveryIdentity(
+  emissionId: string,
+  scope: Readonly<NotificationSubscriptionScope>,
+  subscription: Readonly<StoredNotificationSubscription>
+): string {
+  return `notification_${canonicalJsonSha256({
+    emissionId,
+    scope,
+    subscriberId: subscription.subscriberId,
+    destinationGeneration: subscription.destinationGeneration,
+  })}`;
+}
+
+function assertEvent(
+  event: Readonly<NotificationEvent>,
+  accountEventTypes: ReadonlySet<string>,
+  callerOnlyEventTypes: ReadonlySet<string>
+): void {
+  assertIdentifier(event.emissionId, 'emissionId', 512);
+  assertIdentifier(event.notificationId, 'notificationId', 512);
+  assertIdentifier(event.notificationType, 'notificationType', 255);
+  assertIdentifier(event.tenantId, 'tenantId', 512);
+  if (event.principalId !== undefined) assertIdentifier(event.principalId, 'principalId', 512);
+  if (event.anchor === 'account') {
+    if (!event.accountId)
+      throw new NotificationSubscriptionValidationError('accountId is required for account events', 'accountId');
+    assertIdentifier(event.accountId, 'accountId', 512);
+    if (!accountEventTypes.has(event.notificationType)) {
+      throw new NotificationSubscriptionValidationError('notificationType is not account-anchored', 'notificationType');
+    }
+  } else if (event.anchor === 'caller') {
+    if (event.accountId !== undefined) {
+      throw new NotificationSubscriptionValidationError('caller events must not carry accountId', 'accountId');
+    }
+    if (!callerOnlyEventTypes.has(event.notificationType)) {
+      throw new NotificationSubscriptionValidationError('notificationType is not caller-anchored', 'notificationType');
+    }
+  } else {
+    throw new NotificationSubscriptionValidationError('anchor must be caller or account', 'anchor');
+  }
+  canonicalJsonSha256(event.payload);
+}
+
+function assertUniqueSubscribers(configs: readonly NotificationSubscriptionConfigInput[]): void {
+  if (!Array.isArray(configs) || configs.length > 16) {
+    throw new NotificationSubscriptionValidationError(
+      'notification_configs must contain at most 16 subscribers',
+      'notification_configs'
+    );
+  }
+  const seen = new Set<string>();
+  for (let index = 0; index < configs.length; index++) {
+    const subscriberId = configs[index]?.subscriber_id;
+    if (typeof subscriberId !== 'string') {
+      throw validation('subscriber_id must be a string', index, 'subscriber_id');
+    }
+    if (seen.has(subscriberId)) {
+      throw validation('duplicate subscriber_id', index, 'subscriber_id');
+    }
+    seen.add(subscriberId);
+  }
+}
+
+function normalizeWebhookUrl(value: unknown, field: string): string {
+  if (typeof value !== 'string')
+    throw new NotificationSubscriptionValidationError('webhook URL must be a string', field);
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new NotificationSubscriptionValidationError('webhook URL is invalid', field);
+  }
+  if (url.username || url.password || url.hash) {
+    throw new NotificationSubscriptionValidationError('webhook URL must not contain userinfo or a fragment', field);
+  }
+  const policy = enforceSsrfPolicy(url, WEBHOOK_SSRF_POLICY);
+  if (!policy.allowed) throw new NotificationSubscriptionValidationError('webhook URL is denied by SSRF policy', field);
+  return url.toString();
+}
+
+/** Point-in-time registration validation; delivery still re-resolves and pins every attempt. */
+export async function validatePersistentNotificationDestination(input: {
+  url: string;
+}): Promise<{ allowed: true } | { allowed: false }> {
+  let url: URL;
+  try {
+    url = new URL(input.url);
+  } catch {
+    return { allowed: false };
+  }
+  const literal = enforceSsrfPolicy(url, WEBHOOK_SSRF_POLICY);
+  if (!literal.allowed) return { allowed: false };
+  try {
+    const addresses = await lookup(url.hostname, { all: true, verbatim: true });
+    const resolved = enforceSsrfPolicyResolved(
+      url,
+      addresses.map(address => address.address),
+      WEBHOOK_SSRF_POLICY
+    );
+    return resolved.allowed ? { allowed: true } : { allowed: false };
+  } catch {
+    return { allowed: false };
+  }
+}
+
+function parseAttemptContext(value: unknown): NotificationAttemptContext | null {
+  if (value == null || typeof value !== 'object' || Array.isArray(value)) return null;
+  const input = value as Record<string, unknown>;
+  if (input.kind !== 'adcp_notification_subscription' || input.version !== 1) return null;
+  if (
+    typeof input.subscriberId !== 'string' ||
+    typeof input.destinationGeneration !== 'string' ||
+    typeof input.eventType !== 'string' ||
+    typeof input.notificationId !== 'string' ||
+    (input.eventAnchor !== 'caller' && input.eventAnchor !== 'account') ||
+    (input.futureCallerInvalidation !== undefined && input.futureCallerInvalidation !== true) ||
+    (input.accountId !== undefined && typeof input.accountId !== 'string')
+  ) {
+    return null;
+  }
+  try {
+    assertScope(input.scope as NotificationSubscriptionScope);
+  } catch {
+    return null;
+  }
+  return {
+    kind: 'adcp_notification_subscription',
+    version: 1,
+    scope: structuredClone(input.scope as NotificationSubscriptionScope),
+    eventAnchor: input.eventAnchor,
+    ...(input.accountId === undefined ? {} : { accountId: input.accountId as string }),
+    subscriberId: input.subscriberId,
+    destinationGeneration: input.destinationGeneration,
+    eventType: input.eventType,
+    ...(input.futureCallerInvalidation === true ? { futureCallerInvalidation: true } : {}),
+    notificationId: input.notificationId,
+  };
+}
+
+function resolvedAuthenticationMatches(
+  mode: Exclude<NotificationAuthenticationMode, 'rfc9421'>,
+  authentication: WebhookAuthentication
+): authentication is Exclude<WebhookAuthentication, null> {
+  return (
+    (mode === 'bearer' && authentication?.type === 'bearer' && authentication.token.length > 0) ||
+    (mode === 'hmac_sha256' && authentication?.type === 'hmac_sha256' && authentication.secret.length > 0)
+  );
+}
+
+function assertScope(scope: Readonly<NotificationSubscriptionScope>): void {
+  if (scope == null || typeof scope !== 'object') throw new TypeError('notification subscription scope is required');
+  if (scope.kind !== 'caller' && scope.kind !== 'account') throw new TypeError('scope.kind must be caller or account');
+  assertIdentifier(scope.tenantId, 'scope.tenantId', 512);
+  assertIdentifier(scope.principalId, 'scope.principalId', 512);
+  if (scope.kind === 'account') assertIdentifier(scope.accountId, 'scope.accountId', 512);
+}
+
+function assertIdentifier(value: unknown, field: string, maxBytes: number): asserts value is string {
+  if (
+    typeof value !== 'string' ||
+    value.length === 0 ||
+    Buffer.byteLength(value, 'utf8') > maxBytes ||
+    value.includes('\0')
+  ) {
+    throw new NotificationSubscriptionValidationError(
+      `${field} must be a non-empty UTF-8 string of at most ${maxBytes} bytes without NUL`,
+      field
+    );
+  }
+}
+
+function validation(message: string, index: number, field: string): NotificationSubscriptionValidationError {
+  return new NotificationSubscriptionValidationError(message, `notification_configs[${index}].${field}`);
+}

--- a/src/lib/server/notification-subscriptions/runtime.ts
+++ b/src/lib/server/notification-subscriptions/runtime.ts
@@ -87,6 +87,18 @@ export function createPersistentNotificationRuntime(
   if (!Number.isSafeInteger(maxFanoutCandidates) || maxFanoutCandidates < 1 || maxFanoutCandidates > 10_000) {
     throw new TypeError('maxFanoutCandidates must be an integer from 1 through 10000');
   }
+  const fanoutConcurrency = options.fanoutConcurrency ?? 8;
+  if (!Number.isSafeInteger(fanoutConcurrency) || fanoutConcurrency < 1 || fanoutConcurrency > 64) {
+    throw new TypeError('fanoutConcurrency must be an integer from 1 through 64');
+  }
+  const adopterCallbackTimeoutMs = options.adopterCallbackTimeoutMs ?? 30_000;
+  if (
+    !Number.isSafeInteger(adopterCallbackTimeoutMs) ||
+    adopterCallbackTimeoutMs < 1 ||
+    adopterCallbackTimeoutMs > 300_000
+  ) {
+    throw new TypeError('adopterCallbackTimeoutMs must be an integer from 1 through 300000');
+  }
 
   const accountEventTypes = new Set(options.supportedAccountEventTypes ?? ACCOUNT_NOTIFICATION_TYPES);
   const futureCallerInvalidationEventTypes = new Set(options.futureCallerInvalidationEventTypes ?? []);
@@ -149,21 +161,25 @@ export function createPersistentNotificationRuntime(
 
     let decision: { authorized: true } | { authorized: false };
     try {
-      decision = await options.authorizeDelivery({
-        scope: structuredClone(context.scope),
-        eventAnchor: context.eventAnchor,
-        ...(context.accountId === undefined ? {} : { accountId: context.accountId }),
-        subscriberId: context.subscriberId,
-        destinationGeneration: context.destinationGeneration,
-        eventType: context.eventType,
-        notificationId: context.notificationId,
-      });
+      decision = await runAdopterCallback(adopterCallbackTimeoutMs, 'authorizeDelivery', signal =>
+        options.authorizeDelivery({
+          scope: structuredClone(context.scope),
+          eventAnchor: context.eventAnchor,
+          ...(context.accountId === undefined ? {} : { accountId: context.accountId }),
+          subscriberId: context.subscriberId,
+          destinationGeneration: context.destinationGeneration,
+          eventType: context.eventType,
+          notificationId: context.notificationId,
+          signal,
+        })
+      );
     } catch {
       return { decision: 'suppress', reason: 'authorization_error' };
     }
     if (decision?.authorized !== true) return { decision: 'suppress', reason: 'authorization_denied' };
 
-    if (subscription.authentication.mode === 'rfc9421') {
+    const authenticationMode = subscription.authentication.mode;
+    if (authenticationMode === 'rfc9421') {
       return { decision: 'allow', authentication: null };
     }
     const bindingId = subscription.authentication.bindingId;
@@ -171,14 +187,17 @@ export function createPersistentNotificationRuntime(
       return { decision: 'suppress', reason: 'credential_unavailable' };
     }
     try {
-      const authentication = await options.credentialAdapter.resolve({
-        scope: structuredClone(context.scope),
-        subscriberId: context.subscriberId,
-        destinationGeneration: context.destinationGeneration,
-        mode: subscription.authentication.mode,
-        bindingId,
-      });
-      if (!resolvedAuthenticationMatches(subscription.authentication.mode, authentication)) {
+      const authentication = await runAdopterCallback(adopterCallbackTimeoutMs, 'credentialAdapter.resolve', signal =>
+        options.credentialAdapter!.resolve({
+          scope: structuredClone(context.scope),
+          subscriberId: context.subscriberId,
+          destinationGeneration: context.destinationGeneration,
+          mode: authenticationMode,
+          bindingId,
+          signal,
+        })
+      );
+      if (!resolvedAuthenticationMatches(authenticationMode, authentication)) {
         return { decision: 'suppress', reason: 'credential_unavailable' };
       }
       return { decision: 'allow', authentication };
@@ -211,21 +230,36 @@ export function createPersistentNotificationRuntime(
       }
       const previous = new Map(current?.subscriptions.map(item => [item.subscriberId, item]));
       const normalized: StoredNotificationSubscription[] = [];
-      for (let index = 0; index < configs.length; index++) {
-        normalized.push(
-          await normalizeConfig({
-            scope,
-            config: configs[index]!,
-            previous: previous.get(configs[index]!.subscriber_id),
-            index,
-            dryRun: replaceOptions.dryRun === true,
-            accountEventTypes,
-            callerEventTypes,
-            callerOnlyEventTypes,
-            credentialAdapter: options.credentialAdapter,
-            validateDestination,
-          })
+      const credentialStages: PreparedCredentialStage[] = [];
+      const discardStages = () =>
+        discardCredentialStages(
+          options.credentialAdapter,
+          credentialStages,
+          adopterCallbackTimeoutMs,
+          options.onCredentialStageError
         );
+      try {
+        for (let index = 0; index < configs.length; index++) {
+          normalized.push(
+            await normalizeConfig({
+              scope,
+              config: configs[index]!,
+              previous: previous.get(configs[index]!.subscriber_id),
+              index,
+              dryRun: replaceOptions.dryRun === true,
+              accountEventTypes,
+              callerEventTypes,
+              callerOnlyEventTypes,
+              credentialAdapter: options.credentialAdapter,
+              credentialStages,
+              adopterCallbackTimeoutMs,
+              validateDestination,
+            })
+          );
+        }
+      } catch (error) {
+        await discardStages();
+        throw error;
       }
       normalized.sort((a, b) => a.subscriberId.localeCompare(b.subscriberId));
 
@@ -256,30 +290,49 @@ export function createPersistentNotificationRuntime(
         }
         let proof: { proved: true } | { proved: false };
         try {
-          proof = await options.proofAdapter.prove({
-            scope: structuredClone(scope),
-            subscriberId: subscription.subscriberId,
-            url: subscription.url,
-            eventTypes: [...subscription.eventTypes],
-            authentication: { ...subscription.authentication },
-            destinationGeneration: subscription.destinationGeneration,
-          });
+          proof = await runAdopterCallback(adopterCallbackTimeoutMs, 'proofAdapter.prove', signal =>
+            options.proofAdapter.prove({
+              scope: structuredClone(scope),
+              subscriberId: subscription.subscriberId,
+              url: subscription.url,
+              eventTypes: [...subscription.eventTypes],
+              authentication: { ...subscription.authentication },
+              destinationGeneration: subscription.destinationGeneration,
+              signal,
+            })
+          );
         } catch {
           proof = { proved: false };
         }
         if (proof?.proved !== true) {
+          await discardStages();
           return { outcome: 'proof_failed', subscriberId: subscription.subscriberId };
         }
         subscription.proofGeneration = subscription.destinationGeneration;
       }
 
-      const result = await options.store.replace({
-        scope,
-        expectedGeneration: current?.generation ?? null,
-        nextGeneration: `cfg_${randomUUID()}`,
-        subscriptions: normalized,
-      });
-      if (result.outcome === 'conflict') return result;
+      let result: Awaited<ReturnType<typeof options.store.replace>>;
+      try {
+        result = await options.store.replace({
+          scope,
+          expectedGeneration: current?.generation ?? null,
+          nextGeneration: `cfg_${randomUUID()}`,
+          subscriptions: normalized,
+        });
+      } catch (error) {
+        await discardStages();
+        throw error;
+      }
+      if (result.outcome === 'conflict') {
+        await discardStages();
+        return result;
+      }
+      await commitCredentialStages(
+        options.credentialAdapter,
+        credentialStages,
+        adopterCallbackTimeoutMs,
+        options.onCredentialStageError
+      );
       return {
         outcome:
           result.outcome === 'unchanged' ? 'unchanged' : result.set.subscriptions.length === 0 ? 'cleared' : 'applied',
@@ -328,8 +381,7 @@ export function createPersistentNotificationRuntime(
       if (targets.length > maxFanoutCandidates) {
         throw new Error('Persistent notification fanout exceeded maxFanoutCandidates; no deliveries were attempted');
       }
-      const deliveries: NotificationFanoutDelivery[] = [];
-      for (const { set, subscription } of targets) {
+      const deliveries = await mapConcurrent(targets, fanoutConcurrency, async ({ set, subscription }) => {
         const deliveryId = deliveryIdentity(event.emissionId, set.scope, subscription);
         const payload = notificationPayload(event, subscription.subscriberId);
         const context: NotificationAttemptContext = {
@@ -344,20 +396,27 @@ export function createPersistentNotificationRuntime(
           ...(futureCallerInvalidation ? { futureCallerInvalidation: true } : {}),
           notificationId: event.notificationId,
         };
-        const result = await emitter.forTenantScope(set.scope.tenantId).emit({
-          url: subscription.url,
-          payload,
-          delivery_id: deliveryId,
-          authentication: null,
-          attemptAuthorizationContext: context as unknown as Record<string, unknown>,
-        });
-        deliveries.push({
+        const delivery = {
           scope: structuredClone(set.scope),
           subscriberId: subscription.subscriberId,
           destinationGeneration: subscription.destinationGeneration,
-          result,
-        });
-      }
+        };
+        try {
+          const result = await emitter.forTenantScope(set.scope.tenantId).emit({
+            url: subscription.url,
+            payload,
+            delivery_id: deliveryId,
+            authentication: null,
+            attemptAuthorizationContext: context as unknown as Record<string, unknown>,
+          });
+          return { ...delivery, result } satisfies NotificationFanoutDelivery;
+        } catch {
+          return {
+            ...delivery,
+            failure: { reason: 'delivery_runtime_error' },
+          } satisfies NotificationFanoutDelivery;
+        }
+      });
       return {
         notificationId: event.notificationId,
         emissionId: event.emissionId,
@@ -373,6 +432,15 @@ function withoutProofGeneration(subscription: Readonly<StoredNotificationSubscri
   return rest;
 }
 
+interface PreparedCredentialStage {
+  scope: NotificationSubscriptionScope;
+  subscriberId: string;
+  mode: Exclude<NotificationAuthenticationMode, 'rfc9421'>;
+  bindingId: string;
+  stageId: string;
+  supersedesBindingId?: string;
+}
+
 interface NormalizeConfigInput {
   scope: Readonly<NotificationSubscriptionScope>;
   config: Readonly<NotificationSubscriptionConfigInput>;
@@ -383,6 +451,8 @@ interface NormalizeConfigInput {
   callerEventTypes: ReadonlySet<string>;
   callerOnlyEventTypes: ReadonlySet<string>;
   credentialAdapter?: PersistentNotificationRuntimeOptions['credentialAdapter'];
+  credentialStages: PreparedCredentialStage[];
+  adopterCallbackTimeoutMs: number;
   validateDestination: NonNullable<PersistentNotificationRuntimeOptions['validateDestination']>;
 }
 
@@ -392,11 +462,14 @@ async function normalizeConfig(input: NormalizeConfigInput): Promise<StoredNotif
   const url = normalizeWebhookUrl(config.url, `notification_configs[${input.index}].url`);
   let destinationValidation: { allowed: true } | { allowed: false };
   try {
-    destinationValidation = await input.validateDestination({
-      scope: structuredClone(scope),
-      subscriberId: config.subscriber_id,
-      url,
-    });
+    destinationValidation = await runAdopterCallback(input.adopterCallbackTimeoutMs, 'validateDestination', signal =>
+      input.validateDestination({
+        scope: structuredClone(scope),
+        subscriberId: config.subscriber_id,
+        url,
+        signal,
+      })
+    );
   } catch {
     destinationValidation = { allowed: false };
   }
@@ -508,7 +581,18 @@ async function normalizeAuthentication(input: NormalizeConfigInput): Promise<Sto
       'authentication'
     );
   }
-  let bound: { bindingId: string };
+  if (
+    !input.dryRun &&
+    (typeof input.credentialAdapter.stage !== 'function' ||
+      typeof input.credentialAdapter.commit !== 'function' ||
+      typeof input.credentialAdapter.discard !== 'function')
+  ) {
+    throw validation(
+      'credentialAdapter.stage, commit, and discard are required for legacy authentication',
+      input.index,
+      'authentication'
+    );
+  }
   const bindingInput = {
     scope: structuredClone(input.scope),
     subscriberId: input.config.subscriber_id,
@@ -516,33 +600,78 @@ async function normalizeAuthentication(input: NormalizeConfigInput): Promise<Sto
     credential: auth.credentials,
     ...(previous?.bindingId === undefined ? {} : { previousBindingId: previous.bindingId }),
   };
-  try {
-    if (input.dryRun) {
-      bound = await input.credentialAdapter.preview(bindingInput);
-    } else {
-      bound = await input.credentialAdapter.bind(bindingInput);
+  if (input.dryRun) {
+    let preview: { outcome: 'unchanged' } | { outcome: 'changed' };
+    try {
+      preview = await runAdopterCallback(input.adopterCallbackTimeoutMs, 'credentialAdapter.preview', signal =>
+        input.credentialAdapter!.preview({ ...bindingInput, signal })
+      );
+    } catch {
+      throw validation('credential binding preview failed', input.index, 'authentication');
     }
+    if (preview?.outcome === 'unchanged') {
+      if (!previous?.bindingId) {
+        throw validation(
+          'credentialAdapter.preview cannot report unchanged without a previous binding',
+          input.index,
+          'authentication'
+        );
+      }
+      return { mode, bindingId: previous.bindingId };
+    }
+    if (preview?.outcome !== 'changed') {
+      throw validation('credentialAdapter.preview returned an invalid outcome', input.index, 'authentication');
+    }
+    // This value is never persisted or projected. A fresh opaque sentinel only
+    // makes the semantic comparison differ without hashing the credential.
+    return { mode, bindingId: `dry_${randomUUID()}` };
+  }
+
+  let stage: { outcome: 'unchanged'; bindingId: string } | { outcome: 'staged'; bindingId: string; stageId: string };
+  try {
+    stage = await runAdopterCallback(input.adopterCallbackTimeoutMs, 'credentialAdapter.stage', signal =>
+      input.credentialAdapter!.stage({ ...bindingInput, signal })
+    );
   } catch {
+    throw validation('credential binding stage failed', input.index, 'authentication');
+  }
+  if (!stage || !validOpaqueHandle(stage.bindingId, auth.credentials)) {
     throw validation(
-      input.dryRun ? 'credential binding preview failed' : 'credential binding failed',
+      'credentialAdapter.stage must return an opaque non-secret bindingId of at most 512 bytes',
       input.index,
       'authentication'
     );
+  }
+  if (stage.outcome === 'unchanged') {
+    if (!previous?.bindingId || stage.bindingId !== previous.bindingId) {
+      throw validation(
+        'credentialAdapter.stage returned unchanged without the exact previous binding',
+        input.index,
+        'authentication'
+      );
+    }
+    return { mode, bindingId: stage.bindingId };
   }
   if (
-    !bound ||
-    typeof bound.bindingId !== 'string' ||
-    bound.bindingId.length < 1 ||
-    Buffer.byteLength(bound.bindingId, 'utf8') > 512 ||
-    bound.bindingId.includes(auth.credentials)
+    stage.outcome !== 'staged' ||
+    !validOpaqueHandle(stage.stageId, auth.credentials) ||
+    stage.bindingId === previous?.bindingId
   ) {
     throw validation(
-      `credentialAdapter.${input.dryRun ? 'preview' : 'bind'} must return an opaque non-secret bindingId of at most 512 bytes`,
+      'credentialAdapter.stage must return a new immutable binding and opaque stageId for changed credentials',
       input.index,
       'authentication'
     );
   }
-  return { mode, bindingId: bound.bindingId };
+  input.credentialStages.push({
+    scope: structuredClone(input.scope),
+    subscriberId: input.config.subscriber_id,
+    mode,
+    bindingId: stage.bindingId,
+    stageId: stage.stageId,
+    ...(previous?.bindingId === undefined ? {} : { supersedesBindingId: previous.bindingId }),
+  });
+  return { mode, bindingId: stage.bindingId };
 }
 
 function projectSubscription(
@@ -757,6 +886,121 @@ function resolvedAuthenticationMatches(
     (mode === 'bearer' && authentication?.type === 'bearer' && authentication.token.length > 0) ||
     (mode === 'hmac_sha256' && authentication?.type === 'hmac_sha256' && authentication.secret.length > 0)
   );
+}
+
+function validOpaqueHandle(value: unknown, credential: string): value is string {
+  return (
+    typeof value === 'string' &&
+    value.length > 0 &&
+    Buffer.byteLength(value, 'utf8') <= 512 &&
+    !value.includes(credential)
+  );
+}
+
+async function commitCredentialStages(
+  adapter: PersistentNotificationRuntimeOptions['credentialAdapter'],
+  stages: readonly PreparedCredentialStage[],
+  timeoutMs: number,
+  onError: PersistentNotificationRuntimeOptions['onCredentialStageError']
+): Promise<void> {
+  if (stages.length === 0) return;
+  if (!adapter) return;
+  const results = await Promise.allSettled(
+    stages.map(stage =>
+      runAdopterCallback(timeoutMs, 'credentialAdapter.commit', signal => adapter.commit({ ...stage, signal }))
+    )
+  );
+  reportCredentialStageErrors('commit', stages, results, onError);
+}
+
+async function discardCredentialStages(
+  adapter: PersistentNotificationRuntimeOptions['credentialAdapter'],
+  stages: readonly PreparedCredentialStage[],
+  timeoutMs: number,
+  onError: PersistentNotificationRuntimeOptions['onCredentialStageError']
+): Promise<void> {
+  if (!adapter || stages.length === 0) return;
+  const results = await Promise.allSettled(
+    stages.map(stage =>
+      runAdopterCallback(timeoutMs, 'credentialAdapter.discard', signal =>
+        adapter.discard({
+          scope: stage.scope,
+          subscriberId: stage.subscriberId,
+          mode: stage.mode,
+          bindingId: stage.bindingId,
+          stageId: stage.stageId,
+          signal,
+        })
+      )
+    )
+  );
+  reportCredentialStageErrors('discard', stages, results, onError);
+}
+
+function reportCredentialStageErrors(
+  operation: 'commit' | 'discard',
+  stages: readonly PreparedCredentialStage[],
+  results: readonly PromiseSettledResult<void>[],
+  onError: PersistentNotificationRuntimeOptions['onCredentialStageError']
+): void {
+  if (!onError) return;
+  results.forEach((result, index) => {
+    if (result.status !== 'rejected') return;
+    const stage = stages[index]!;
+    try {
+      void Promise.resolve(
+        onError({
+          operation,
+          scope: structuredClone(stage.scope),
+          subscriberId: stage.subscriberId,
+          bindingId: stage.bindingId,
+          stageId: stage.stageId,
+          error: result.reason,
+        })
+      ).catch(() => undefined);
+    } catch {
+      // Observability must not change the durable replacement outcome.
+    }
+  });
+}
+
+async function runAdopterCallback<T>(
+  timeoutMs: number,
+  name: string,
+  invoke: (signal: AbortSignal) => T | PromiseLike<T>
+): Promise<T> {
+  const controller = new AbortController();
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(() => {
+      controller.abort();
+      reject(new Error(`${name} timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+  });
+  try {
+    return await Promise.race([Promise.resolve().then(() => invoke(controller.signal)), timeout]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+async function mapConcurrent<T, R>(
+  values: readonly T[],
+  concurrency: number,
+  mapper: (value: T, index: number) => Promise<R>
+): Promise<R[]> {
+  const results = new Array<R>(values.length);
+  let nextIndex = 0;
+  await Promise.all(
+    Array.from({ length: Math.min(concurrency, values.length) }, async () => {
+      while (true) {
+        const index = nextIndex++;
+        if (index >= values.length) return;
+        results[index] = await mapper(values[index]!, index);
+      }
+    })
+  );
+  return results;
 }
 
 function assertScope(scope: Readonly<NotificationSubscriptionScope>): void {

--- a/src/lib/server/notification-subscriptions/runtime.ts
+++ b/src/lib/server/notification-subscriptions/runtime.ts
@@ -485,7 +485,6 @@ async function normalizeAuthentication(input: NormalizeConfigInput): Promise<Sto
   const previous = input.previous?.authentication.mode === mode ? input.previous.authentication : undefined;
   if (auth.credentials === undefined) {
     if (previous?.bindingId) return { mode, bindingId: previous.bindingId };
-    if (input.dryRun && input.credentialAdapter) return { mode, bindingId: 'dry-run-unissued-binding' };
     throw validation(
       'credentials are required for a new legacy authentication binding',
       input.index,
@@ -502,18 +501,33 @@ async function normalizeAuthentication(input: NormalizeConfigInput): Promise<Sto
   if (!input.credentialAdapter) {
     throw validation('legacy authentication requires a credentialAdapter', input.index, 'authentication');
   }
-  if (input.dryRun) return { mode, bindingId: 'dry-run-unissued-binding' };
+  if (input.dryRun && typeof input.credentialAdapter.preview !== 'function') {
+    throw validation(
+      'credentialAdapter.preview is required for dry-run legacy authentication',
+      input.index,
+      'authentication'
+    );
+  }
   let bound: { bindingId: string };
+  const bindingInput = {
+    scope: structuredClone(input.scope),
+    subscriberId: input.config.subscriber_id,
+    mode,
+    credential: auth.credentials,
+    ...(previous?.bindingId === undefined ? {} : { previousBindingId: previous.bindingId }),
+  };
   try {
-    bound = await input.credentialAdapter.bind({
-      scope: structuredClone(input.scope),
-      subscriberId: input.config.subscriber_id,
-      mode,
-      credential: auth.credentials,
-      ...(previous?.bindingId === undefined ? {} : { previousBindingId: previous.bindingId }),
-    });
+    if (input.dryRun) {
+      bound = await input.credentialAdapter.preview(bindingInput);
+    } else {
+      bound = await input.credentialAdapter.bind(bindingInput);
+    }
   } catch {
-    throw validation('credential binding failed', input.index, 'authentication');
+    throw validation(
+      input.dryRun ? 'credential binding preview failed' : 'credential binding failed',
+      input.index,
+      'authentication'
+    );
   }
   if (
     !bound ||
@@ -523,7 +537,7 @@ async function normalizeAuthentication(input: NormalizeConfigInput): Promise<Sto
     bound.bindingId.includes(auth.credentials)
   ) {
     throw validation(
-      'credentialAdapter.bind must return an opaque non-secret bindingId of at most 512 bytes',
+      `credentialAdapter.${input.dryRun ? 'preview' : 'bind'} must return an opaque non-secret bindingId of at most 512 bytes`,
       input.index,
       'authentication'
     );

--- a/src/lib/server/notification-subscriptions/types.ts
+++ b/src/lib/server/notification-subscriptions/types.ts
@@ -1,0 +1,248 @@
+import type { MaybePromise } from '../create-adcp-server';
+import type {
+  RecoverableWebhookEmitter,
+  WebhookAttemptAuthorizer,
+  WebhookAuthentication,
+  WebhookEmitResult,
+} from '../webhook-emitter';
+
+export type NotificationSubscriptionScope =
+  | { kind: 'caller'; tenantId: string; principalId: string }
+  | { kind: 'account'; tenantId: string; principalId: string; accountId: string };
+
+export type NotificationEventAnchor = 'caller' | 'account';
+
+/** Structural input accepted from either generated notification-config shape. */
+export interface NotificationSubscriptionConfigInput {
+  subscriber_id: string;
+  url: string;
+  event_types: readonly string[];
+  all_authorized_accounts?: boolean;
+  include_future_event_types?: boolean;
+  product_payload_view?: 'canonical' | 'legacy';
+  authentication?: {
+    schemes: readonly ('Bearer' | 'HMAC-SHA256')[];
+    credentials?: string;
+  };
+  active?: boolean;
+}
+
+export type NotificationAuthenticationMode = 'rfc9421' | 'bearer' | 'hmac_sha256';
+
+export interface StoredNotificationAuthentication {
+  mode: NotificationAuthenticationMode;
+  /** Opaque, stable, non-secret application handle. Never a credential or credential hash. */
+  bindingId?: string;
+}
+
+export interface StoredNotificationSubscription {
+  subscriberId: string;
+  url: string;
+  eventTypes: string[];
+  active: boolean;
+  allAuthorizedAccounts: boolean;
+  includeFutureEventTypes: boolean;
+  productPayloadView?: 'canonical' | 'legacy';
+  authentication: StoredNotificationAuthentication;
+  /** Hash of the exact proof-bound destination tuple. */
+  destinationGeneration: string;
+  /** Equal to destinationGeneration only after exact-tuple proof succeeds. */
+  proofGeneration?: string;
+}
+
+export interface NotificationSubscriptionSet {
+  scope: NotificationSubscriptionScope;
+  /** Opaque CAS token for the whole declarative set. */
+  generation: string;
+  subscriptions: StoredNotificationSubscription[];
+}
+
+export interface NotificationSubscriptionMatch {
+  anchor: NotificationEventAnchor;
+  tenantId: string;
+  principalId?: string;
+  accountId?: string;
+  eventType: string;
+  /** This event was explicitly classified by the server as future, caller-only, and invalidation-only. */
+  futureCallerInvalidation?: boolean;
+}
+
+export type NotificationSubscriptionStoreReplaceResult =
+  | { outcome: 'applied'; set: NotificationSubscriptionSet }
+  | { outcome: 'unchanged'; set: NotificationSubscriptionSet }
+  | { outcome: 'conflict'; currentGeneration?: string };
+
+export interface NotificationSubscriptionStore {
+  readonly durability: 'process-local' | 'durable';
+  probe?(): Promise<void>;
+  get(scope: Readonly<NotificationSubscriptionScope>): MaybePromise<NotificationSubscriptionSet | null>;
+  /**
+   * Atomic full-set replacement. `expectedGeneration: null` means the scope
+   * must not exist; a string must match exactly.
+   */
+  replace(args: {
+    scope: Readonly<NotificationSubscriptionScope>;
+    expectedGeneration: string | null;
+    nextGeneration: string;
+    subscriptions: readonly StoredNotificationSubscription[];
+  }): MaybePromise<NotificationSubscriptionStoreReplaceResult>;
+  /** Returns at most `limit + 1` sets so the runtime can fail closed on truncation. */
+  findCandidates(
+    match: Readonly<NotificationSubscriptionMatch>,
+    limit: number
+  ): MaybePromise<NotificationSubscriptionSet[]>;
+}
+
+export interface NotificationCredentialBindingAdapter {
+  /**
+   * Store or rotate a write-only credential and return a stable opaque
+   * binding. Rebinding the same credential for the same tuple should return
+   * the same binding so exact retries stay idempotent.
+   */
+  bind(input: {
+    scope: Readonly<NotificationSubscriptionScope>;
+    subscriberId: string;
+    mode: Exclude<NotificationAuthenticationMode, 'rfc9421'>;
+    credential: string;
+    previousBindingId?: string;
+  }): MaybePromise<{ bindingId: string }>;
+  /** Resolve only after live subscription and application authorization succeed. */
+  resolve(input: {
+    scope: Readonly<NotificationSubscriptionScope>;
+    subscriberId: string;
+    destinationGeneration: string;
+    mode: Exclude<NotificationAuthenticationMode, 'rfc9421'>;
+    bindingId: string;
+  }): MaybePromise<WebhookAuthentication>;
+}
+
+export interface NotificationProofAdapter {
+  prove(input: {
+    scope: Readonly<NotificationSubscriptionScope>;
+    subscriberId: string;
+    url: string;
+    eventTypes: readonly string[];
+    authentication: Readonly<StoredNotificationAuthentication>;
+    destinationGeneration: string;
+  }): MaybePromise<{ proved: true } | { proved: false }>;
+}
+
+export type NotificationDestinationValidator = (input: {
+  scope: Readonly<NotificationSubscriptionScope>;
+  subscriberId: string;
+  url: string;
+}) => MaybePromise<{ allowed: true } | { allowed: false }>;
+
+export interface NotificationDeliveryAuthorizationInput {
+  scope: Readonly<NotificationSubscriptionScope>;
+  eventAnchor: NotificationEventAnchor;
+  /** Account whose data the event carries, including for caller-scoped all-account subscribers. */
+  accountId?: string;
+  subscriberId: string;
+  destinationGeneration: string;
+  eventType: string;
+  notificationId: string;
+}
+
+export type NotificationDeliveryAuthorizer = (
+  input: Readonly<NotificationDeliveryAuthorizationInput>
+) => MaybePromise<{ authorized: true } | { authorized: false }>;
+
+export interface NotificationEvent {
+  /** Application-stable identity for this delivery event; reuse on crash retry, rotate on re-emission. */
+  emissionId: string;
+  /** Logical protocol identity. Keep stable when the same event is re-emitted. */
+  notificationId: string;
+  notificationType: string;
+  anchor: NotificationEventAnchor;
+  tenantId: string;
+  /** Restrict fanout to one authenticated caller; omit only for deliberate tenant-wide fanout. */
+  principalId?: string;
+  /** Required for account-anchored events. */
+  accountId?: string;
+  payload: Record<string, unknown>;
+}
+
+export interface NotificationSubscriptionView {
+  subscriber_id: string;
+  url: string;
+  event_types: string[];
+  active: boolean;
+  all_authorized_accounts?: boolean;
+  include_future_event_types?: boolean;
+  product_payload_view?: 'canonical' | 'legacy';
+  authentication?: { schemes: ['Bearer'] | ['HMAC-SHA256'] };
+  destination_generation?: string;
+  proof_generation?: string;
+}
+
+export class NotificationSubscriptionValidationError extends Error {
+  override readonly name = 'NotificationSubscriptionValidationError';
+  constructor(
+    message: string,
+    readonly field?: string
+  ) {
+    super(message);
+  }
+}
+
+export type NotificationReplacementResult =
+  | {
+      outcome: 'applied' | 'unchanged' | 'cleared' | 'validated';
+      generation?: string;
+      notificationConfigs: NotificationSubscriptionView[];
+      /** Present on dry-run validation. */
+      wouldChange?: boolean;
+    }
+  | { outcome: 'conflict'; currentGeneration?: string }
+  | { outcome: 'proof_failed'; subscriberId: string };
+
+export interface NotificationFanoutDelivery {
+  scope: NotificationSubscriptionScope;
+  subscriberId: string;
+  destinationGeneration: string;
+  result: WebhookEmitResult;
+}
+
+export interface NotificationFanoutResult {
+  notificationId: string;
+  emissionId: string;
+  matched: number;
+  deliveries: NotificationFanoutDelivery[];
+}
+
+export interface PersistentNotificationRuntimeOptions {
+  store: NotificationSubscriptionStore;
+  proofAdapter: NotificationProofAdapter;
+  credentialAdapter?: NotificationCredentialBindingAdapter;
+  authorizeDelivery: NotificationDeliveryAuthorizer;
+  /** Defaults to DNS resolution plus the SDK's strict webhook SSRF policy. */
+  validateDestination?: NotificationDestinationValidator;
+  /** Build the emitter with the supplied mandatory per-attempt authorizer. */
+  createEmitter(authorizeAttempt: WebhookAttemptAuthorizer): RecoverableWebhookEmitter;
+  supportedCallerEventTypes?: readonly string[];
+  supportedAccountEventTypes?: readonly string[];
+  /**
+   * Later-version caller-only events safe for `include_future_event_types`.
+   * Every listed type MUST be invalidation-only; the adopting application owns
+   * that classification and payload construction.
+   */
+  futureCallerInvalidationEventTypes?: readonly string[];
+  maxFanoutCandidates?: number;
+}
+
+export interface PersistentNotificationRuntime {
+  readonly store: NotificationSubscriptionStore;
+  readonly emitter: RecoverableWebhookEmitter;
+  readonly authorizeWebhookAttempt: WebhookAttemptAuthorizer;
+  replace(
+    scope: Readonly<NotificationSubscriptionScope>,
+    configs: readonly NotificationSubscriptionConfigInput[],
+    options?: { expectedGeneration?: string; dryRun?: boolean }
+  ): Promise<NotificationReplacementResult>;
+  read(scope: Readonly<NotificationSubscriptionScope>): Promise<{
+    generation?: string;
+    notificationConfigs: NotificationSubscriptionView[];
+  }>;
+  emit(event: Readonly<NotificationEvent>): Promise<NotificationFanoutResult>;
+}

--- a/src/lib/server/notification-subscriptions/types.ts
+++ b/src/lib/server/notification-subscriptions/types.ts
@@ -95,9 +95,21 @@ export interface NotificationSubscriptionStore {
 
 export interface NotificationCredentialBindingAdapter {
   /**
+   * Resolve the stable opaque binding that `bind()` would return without
+   * persisting or rotating the credential. Dry-run replacement uses this to
+   * compare the exact destination tuple without causing a secret-store write.
+   */
+  preview(input: {
+    scope: Readonly<NotificationSubscriptionScope>;
+    subscriberId: string;
+    mode: Exclude<NotificationAuthenticationMode, 'rfc9421'>;
+    credential: string;
+    previousBindingId?: string;
+  }): MaybePromise<{ bindingId: string }>;
+  /**
    * Store or rotate a write-only credential and return a stable opaque
-   * binding. Rebinding the same credential for the same tuple should return
-   * the same binding so exact retries stay idempotent.
+   * binding. It must return the same binding as `preview()` for the same
+   * credential and tuple, and rebinding that tuple must remain idempotent.
    */
   bind(input: {
     scope: Readonly<NotificationSubscriptionScope>;

--- a/src/lib/server/notification-subscriptions/types.ts
+++ b/src/lib/server/notification-subscriptions/types.ts
@@ -95,9 +95,8 @@ export interface NotificationSubscriptionStore {
 
 export interface NotificationCredentialBindingAdapter {
   /**
-   * Resolve the stable opaque binding that `bind()` would return without
-   * persisting or rotating the credential. Dry-run replacement uses this to
-   * compare the exact destination tuple without causing a secret-store write.
+   * Compare a credential with the immutable binding already on the tuple.
+   * This MUST NOT write, rotate, hash, or otherwise expose the credential.
    */
   preview(input: {
     scope: Readonly<NotificationSubscriptionScope>;
@@ -105,19 +104,56 @@ export interface NotificationCredentialBindingAdapter {
     mode: Exclude<NotificationAuthenticationMode, 'rfc9421'>;
     credential: string;
     previousBindingId?: string;
-  }): MaybePromise<{ bindingId: string }>;
+    signal: AbortSignal;
+  }): MaybePromise<{ outcome: 'unchanged' } | { outcome: 'changed' }>;
   /**
-   * Store or rotate a write-only credential and return a stable opaque
-   * binding. It must return the same binding as `preview()` for the same
-   * credential and tuple, and rebinding that tuple must remain idempotent.
+   * Stage a write-only credential under an immutable, versioned opaque
+   * binding. Never mutate an existing binding in place. A new or changed
+   * credential MUST return `staged` with a bindingId different from
+   * previousBindingId. Every `staged` outcome owns a fresh binding that is not
+   * shared with another staging operation, even when concurrent operations
+   * supply the same credential. A stage must be durable and resolvable for
+   * proof and post-CAS delivery.
    */
-  bind(input: {
+  stage(input: {
     scope: Readonly<NotificationSubscriptionScope>;
     subscriberId: string;
     mode: Exclude<NotificationAuthenticationMode, 'rfc9421'>;
     credential: string;
     previousBindingId?: string;
-  }): MaybePromise<{ bindingId: string }>;
+    signal: AbortSignal;
+  }): MaybePromise<
+    { outcome: 'unchanged'; bindingId: string } | { outcome: 'staged'; bindingId: string; stageId: string }
+  >;
+  /**
+   * Finalize a stage after the subscription CAS references its binding.
+   * Idempotent. This is post-CAS bookkeeping and must own its monitoring and
+   * retry path; failure cannot roll back the durable subscription reference.
+   */
+  commit(input: {
+    scope: Readonly<NotificationSubscriptionScope>;
+    subscriberId: string;
+    mode: Exclude<NotificationAuthenticationMode, 'rfc9421'>;
+    bindingId: string;
+    stageId: string;
+    /** Retire only after a grace period for already-authorized in-flight sends. */
+    supersedesBindingId?: string;
+    signal: AbortSignal;
+  }): MaybePromise<void>;
+  /**
+   * Discard an unreferenced stage after validation/proof/CAS failure.
+   * Idempotent. It MUST NOT affect any other stage or committed binding. The
+   * adapter must reap abandoned stages because a process can fail before this
+   * callback, or a callback can ignore its aborted signal and complete late.
+   */
+  discard(input: {
+    scope: Readonly<NotificationSubscriptionScope>;
+    subscriberId: string;
+    mode: Exclude<NotificationAuthenticationMode, 'rfc9421'>;
+    bindingId: string;
+    stageId: string;
+    signal: AbortSignal;
+  }): MaybePromise<void>;
   /** Resolve only after live subscription and application authorization succeed. */
   resolve(input: {
     scope: Readonly<NotificationSubscriptionScope>;
@@ -125,6 +161,7 @@ export interface NotificationCredentialBindingAdapter {
     destinationGeneration: string;
     mode: Exclude<NotificationAuthenticationMode, 'rfc9421'>;
     bindingId: string;
+    signal: AbortSignal;
   }): MaybePromise<WebhookAuthentication>;
 }
 
@@ -136,6 +173,7 @@ export interface NotificationProofAdapter {
     eventTypes: readonly string[];
     authentication: Readonly<StoredNotificationAuthentication>;
     destinationGeneration: string;
+    signal: AbortSignal;
   }): MaybePromise<{ proved: true } | { proved: false }>;
 }
 
@@ -143,6 +181,7 @@ export type NotificationDestinationValidator = (input: {
   scope: Readonly<NotificationSubscriptionScope>;
   subscriberId: string;
   url: string;
+  signal: AbortSignal;
 }) => MaybePromise<{ allowed: true } | { allowed: false }>;
 
 export interface NotificationDeliveryAuthorizationInput {
@@ -154,6 +193,7 @@ export interface NotificationDeliveryAuthorizationInput {
   destinationGeneration: string;
   eventType: string;
   notificationId: string;
+  signal: AbortSignal;
 }
 
 export type NotificationDeliveryAuthorizer = (
@@ -209,12 +249,14 @@ export type NotificationReplacementResult =
   | { outcome: 'conflict'; currentGeneration?: string }
   | { outcome: 'proof_failed'; subscriberId: string };
 
-export interface NotificationFanoutDelivery {
+interface NotificationFanoutDeliveryBase {
   scope: NotificationSubscriptionScope;
   subscriberId: string;
   destinationGeneration: string;
-  result: WebhookEmitResult;
 }
+
+export type NotificationFanoutDelivery = NotificationFanoutDeliveryBase &
+  ({ result: WebhookEmitResult; failure?: never } | { result?: never; failure: { reason: 'delivery_runtime_error' } });
 
 export interface NotificationFanoutResult {
   notificationId: string;
@@ -241,6 +283,26 @@ export interface PersistentNotificationRuntimeOptions {
    */
   futureCallerInvalidationEventTypes?: readonly string[];
   maxFanoutCandidates?: number;
+  /** Maximum simultaneous subscriber retry cycles. Defaults to 8. */
+  fanoutConcurrency?: number;
+  /**
+   * Timeout for policy, credential, proof, and destination callbacks. Defaults
+   * to 30 seconds. Store operations must enforce transaction-level deadlines;
+   * the runtime cannot safely abandon a mutating CAS that may commit late.
+   */
+  adopterCallbackTimeoutMs?: number;
+  /**
+   * Non-blocking observer for failed post-stage commit/discard bookkeeping.
+   * Observer failures never change the already-decided replacement outcome.
+   */
+  onCredentialStageError?: (event: {
+    operation: 'commit' | 'discard';
+    scope: NotificationSubscriptionScope;
+    subscriberId: string;
+    bindingId: string;
+    stageId: string;
+    error: unknown;
+  }) => MaybePromise<void>;
 }
 
 export interface PersistentNotificationRuntime {

--- a/src/lib/server/webhook-delivery/recovery.ts
+++ b/src/lib/server/webhook-delivery/recovery.ts
@@ -60,6 +60,8 @@ export interface WebhookAuthenticationContext {
 export interface StoredWebhookDeliverySnapshot {
   url: string;
   payload: Record<string, unknown>;
+  /** Non-secret live-authorization context; never serialized into the webhook body. */
+  attemptAuthorizationContext?: Record<string, unknown>;
   authentication: { kind: 'none' } | { kind: 'protected'; protectedValue: unknown; fingerprint: string };
   /**
    * A top-level task-webhook `token`, protected independently from transport
@@ -537,6 +539,9 @@ async function protectSnapshot(
     url: snapshot.url,
     payload,
     retries: { ...snapshot.retries },
+    ...(snapshot.attemptAuthorizationContext === undefined
+      ? {}
+      : { attemptAuthorizationContext: structuredClone(snapshot.attemptAuthorizationContext) }),
   };
   // Canonicalization validates every stored field as plain JSON.
   canonicalJsonSha256(base);
@@ -601,6 +606,9 @@ async function resolveSnapshot(
       payload,
       authentication,
       retries: { ...snapshot.retries },
+      ...(snapshot.attemptAuthorizationContext === undefined
+        ? {}
+        : { attemptAuthorizationContext: structuredClone(snapshot.attemptAuthorizationContext) }),
     };
   } catch (cause) {
     if (cause instanceof WebhookAuthenticationResolutionError) throw cause;
@@ -610,7 +618,7 @@ async function resolveSnapshot(
 
 function authenticationContext(
   key: Readonly<WebhookDeliveryKey>,
-  snapshot: Pick<StoredWebhookDeliverySnapshot, 'url' | 'payload' | 'retries'>,
+  snapshot: Pick<StoredWebhookDeliverySnapshot, 'url' | 'payload' | 'retries' | 'attemptAuthorizationContext'>,
   purpose?: 'payload_token'
 ): WebhookAuthenticationContext {
   const base = {
@@ -627,6 +635,9 @@ function authenticationContext(
         url: snapshot.url,
         payload: snapshot.payload,
         retries: snapshot.retries,
+        ...(snapshot.attemptAuthorizationContext === undefined
+          ? {}
+          : { attemptAuthorizationContext: snapshot.attemptAuthorizationContext }),
       }),
     };
   }
@@ -639,6 +650,9 @@ function authenticationContext(
       url: snapshot.url,
       payload: snapshot.payload,
       retries: snapshot.retries,
+      ...(snapshot.attemptAuthorizationContext === undefined
+        ? {}
+        : { attemptAuthorizationContext: snapshot.attemptAuthorizationContext }),
     }),
   };
 }
@@ -703,6 +717,9 @@ function snapshotFingerprint(snapshot: StoredWebhookDeliverySnapshot): string {
     url: snapshot.url,
     payload: snapshot.payload,
     retries: snapshot.retries,
+    ...(snapshot.attemptAuthorizationContext === undefined
+      ? {}
+      : { attemptAuthorizationContext: snapshot.attemptAuthorizationContext }),
     authentication:
       snapshot.authentication.kind === 'none'
         ? { kind: 'none' }

--- a/src/lib/server/webhook-emitter.ts
+++ b/src/lib/server/webhook-emitter.ts
@@ -98,6 +98,13 @@ export interface WebhookDeliverySnapshot {
   payload: Record<string, unknown>;
   authentication: WebhookAuthentication;
   retries: Required<WebhookRetryOptions>;
+  /**
+   * Non-secret application context used to re-authorize every external
+   * attempt, including attempts reconstructed from a durable outbox. This is
+   * stored with the recovery snapshot but is never included in the webhook
+   * body. Callers MUST NOT put credentials or bearer material here.
+   */
+  attemptAuthorizationContext?: Record<string, unknown>;
 }
 
 /**
@@ -321,6 +328,17 @@ export interface WebhookEmitterOptions {
   /** Observability hook called AFTER each attempt completes. */
   onAttemptResult?: (info: WebhookEmitAttemptResult) => void;
   /**
+   * Fail-closed authorization hook invoked immediately before every external
+   * POST, including each in-process retry and every recovered attempt. A
+   * suppression is terminal for this delivery identity. Throwing is treated
+   * as `authorization_error` and never falls through to network delivery.
+   *
+   * The hook may resolve write-only authentication just in time. This lets a
+   * persistent subscription runtime keep only an opaque credential binding in
+   * its store and keep the clear credential out of recovery snapshots.
+   */
+  authorizeAttempt?: WebhookAttemptAuthorizer;
+  /**
    * Sleeper override. Production uses `setTimeout`; tests inject a stub to
    * skip real backoff. Takes (ms, abortSignal) and resolves when slept.
    */
@@ -357,6 +375,12 @@ export interface WebhookEmitParams {
   authentication?: WebhookAuthentication;
   /** Per-emit retries override. */
   retries?: WebhookRetryOptions;
+  /**
+   * Non-secret context for `authorizeAttempt`. It is durably snapshotted so a
+   * restarted worker can re-check the exact subscription generation. It is
+   * never serialized into the webhook payload.
+   */
+  attemptAuthorizationContext?: Record<string, unknown>;
 }
 
 export interface WebhookEmitAttempt {
@@ -364,7 +388,30 @@ export interface WebhookEmitAttempt {
   idempotency_key: string;
   attempt: number;
   url: string;
+  /** Durable non-secret context supplied by the emission owner. */
+  attemptAuthorizationContext?: Record<string, unknown>;
 }
+
+export type WebhookAttemptSuppressionReason =
+  | 'authorization_denied'
+  | 'authorization_error'
+  | 'subscription_missing'
+  | 'subscription_inactive'
+  | 'subscription_stale'
+  | 'event_not_allowed'
+  | 'credential_unavailable';
+
+export type WebhookAttemptAuthorizationDecision =
+  | {
+      decision: 'allow';
+      /** Optional just-in-time override; `null` explicitly selects RFC 9421. */
+      authentication?: WebhookAuthentication;
+    }
+  | { decision: 'suppress'; reason: WebhookAttemptSuppressionReason };
+
+export type WebhookAttemptAuthorizer = (
+  info: Readonly<WebhookEmitAttempt>
+) => Promise<WebhookAttemptAuthorizationDecision> | WebhookAttemptAuthorizationDecision;
 
 export interface WebhookEmitAttemptResult extends WebhookEmitAttempt {
   status?: number;
@@ -376,6 +423,7 @@ export interface WebhookEmitAttemptResult extends WebhookEmitAttempt {
 export interface WebhookEmitResult {
   delivery_id: string;
   idempotency_key: string;
+  /** Number of external HTTP attempts; authorization suppression before network access reports zero. */
   attempts: number;
   delivered: boolean;
   /** True only when the final outcome is known to be non-retryable. */
@@ -383,6 +431,8 @@ export interface WebhookEmitResult {
   final_status?: number;
   /** Sanitized per-attempt failure classifications; nested provider/backend messages are never copied here. */
   errors: string[];
+  /** Present when live delivery authority failed closed before an external attempt. */
+  suppression?: { reason: WebhookAttemptSuppressionReason };
 }
 
 export interface WebhookEmitter {
@@ -459,6 +509,9 @@ export function createWebhookEmitter(options: WebhookEmitterOptions): Recoverabl
         payload: delivery.snapshot.payload,
         authentication: delivery.snapshot.authentication,
         retries: delivery.snapshot.retries,
+        ...(delivery.snapshot.attemptAuthorizationContext === undefined
+          ? {}
+          : { attemptAuthorizationContext: delivery.snapshot.attemptAuthorizationContext }),
         delivery_id: delivery.key.deliveryId,
         __recoveryClaim: delivery,
       } as WebhookEmitParams & { __recoveryClaim: WebhookDeliveryRecoveryClaim });
@@ -479,8 +532,13 @@ export function createWebhookEmitter(options: WebhookEmitterOptions): Recoverabl
       const url = params.url;
       const payloadSnapshot = structuredClone(params.payload);
       const authentication = params.authentication == null ? null : structuredClone(params.authentication);
+      const attemptAuthorizationContext =
+        params.attemptAuthorizationContext === undefined
+          ? undefined
+          : structuredClone(params.attemptAuthorizationContext);
       const retries = resolveRetries(params.retries === undefined ? options.retries : structuredClone(params.retries));
       assertIJson(payloadSnapshot);
+      if (attemptAuthorizationContext !== undefined) assertIJson(attemptAuthorizationContext);
       const deliveryKey = { publisherScope, tenantScope: boundTenantScope, deliveryId };
       const recoveredClaim = (params as WebhookEmitParams & { __recoveryClaim?: WebhookDeliveryRecoveryClaim })
         .__recoveryClaim;
@@ -491,6 +549,9 @@ export function createWebhookEmitter(options: WebhookEmitterOptions): Recoverabl
           payload: structuredClone(payloadSnapshot),
           authentication: authentication === null ? null : structuredClone(authentication),
           retries: { ...retries },
+          ...(attemptAuthorizationContext === undefined
+            ? {}
+            : { attemptAuthorizationContext: structuredClone(attemptAuthorizationContext) }),
         }));
       const recoveryHeartbeat = recoveryClaim ? startRecoveryClaimHeartbeat(recoveryClaim) : undefined;
       try {
@@ -529,7 +590,6 @@ export function createWebhookEmitter(options: WebhookEmitterOptions): Recoverabl
         let attempts = 0;
 
         for (let attempt = 1; attempt <= retries.maxAttempts; attempt++) {
-          attempts = attempt;
           await recoveryHeartbeat?.renewNow();
           if (attempt > 1) {
             binding = await refreshDeliveryBinding(store, deliveryKey, binding, retryHorizonSeconds);
@@ -540,7 +600,49 @@ export function createWebhookEmitter(options: WebhookEmitterOptions): Recoverabl
             idempotency_key,
             attempt,
             url,
+            ...(attemptAuthorizationContext === undefined
+              ? {}
+              : { attemptAuthorizationContext: structuredClone(attemptAuthorizationContext) }),
           };
+
+          let attemptAuthentication = authentication;
+          if (options.authorizeAttempt) {
+            let authorization: WebhookAttemptAuthorizationDecision;
+            try {
+              authorization = await options.authorizeAttempt(attemptInfo);
+              assertAttemptAuthorizationDecision(authorization);
+            } catch {
+              authorization = { decision: 'suppress', reason: 'authorization_error' };
+            }
+            if (authorization.decision === 'suppress') {
+              await recoveryHeartbeat?.stop();
+              const heartbeatError = recoveryHeartbeat?.lossMessage();
+              if (heartbeatError) errors.push(heartbeatError);
+              if (!recoveredClaim) {
+                if (recoveryClaim) {
+                  if (!heartbeatError && !(await recoveryClaim.settle('terminal'))) {
+                    errors.push('suppressed delivery could not settle its recovery lease');
+                  }
+                } else {
+                  await options.deliveryRecovery?.settle(deliveryKey, 'terminal');
+                }
+              }
+              return {
+                delivery_id: deliveryId,
+                idempotency_key,
+                attempts,
+                delivered: false,
+                terminal: true,
+                errors,
+                suppression: { reason: authorization.reason },
+              };
+            }
+            if ('authentication' in authorization) {
+              attemptAuthentication =
+                authorization.authentication == null ? null : structuredClone(authorization.authentication);
+            }
+          }
+          attempts = attempt;
           options.onAttempt?.(attemptInfo);
 
           const started = Date.now();
@@ -554,7 +656,7 @@ export function createWebhookEmitter(options: WebhookEmitterOptions): Recoverabl
               bodyBytes,
               signerKey: options.signerKey,
               signerProvider: options.signerProvider,
-              authentication,
+              authentication: attemptAuthentication,
               tag: options.tag,
               userAgent: options.userAgent,
               fetch: fetchImpl,
@@ -653,6 +755,42 @@ export function createWebhookEmitter(options: WebhookEmitterOptions): Recoverabl
     },
   });
   return makeEmitter(tenantScope);
+}
+
+function assertAttemptAuthorizationDecision(value: unknown): asserts value is WebhookAttemptAuthorizationDecision {
+  if (value == null || typeof value !== 'object') {
+    throw new TypeError('authorizeAttempt must return an authorization decision');
+  }
+  const decision = value as { decision?: unknown; reason?: unknown; authentication?: unknown };
+  if (decision.decision === 'allow') {
+    if ('authentication' in decision) assertWebhookAuthentication(decision.authentication);
+    return;
+  }
+  if (
+    decision.decision !== 'suppress' ||
+    ![
+      'authorization_denied',
+      'authorization_error',
+      'subscription_missing',
+      'subscription_inactive',
+      'subscription_stale',
+      'event_not_allowed',
+      'credential_unavailable',
+    ].includes(String(decision.reason))
+  ) {
+    throw new TypeError('authorizeAttempt returned an invalid authorization decision');
+  }
+}
+
+function assertWebhookAuthentication(value: unknown): asserts value is WebhookAuthentication {
+  if (value === null) return;
+  if (value == null || typeof value !== 'object') {
+    throw new TypeError('authorizeAttempt authentication must be null, bearer, or hmac_sha256');
+  }
+  const auth = value as { type?: unknown; token?: unknown; secret?: unknown };
+  if (auth.type === 'bearer' && typeof auth.token === 'string' && auth.token.length > 0) return;
+  if (auth.type === 'hmac_sha256' && typeof auth.secret === 'string' && auth.secret.length > 0) return;
+  throw new TypeError('authorizeAttempt authentication must be null, bearer, or hmac_sha256');
 }
 
 interface RecoveryClaimHeartbeat {

--- a/test/lib/persistent-notification-runtime.test.js
+++ b/test/lib/persistent-notification-runtime.test.js
@@ -1,6 +1,6 @@
 const { test, after } = require('node:test');
 const assert = require('node:assert/strict');
-const { createHash, generateKeyPairSync, randomBytes } = require('node:crypto');
+const { generateKeyPairSync, randomBytes } = require('node:crypto');
 const { spawnSync } = require('node:child_process');
 
 const {
@@ -55,6 +55,7 @@ function makeRuntime({
   retries = { maxAttempts: 1, initialDelayMs: 0, maxDelayMs: 0, jitter: 0 },
   sleep = async () => {},
   runtimeOptions = {},
+  emitterFactory,
 } = {}) {
   const store = memoryNotificationSubscriptionStore();
   const runtime = createPersistentNotificationRuntime({
@@ -64,16 +65,68 @@ function makeRuntime({
     validateDestination: async () => ({ allowed: true }),
     credentialAdapter,
     ...runtimeOptions,
-    createEmitter: authorizeAttempt =>
-      createWebhookEmitter({
-        signerKey: signerKey(),
-        fetch,
-        retries,
-        sleep,
-        authorizeAttempt,
-      }),
+    createEmitter:
+      emitterFactory ??
+      (authorizeAttempt =>
+        createWebhookEmitter({
+          signerKey: signerKey(),
+          fetch,
+          retries,
+          sleep,
+          authorizeAttempt,
+        })),
   });
   return { runtime, store, fetch };
+}
+
+function createVersionedCredentialAdapter() {
+  let sequence = 0;
+  const bindings = new Map();
+  const calls = { previews: [], stages: [], commits: [], discards: [], resolves: [] };
+  const adapter = {
+    preview(input) {
+      calls.previews.push(input);
+      const previous = input.previousBindingId && bindings.get(input.previousBindingId);
+      return { outcome: previous?.credential === input.credential ? 'unchanged' : 'changed' };
+    },
+    stage(input) {
+      const previous = input.previousBindingId && bindings.get(input.previousBindingId);
+      if (previous?.credential === input.credential) {
+        const result = { outcome: 'unchanged', bindingId: input.previousBindingId };
+        calls.stages.push({ ...input, ...result });
+        return result;
+      }
+      sequence++;
+      const bindingId = `vault-binding-${sequence}`;
+      const stageId = `vault-stage-${sequence}`;
+      const record = { bindingId, stageId, credential: input.credential, committed: false };
+      bindings.set(bindingId, record);
+      const result = { outcome: 'staged', bindingId, stageId };
+      calls.stages.push({ ...input, ...result });
+      return result;
+    },
+    commit(input) {
+      calls.commits.push(input);
+      const record = bindings.get(input.bindingId);
+      if (!record || record.stageId !== input.stageId) throw new Error('unknown stage');
+      record.committed = true;
+    },
+    discard(input) {
+      calls.discards.push(input);
+      const record = bindings.get(input.bindingId);
+      if (!record || record.committed) return;
+      bindings.delete(input.bindingId);
+    },
+    resolve(input) {
+      calls.resolves.push(input);
+      const record = bindings.get(input.bindingId);
+      if (!record) throw new Error('unknown binding');
+      return input.mode === 'bearer'
+        ? { type: 'bearer', token: record.credential }
+        : { type: 'hmac_sha256', secret: record.credential };
+    },
+  };
+  return { adapter, bindings, calls };
 }
 
 const callerA = { kind: 'caller', tenantId: 'seller-us', principalId: 'buyer-a' };
@@ -285,10 +338,18 @@ test('changed active tuple is proved before CAS and proof failure preserves the 
 });
 
 test('account event fans out independently to account and all-authorized caller subscribers', async () => {
-  const fetch = scriptedFetch([500, 204, 500, 204]);
+  const attemptsByUrl = new Map();
+  const calls = [];
+  const retryingFetch = async (url, init) => {
+    calls.push({ url, init, body: JSON.parse(init.body) });
+    const attempt = (attemptsByUrl.get(url) ?? 0) + 1;
+    attemptsByUrl.set(url, attempt);
+    return { status: attempt === 1 ? 500 : 204, headers: { get: () => undefined } };
+  };
+  retryingFetch.calls = calls;
   let authorizationChecks = 0;
   const { runtime } = makeRuntime({
-    fetch,
+    fetch: retryingFetch,
     retries: { maxAttempts: 2, initialDelayMs: 0, maxDelayMs: 0, jitter: 0 },
     authorize: async () => {
       authorizationChecks++;
@@ -323,14 +384,14 @@ test('account event fans out independently to account and all-authorized caller 
   });
   assert.equal(result.matched, 2);
   assert.equal(result.deliveries.length, 2);
-  assert.equal(fetch.calls.length, 4);
+  assert.equal(retryingFetch.calls.length, 4);
   assert.equal(authorizationChecks, 4, 'authorization is re-evaluated before every retry');
-  assert.deepEqual(new Set(fetch.calls.map(call => call.body.notification_id)), new Set(['change-42']));
-  assert.equal(new Set(fetch.calls.map(call => call.body.subscriber_id)).size, 2);
+  assert.deepEqual(new Set(retryingFetch.calls.map(call => call.body.notification_id)), new Set(['change-42']));
+  assert.equal(new Set(retryingFetch.calls.map(call => call.body.subscriber_id)).size, 2);
   for (const subscriber of ['account-hook', 'principal-hook']) {
-    const calls = fetch.calls.filter(call => call.body.subscriber_id === subscriber);
-    assert.equal(calls.length, 2);
-    assert.equal(calls[0].body.idempotency_key, calls[1].body.idempotency_key);
+    const subscriberCalls = retryingFetch.calls.filter(call => call.body.subscriber_id === subscriber);
+    assert.equal(subscriberCalls.length, 2);
+    assert.equal(subscriberCalls[0].body.idempotency_key, subscriberCalls[1].body.idempotency_key);
   }
 });
 
@@ -380,21 +441,8 @@ test('deactivation during retry suppresses old work before the second external a
 
 test('legacy credentials remain write-only and resolve only after per-attempt authorization', async () => {
   const secret = 'secret-material-with-at-least-32-characters';
-  let resolves = 0;
-  const credentialAdapter = {
-    preview({ credential }) {
-      return { bindingId: `vault_${createHash('sha256').update(credential).digest('hex')}` };
-    },
-    bind({ credential }) {
-      return { bindingId: `vault_${createHash('sha256').update(credential).digest('hex')}` };
-    },
-    resolve({ mode }) {
-      resolves++;
-      assert.equal(mode, 'bearer');
-      return { type: 'bearer', token: secret };
-    },
-  };
-  const { runtime, store } = makeRuntime({ credentialAdapter });
+  const credentials = createVersionedCredentialAdapter();
+  const { runtime, store } = makeRuntime({ credentialAdapter: credentials.adapter });
   await runtime.replace(accountA, [
     {
       subscriber_id: 'legacy',
@@ -418,29 +466,15 @@ test('legacy credentials remain write-only and resolve only after per-attempt au
     accountId: 'account-1',
     payload: { reporting_run_id: 'run-1' },
   });
-  assert.equal(resolves, 1);
+  assert.equal(credentials.calls.resolves.length, 1);
+  assert.equal(credentials.calls.resolves[0].mode, 'bearer');
 });
 
 test('legacy credential dry-run previews use the stable binding without writing', async () => {
   const secret = 'secret-material-with-at-least-32-characters';
   const rotatedSecret = 'rotated-material-with-at-least-32-characters';
-  let previews = 0;
-  let binds = 0;
-  const binding = credential => `vault_${createHash('sha256').update(credential).digest('hex')}`;
-  const credentialAdapter = {
-    preview({ credential }) {
-      previews++;
-      return { bindingId: binding(credential) };
-    },
-    bind({ credential }) {
-      binds++;
-      return { bindingId: binding(credential) };
-    },
-    resolve() {
-      return { type: 'bearer', token: secret };
-    },
-  };
-  const { runtime } = makeRuntime({ credentialAdapter });
+  const credentials = createVersionedCredentialAdapter();
+  const { runtime } = makeRuntime({ credentialAdapter: credentials.adapter });
   const config = credential => ({
     subscriber_id: 'legacy-preview',
     url: 'https://buyer.example/legacy-preview',
@@ -450,27 +484,30 @@ test('legacy credential dry-run previews use the stable binding without writing'
 
   const applied = await runtime.replace(accountA, [config(secret)]);
   assert.equal(applied.outcome, 'applied');
-  assert.equal(binds, 1);
+  assert.equal(credentials.calls.stages.length, 1);
+  assert.equal(credentials.calls.commits.length, 1);
 
   const unchanged = await runtime.replace(accountA, [config(secret)], { dryRun: true });
   assert.equal(unchanged.outcome, 'validated');
   assert.equal(unchanged.wouldChange, false);
-  assert.equal(binds, 1, 'dry-run must not persist or rotate a credential');
+  assert.equal(credentials.calls.stages.length, 1, 'dry-run must not stage or rotate a credential');
 
   const changed = await runtime.replace(accountA, [config(rotatedSecret)], { dryRun: true });
   assert.equal(changed.outcome, 'validated');
   assert.equal(changed.wouldChange, true);
-  assert.equal(binds, 1);
-  assert.equal(previews, 2);
+  assert.equal(credentials.calls.stages.length, 1);
+  assert.equal(credentials.calls.previews.length, 2);
 });
 
 test('legacy credential dry-run reports a missing preview adapter precisely', async () => {
   const secret = 'secret-material-with-at-least-32-characters';
   const { runtime } = makeRuntime({
     credentialAdapter: {
-      bind() {
-        return { bindingId: 'vault-binding' };
+      stage() {
+        return { outcome: 'staged', bindingId: 'vault-binding', stageId: 'vault-stage' };
       },
+      commit() {},
+      discard() {},
       resolve() {
         return { type: 'bearer', token: secret };
       },
@@ -495,6 +532,294 @@ test('legacy credential dry-run reports a missing preview adapter precisely', as
       error instanceof NotificationSubscriptionValidationError &&
       error.message === 'credentialAdapter.preview is required for dry-run legacy authentication'
   );
+});
+
+test('credential rotation stages an immutable version and discards it when proof fails', async () => {
+  const initialSecret = 'initial-secret-material-with-32-characters';
+  const rotatedSecret = 'rotated-secret-material-with-32-characters';
+  const credentials = createVersionedCredentialAdapter();
+  let rejectProof = false;
+  const { runtime, store } = makeRuntime({
+    credentialAdapter: credentials.adapter,
+    proof: async () => ({ proved: !rejectProof }),
+  });
+  const config = credential => ({
+    subscriber_id: 'immutable-credential',
+    url: 'https://buyer.example/immutable-credential',
+    event_types: ['reporting.delivery_ready'],
+    authentication: { schemes: ['Bearer'], credentials: credential },
+  });
+
+  const applied = await runtime.replace(accountA, [config(initialSecret)]);
+  const before = await store.get(accountA);
+  const initialBindingId = before.subscriptions[0].authentication.bindingId;
+  assert.equal(applied.outcome, 'applied');
+  assert.equal(initialBindingId, 'vault-binding-1');
+
+  rejectProof = true;
+  const rejected = await runtime.replace(accountA, [config(rotatedSecret)], {
+    expectedGeneration: applied.generation,
+  });
+  assert.deepEqual(rejected, { outcome: 'proof_failed', subscriberId: 'immutable-credential' });
+  assert.equal(credentials.calls.stages[1].previousBindingId, initialBindingId);
+  assert.equal(credentials.calls.discards.length, 1);
+  assert.equal(credentials.calls.discards[0].bindingId, 'vault-binding-2');
+  assert.notEqual(credentials.calls.discards[0].bindingId, initialBindingId);
+  assert.deepEqual([...credentials.bindings.keys()], [initialBindingId]);
+  assert.deepEqual(await store.get(accountA), before, 'failed proof preserves the prior binding and generation');
+});
+
+test('post-CAS credential commit failure is observable without reversing the replacement', async () => {
+  const secret = 'observable-commit-secret-material-32-characters';
+  const credentials = createVersionedCredentialAdapter();
+  const observed = [];
+  credentials.adapter.commit = input => {
+    credentials.calls.commits.push(input);
+    throw new Error('vault bookkeeping unavailable');
+  };
+  const { runtime, store } = makeRuntime({
+    credentialAdapter: credentials.adapter,
+    runtimeOptions: { onCredentialStageError: event => observed.push(event) },
+  });
+
+  const result = await runtime.replace(accountA, [
+    {
+      subscriber_id: 'observable-commit',
+      url: 'https://buyer.example/observable-commit',
+      event_types: ['reporting.delivery_ready'],
+      authentication: { schemes: ['Bearer'], credentials: secret },
+    },
+  ]);
+
+  assert.equal(result.outcome, 'applied');
+  assert.equal(observed.length, 1);
+  assert.equal(observed[0].operation, 'commit');
+  assert.equal(observed[0].subscriberId, 'observable-commit');
+  assert.match(observed[0].error.message, /bookkeeping unavailable/);
+  const stored = await store.get(accountA);
+  assert.equal(stored.subscriptions[0].authentication.bindingId, observed[0].bindingId);
+  assert.equal(credentials.bindings.has(observed[0].bindingId), true, 'the staged binding remains resolvable');
+});
+
+test('concurrent credential replacements commit only the CAS winner and discard the loser', async () => {
+  const initialSecret = 'initial-secret-material-with-32-characters';
+  const replacementA = 'replacement-a-material-with-32-characters';
+  const replacementB = 'replacement-b-material-with-32-characters';
+  const credentials = createVersionedCredentialAdapter();
+  let rotating = false;
+  let proofArrivals = 0;
+  let releaseProofs;
+  const proofBarrier = new Promise(resolve => {
+    releaseProofs = resolve;
+  });
+  const { runtime, store } = makeRuntime({
+    credentialAdapter: credentials.adapter,
+    proof: async () => {
+      if (!rotating) return { proved: true };
+      proofArrivals++;
+      if (proofArrivals === 2) releaseProofs();
+      await proofBarrier;
+      return { proved: true };
+    },
+  });
+  const config = credential => ({
+    subscriber_id: 'credential-race',
+    url: 'https://buyer.example/credential-race',
+    event_types: ['reporting.delivery_ready'],
+    authentication: { schemes: ['Bearer'], credentials: credential },
+  });
+  const initial = await runtime.replace(accountA, [config(initialSecret)]);
+  rotating = true;
+
+  const [first, second] = await Promise.all([
+    runtime.replace(accountA, [config(replacementA)], { expectedGeneration: initial.generation }),
+    runtime.replace(accountA, [config(replacementB)], { expectedGeneration: initial.generation }),
+  ]);
+
+  assert.deepEqual([first.outcome, second.outcome].sort(), ['applied', 'conflict']);
+  const rotatedStages = credentials.calls.stages.slice(1);
+  assert.equal(rotatedStages.length, 2);
+  assert.notEqual(rotatedStages[0].credential, rotatedStages[1].credential);
+  const committed = credentials.calls.commits.at(-1).bindingId;
+  const discarded = credentials.calls.discards.at(-1).bindingId;
+  assert.notEqual(committed, discarded);
+  assert.equal(credentials.bindings.has(committed), true);
+  assert.equal(credentials.bindings.has(discarded), false);
+  const final = await store.get(accountA);
+  assert.equal(final.subscriptions[0].authentication.bindingId, committed);
+  assert.equal(final.subscriptions[0].proofGeneration, final.subscriptions[0].destinationGeneration);
+});
+
+test('concurrent equal credential replacements use independent stages', async () => {
+  const initialSecret = 'initial-equal-race-secret-with-32-characters';
+  const replacement = 'shared-race-secret-material-with-32-characters';
+  const credentials = createVersionedCredentialAdapter();
+  let rotating = false;
+  let proofArrivals = 0;
+  let releaseProofs;
+  const proofBarrier = new Promise(resolve => {
+    releaseProofs = resolve;
+  });
+  const { runtime, store } = makeRuntime({
+    credentialAdapter: credentials.adapter,
+    proof: async () => {
+      if (!rotating) return { proved: true };
+      proofArrivals++;
+      if (proofArrivals === 2) releaseProofs();
+      await proofBarrier;
+      return { proved: true };
+    },
+  });
+  const config = credential => ({
+    subscriber_id: 'equal-credential-race',
+    url: 'https://buyer.example/equal-credential-race',
+    event_types: ['reporting.delivery_ready'],
+    authentication: { schemes: ['Bearer'], credentials: credential },
+  });
+  const initial = await runtime.replace(accountA, [config(initialSecret)]);
+  rotating = true;
+
+  const results = await Promise.all([
+    runtime.replace(accountA, [config(replacement)], { expectedGeneration: initial.generation }),
+    runtime.replace(accountA, [config(replacement)], { expectedGeneration: initial.generation }),
+  ]);
+
+  assert.deepEqual(results.map(result => result.outcome).sort(), ['applied', 'conflict']);
+  const rotatedBindings = credentials.calls.stages.slice(1).map(stage => stage.bindingId);
+  const committed = credentials.calls.commits.at(-1).bindingId;
+  const discarded = credentials.calls.discards.at(-1).bindingId;
+  assert.notEqual(committed, discarded);
+  assert.equal(credentials.bindings.has(committed), true);
+  assert.equal(credentials.bindings.has(discarded), false);
+  assert.deepEqual(new Set(rotatedBindings), new Set([committed, discarded]));
+  const final = await store.get(accountA);
+  assert.equal(final.subscriptions[0].authentication.bindingId, committed);
+});
+
+test('adopter callbacks time out fail closed and receive an aborted signal', async () => {
+  let authorizationSignal;
+  const { runtime, fetch } = makeRuntime({
+    runtimeOptions: { adopterCallbackTimeoutMs: 10 },
+    authorize: ({ signal }) => {
+      authorizationSignal = signal;
+      return new Promise(() => {});
+    },
+  });
+  await runtime.replace(callerA, [
+    {
+      subscriber_id: 'timed-out-authority',
+      url: 'https://buyer.example/timed-out-authority',
+      event_types: ['capabilities.changed'],
+    },
+  ]);
+
+  const result = await runtime.emit({
+    emissionId: 'emission-timeout',
+    notificationId: 'notification-timeout',
+    notificationType: 'capabilities.changed',
+    anchor: 'caller',
+    tenantId: callerA.tenantId,
+    principalId: callerA.principalId,
+    payload: { repair: '/capabilities' },
+  });
+  assert.equal(fetch.calls.length, 0);
+  assert.equal(authorizationSignal.aborted, true);
+  assert.deepEqual(result.deliveries[0].result.suppression, { reason: 'authorization_error' });
+});
+
+test('fanout runs subscriber retry cycles with bounded concurrency and stable ordering', async () => {
+  let active = 0;
+  let peak = 0;
+  const calls = [];
+  const fetch = async url => {
+    calls.push(url);
+    active++;
+    peak = Math.max(peak, active);
+    await new Promise(resolve => setTimeout(resolve, 10));
+    active--;
+    return { status: 204, headers: { get: () => undefined } };
+  };
+  fetch.calls = calls;
+  const { runtime } = makeRuntime({ fetch, runtimeOptions: { fanoutConcurrency: 2 } });
+  await runtime.replace(
+    callerA,
+    Array.from({ length: 4 }, (_, index) => ({
+      subscriber_id: `parallel-${index}`,
+      url: `https://buyer.example/parallel-${index}`,
+      event_types: ['capabilities.changed'],
+    }))
+  );
+
+  const result = await runtime.emit({
+    emissionId: 'emission-parallel',
+    notificationId: 'notification-parallel',
+    notificationType: 'capabilities.changed',
+    anchor: 'caller',
+    tenantId: callerA.tenantId,
+    principalId: callerA.principalId,
+    payload: { repair: '/capabilities' },
+  });
+  assert.equal(calls.length, 4);
+  assert.equal(peak, 2);
+  assert.deepEqual(
+    result.deliveries.map(delivery => delivery.subscriberId),
+    ['parallel-0', 'parallel-1', 'parallel-2', 'parallel-3']
+  );
+});
+
+test('fanout isolates an emitter failure to its subscriber result', async () => {
+  const emitterFactory = () => {
+    const emitter = {
+      async emit(params) {
+        if (params.url.includes('/fails')) throw new Error('delivery binding mismatch with private details');
+        return {
+          delivery_id: params.delivery_id,
+          idempotency_key: 'isolated-fanout-idempotency-key',
+          attempts: 1,
+          delivered: true,
+          terminal: true,
+          final_status: 204,
+          errors: [],
+        };
+      },
+      async emitRecovered() {
+        throw new Error('unused');
+      },
+      forTenantScope() {
+        return emitter;
+      },
+    };
+    return emitter;
+  };
+  const { runtime } = makeRuntime({ emitterFactory });
+  await runtime.replace(callerA, [
+    {
+      subscriber_id: 'a-fails',
+      url: 'https://buyer.example/fails',
+      event_types: ['capabilities.changed'],
+    },
+    {
+      subscriber_id: 'b-succeeds',
+      url: 'https://buyer.example/succeeds',
+      event_types: ['capabilities.changed'],
+    },
+  ]);
+
+  const result = await runtime.emit({
+    emissionId: 'emission-isolated-failure',
+    notificationId: 'notification-isolated-failure',
+    notificationType: 'capabilities.changed',
+    anchor: 'caller',
+    tenantId: callerA.tenantId,
+    principalId: callerA.principalId,
+    payload: { changed: true },
+  });
+
+  assert.equal(result.matched, 2);
+  assert.deepEqual(result.deliveries[0].failure, { reason: 'delivery_runtime_error' });
+  assert.equal(result.deliveries[0].result, undefined);
+  assert.equal(result.deliveries[1].result.delivered, true);
+  assert.equal(result.deliveries[1].failure, undefined);
 });
 
 test('durable recovery round-trips non-secret authorization context and suppresses stale work', async () => {

--- a/test/lib/persistent-notification-runtime.test.js
+++ b/test/lib/persistent-notification-runtime.test.js
@@ -382,6 +382,9 @@ test('legacy credentials remain write-only and resolve only after per-attempt au
   const secret = 'secret-material-with-at-least-32-characters';
   let resolves = 0;
   const credentialAdapter = {
+    preview({ credential }) {
+      return { bindingId: `vault_${createHash('sha256').update(credential).digest('hex')}` };
+    },
     bind({ credential }) {
       return { bindingId: `vault_${createHash('sha256').update(credential).digest('hex')}` };
     },
@@ -416,6 +419,82 @@ test('legacy credentials remain write-only and resolve only after per-attempt au
     payload: { reporting_run_id: 'run-1' },
   });
   assert.equal(resolves, 1);
+});
+
+test('legacy credential dry-run previews use the stable binding without writing', async () => {
+  const secret = 'secret-material-with-at-least-32-characters';
+  const rotatedSecret = 'rotated-material-with-at-least-32-characters';
+  let previews = 0;
+  let binds = 0;
+  const binding = credential => `vault_${createHash('sha256').update(credential).digest('hex')}`;
+  const credentialAdapter = {
+    preview({ credential }) {
+      previews++;
+      return { bindingId: binding(credential) };
+    },
+    bind({ credential }) {
+      binds++;
+      return { bindingId: binding(credential) };
+    },
+    resolve() {
+      return { type: 'bearer', token: secret };
+    },
+  };
+  const { runtime } = makeRuntime({ credentialAdapter });
+  const config = credential => ({
+    subscriber_id: 'legacy-preview',
+    url: 'https://buyer.example/legacy-preview',
+    event_types: ['reporting.delivery_ready'],
+    authentication: { schemes: ['Bearer'], credentials: credential },
+  });
+
+  const applied = await runtime.replace(accountA, [config(secret)]);
+  assert.equal(applied.outcome, 'applied');
+  assert.equal(binds, 1);
+
+  const unchanged = await runtime.replace(accountA, [config(secret)], { dryRun: true });
+  assert.equal(unchanged.outcome, 'validated');
+  assert.equal(unchanged.wouldChange, false);
+  assert.equal(binds, 1, 'dry-run must not persist or rotate a credential');
+
+  const changed = await runtime.replace(accountA, [config(rotatedSecret)], { dryRun: true });
+  assert.equal(changed.outcome, 'validated');
+  assert.equal(changed.wouldChange, true);
+  assert.equal(binds, 1);
+  assert.equal(previews, 2);
+});
+
+test('legacy credential dry-run reports a missing preview adapter precisely', async () => {
+  const secret = 'secret-material-with-at-least-32-characters';
+  const { runtime } = makeRuntime({
+    credentialAdapter: {
+      bind() {
+        return { bindingId: 'vault-binding' };
+      },
+      resolve() {
+        return { type: 'bearer', token: secret };
+      },
+    },
+  });
+
+  await assert.rejects(
+    () =>
+      runtime.replace(
+        accountA,
+        [
+          {
+            subscriber_id: 'legacy-preview',
+            url: 'https://buyer.example/legacy-preview',
+            event_types: ['reporting.delivery_ready'],
+            authentication: { schemes: ['Bearer'], credentials: secret },
+          },
+        ],
+        { dryRun: true }
+      ),
+    error =>
+      error instanceof NotificationSubscriptionValidationError &&
+      error.message === 'credentialAdapter.preview is required for dry-run legacy authentication'
+  );
 });
 
 test('durable recovery round-trips non-secret authorization context and suppresses stale work', async () => {

--- a/test/lib/persistent-notification-runtime.test.js
+++ b/test/lib/persistent-notification-runtime.test.js
@@ -1,0 +1,658 @@
+const { test, after } = require('node:test');
+const assert = require('node:assert/strict');
+const { createHash, generateKeyPairSync, randomBytes } = require('node:crypto');
+const { spawnSync } = require('node:child_process');
+
+const {
+  createPersistentNotificationRuntime,
+  createWebhookEmitter,
+  createWebhookDeliveryRecovery,
+  memoryNotificationSubscriptionStore,
+  memoryWebhookDeliveryRecoveryBackend,
+  memoryWebhookDeliveryStore,
+  getNotificationSubscriptionMigration,
+  pgNotificationSubscriptionStore,
+  createPostgresPersistentNotificationRuntime,
+  NotificationSubscriptionValidationError,
+} = require('../../dist/lib/server/index.js');
+const { canonicalJsonSha256 } = require('../../dist/lib/utils/jcs.js');
+
+function signerKey() {
+  const { privateKey } = generateKeyPairSync('ed25519');
+  const jwk = privateKey.export({ format: 'jwk' });
+  return {
+    keyid: 'notification-runtime-test',
+    alg: 'ed25519',
+    privateKey: {
+      ...jwk,
+      kid: 'notification-runtime-test',
+      alg: 'ed25519',
+      adcp_use: 'request-signing',
+      key_ops: ['sign'],
+    },
+  };
+}
+
+function scriptedFetch(statuses) {
+  const queue = [...statuses];
+  const calls = [];
+  const fetch = async (url, init) => {
+    calls.push({ url, init, body: JSON.parse(init.body) });
+    return {
+      status: queue.shift() ?? 204,
+      headers: { get: () => undefined },
+    };
+  };
+  fetch.calls = calls;
+  return fetch;
+}
+
+function makeRuntime({
+  fetch = scriptedFetch([204]),
+  proof = async () => ({ proved: true }),
+  authorize = async () => ({ authorized: true }),
+  credentialAdapter,
+  retries = { maxAttempts: 1, initialDelayMs: 0, maxDelayMs: 0, jitter: 0 },
+  sleep = async () => {},
+  runtimeOptions = {},
+} = {}) {
+  const store = memoryNotificationSubscriptionStore();
+  const runtime = createPersistentNotificationRuntime({
+    store,
+    proofAdapter: { prove: proof },
+    authorizeDelivery: authorize,
+    validateDestination: async () => ({ allowed: true }),
+    credentialAdapter,
+    ...runtimeOptions,
+    createEmitter: authorizeAttempt =>
+      createWebhookEmitter({
+        signerKey: signerKey(),
+        fetch,
+        retries,
+        sleep,
+        authorizeAttempt,
+      }),
+  });
+  return { runtime, store, fetch };
+}
+
+const callerA = { kind: 'caller', tenantId: 'seller-us', principalId: 'buyer-a' };
+const callerB = { kind: 'caller', tenantId: 'seller-us', principalId: 'buyer-b' };
+const accountA = { ...callerA, kind: 'account', accountId: 'account-1' };
+
+test('caller-scoped full-set replacement is isolated, idempotent, and generation fenced', async () => {
+  const { runtime } = makeRuntime();
+  const config = {
+    subscriber_id: 'primary',
+    url: 'https://buyer.example/capabilities',
+    event_types: ['capabilities.changed'],
+  };
+
+  const first = await runtime.replace(callerA, [config]);
+  const secondCaller = await runtime.replace(callerB, [config]);
+  assert.equal(first.outcome, 'applied');
+  assert.equal(secondCaller.outcome, 'applied');
+  assert.notEqual(first.generation, secondCaller.generation);
+
+  const replay = await runtime.replace(callerA, [config], { expectedGeneration: first.generation });
+  assert.equal(replay.outcome, 'unchanged');
+  assert.equal(replay.generation, first.generation);
+
+  const stale = await runtime.replace(callerA, [], { expectedGeneration: 'cfg_stale' });
+  assert.deepEqual(stale, { outcome: 'conflict', currentGeneration: first.generation });
+
+  const cleared = await runtime.replace(callerA, [], { expectedGeneration: first.generation });
+  assert.equal(cleared.outcome, 'cleared');
+  assert.deepEqual((await runtime.read(callerA)).notificationConfigs, []);
+  assert.equal((await runtime.read(callerB)).notificationConfigs.length, 1);
+});
+
+test('replacement enforces the protocol subscriber cap', async () => {
+  const { runtime } = makeRuntime();
+  await assert.rejects(
+    () =>
+      runtime.replace(
+        callerA,
+        Array.from({ length: 17 }, (_, index) => ({
+          subscriber_id: `subscriber-${index}`,
+          url: `https://buyer.example/hooks/${index}`,
+          event_types: ['capabilities.changed'],
+        }))
+      ),
+    error =>
+      error instanceof NotificationSubscriptionValidationError &&
+      error.field === 'notification_configs' &&
+      /at most 16/.test(error.message)
+  );
+});
+
+test('fanout delivery cap fails closed before sending any partial set', async () => {
+  const { runtime, fetch } = makeRuntime({ runtimeOptions: { maxFanoutCandidates: 1 } });
+  await runtime.replace(callerA, [
+    {
+      subscriber_id: 'first',
+      url: 'https://buyer.example/first',
+      event_types: ['capabilities.changed'],
+    },
+    {
+      subscriber_id: 'second',
+      url: 'https://buyer.example/second',
+      event_types: ['capabilities.changed'],
+    },
+  ]);
+
+  await assert.rejects(
+    () =>
+      runtime.emit({
+        emissionId: 'emission-overflow',
+        notificationId: 'notification-overflow',
+        notificationType: 'capabilities.changed',
+        anchor: 'caller',
+        tenantId: callerA.tenantId,
+        principalId: callerA.principalId,
+        payload: { repair: '/capabilities' },
+      }),
+    /fanout exceeded maxFanoutCandidates/
+  );
+  assert.equal(fetch.calls.length, 0);
+});
+
+test('paused subscriptions do not consume the active fanout candidate cap', async () => {
+  const { runtime, fetch } = makeRuntime({ runtimeOptions: { maxFanoutCandidates: 1 } });
+  await runtime.replace(callerA, [
+    {
+      subscriber_id: 'paused',
+      url: 'https://buyer.example/paused',
+      event_types: ['capabilities.changed'],
+      active: false,
+    },
+  ]);
+  await runtime.replace(callerB, [
+    {
+      subscriber_id: 'live',
+      url: 'https://buyer.example/live',
+      event_types: ['capabilities.changed'],
+    },
+  ]);
+
+  const result = await runtime.emit({
+    emissionId: 'emission-live-only',
+    notificationId: 'notification-live-only',
+    notificationType: 'capabilities.changed',
+    anchor: 'caller',
+    tenantId: callerA.tenantId,
+    payload: { repair: '/capabilities' },
+  });
+  assert.equal(result.matched, 1);
+  assert.equal(fetch.calls.length, 1);
+  assert.equal(fetch.calls[0].body.subscriber_id, 'live');
+});
+
+test('anchor validation rejects incompatible event types and requires all-account acknowledgement', async () => {
+  const { runtime } = makeRuntime();
+  await assert.rejects(
+    () =>
+      runtime.replace(accountA, [
+        {
+          subscriber_id: 'wrong-anchor',
+          url: 'https://buyer.example/hook',
+          event_types: ['capabilities.changed'],
+        },
+      ]),
+    error =>
+      error instanceof NotificationSubscriptionValidationError &&
+      /(caller-anchored|not supported on this anchor)/.test(error.message)
+  );
+  await assert.rejects(
+    () =>
+      runtime.replace(callerA, [
+        {
+          subscriber_id: 'all-accounts',
+          url: 'https://buyer.example/hook',
+          event_types: ['account.change_recorded'],
+        },
+      ]),
+    error => error instanceof NotificationSubscriptionValidationError && /all_authorized_accounts/.test(error.message)
+  );
+});
+
+test('future event opt-in delivers only explicitly classified caller invalidations', async () => {
+  const { runtime, fetch } = makeRuntime({
+    runtimeOptions: { futureCallerInvalidationEventTypes: ['catalog.invalidated'] },
+  });
+  await runtime.replace(callerA, [
+    {
+      subscriber_id: 'future-aware',
+      url: 'https://buyer.example/future',
+      event_types: ['capabilities.changed'],
+      include_future_event_types: true,
+    },
+    {
+      subscriber_id: 'current-only',
+      url: 'https://buyer.example/current',
+      event_types: ['capabilities.changed'],
+    },
+  ]);
+
+  const result = await runtime.emit({
+    emissionId: 'emission-future',
+    notificationId: 'notification-future',
+    notificationType: 'catalog.invalidated',
+    anchor: 'caller',
+    tenantId: callerA.tenantId,
+    principalId: callerA.principalId,
+    payload: { repair: '/catalog' },
+  });
+
+  assert.equal(result.matched, 1);
+  assert.equal(fetch.calls.length, 1);
+  assert.equal(fetch.calls[0].body.subscriber_id, 'future-aware');
+});
+
+test('changed active tuple is proved before CAS and proof failure preserves the prior set', async () => {
+  const proofInputs = [];
+  const { runtime } = makeRuntime({
+    proof: async input => {
+      proofInputs.push(input);
+      return { proved: !input.url.includes('/reject') };
+    },
+  });
+  const initial = await runtime.replace(accountA, [
+    {
+      subscriber_id: 'feed',
+      url: 'https://buyer.example/accept',
+      event_types: ['account.change_recorded'],
+    },
+  ]);
+  assert.equal(initial.outcome, 'applied');
+  assert.equal(proofInputs.length, 1);
+
+  const rejected = await runtime.replace(accountA, [
+    {
+      subscriber_id: 'feed',
+      url: 'https://buyer.example/reject',
+      event_types: ['account.change_recorded', 'account.status_changed'],
+    },
+  ]);
+  assert.deepEqual(rejected, { outcome: 'proof_failed', subscriberId: 'feed' });
+  const readback = await runtime.read(accountA);
+  assert.equal(readback.generation, initial.generation);
+  assert.equal(readback.notificationConfigs[0].url, 'https://buyer.example/accept');
+  assert.equal(
+    readback.notificationConfigs[0].proof_generation,
+    readback.notificationConfigs[0].destination_generation
+  );
+});
+
+test('account event fans out independently to account and all-authorized caller subscribers', async () => {
+  const fetch = scriptedFetch([500, 204, 500, 204]);
+  let authorizationChecks = 0;
+  const { runtime } = makeRuntime({
+    fetch,
+    retries: { maxAttempts: 2, initialDelayMs: 0, maxDelayMs: 0, jitter: 0 },
+    authorize: async () => {
+      authorizationChecks++;
+      return { authorized: true };
+    },
+  });
+  await runtime.replace(accountA, [
+    {
+      subscriber_id: 'account-hook',
+      url: 'https://buyer.example/account',
+      event_types: ['account.change_recorded'],
+    },
+  ]);
+  await runtime.replace(callerA, [
+    {
+      subscriber_id: 'principal-hook',
+      url: 'https://buyer.example/principal',
+      event_types: ['account.change_recorded'],
+      all_authorized_accounts: true,
+    },
+  ]);
+
+  const result = await runtime.emit({
+    emissionId: 'emit-account-change-0001',
+    notificationId: 'change-42',
+    notificationType: 'account.change_recorded',
+    anchor: 'account',
+    tenantId: 'seller-us',
+    principalId: 'buyer-a',
+    accountId: 'account-1',
+    payload: { change_id: 'change-42', through_cursor: 'cursor-advisory' },
+  });
+  assert.equal(result.matched, 2);
+  assert.equal(result.deliveries.length, 2);
+  assert.equal(fetch.calls.length, 4);
+  assert.equal(authorizationChecks, 4, 'authorization is re-evaluated before every retry');
+  assert.deepEqual(new Set(fetch.calls.map(call => call.body.notification_id)), new Set(['change-42']));
+  assert.equal(new Set(fetch.calls.map(call => call.body.subscriber_id)).size, 2);
+  for (const subscriber of ['account-hook', 'principal-hook']) {
+    const calls = fetch.calls.filter(call => call.body.subscriber_id === subscriber);
+    assert.equal(calls.length, 2);
+    assert.equal(calls[0].body.idempotency_key, calls[1].body.idempotency_key);
+  }
+});
+
+test('deactivation during retry suppresses old work before the second external attempt', async () => {
+  const fetch = scriptedFetch([500, 204]);
+  let runtime;
+  let deactivated = false;
+  ({ runtime } = makeRuntime({
+    fetch,
+    retries: { maxAttempts: 2, initialDelayMs: 0, maxDelayMs: 0, jitter: 0 },
+    sleep: async () => {
+      if (deactivated) return;
+      deactivated = true;
+      await runtime.replace(accountA, [
+        {
+          subscriber_id: 'revocable',
+          url: 'https://buyer.example/revocable',
+          event_types: ['account.status_changed'],
+          active: false,
+        },
+      ]);
+    },
+  }));
+  await runtime.replace(accountA, [
+    {
+      subscriber_id: 'revocable',
+      url: 'https://buyer.example/revocable',
+      event_types: ['account.status_changed'],
+    },
+  ]);
+
+  const result = await runtime.emit({
+    emissionId: 'emit-account-status-0001',
+    notificationId: 'account-status-7',
+    notificationType: 'account.status_changed',
+    anchor: 'account',
+    tenantId: 'seller-us',
+    principalId: 'buyer-a',
+    accountId: 'account-1',
+    payload: { status: 'suspended' },
+  });
+  assert.equal(fetch.calls.length, 1);
+  assert.equal(result.deliveries[0].result.attempts, 1);
+  assert.deepEqual(result.deliveries[0].result.suppression, { reason: 'subscription_inactive' });
+  assert.equal(result.deliveries[0].result.terminal, true);
+});
+
+test('legacy credentials remain write-only and resolve only after per-attempt authorization', async () => {
+  const secret = 'secret-material-with-at-least-32-characters';
+  let resolves = 0;
+  const credentialAdapter = {
+    bind({ credential }) {
+      return { bindingId: `vault_${createHash('sha256').update(credential).digest('hex')}` };
+    },
+    resolve({ mode }) {
+      resolves++;
+      assert.equal(mode, 'bearer');
+      return { type: 'bearer', token: secret };
+    },
+  };
+  const { runtime, store } = makeRuntime({ credentialAdapter });
+  await runtime.replace(accountA, [
+    {
+      subscriber_id: 'legacy',
+      url: 'https://buyer.example/legacy',
+      event_types: ['reporting.delivery_ready'],
+      authentication: { schemes: ['Bearer'], credentials: secret },
+    },
+  ]);
+  const stored = await store.get(accountA);
+  assert.ok(!JSON.stringify(stored).includes(secret));
+  const readback = await runtime.read(accountA);
+  assert.deepEqual(readback.notificationConfigs[0].authentication, { schemes: ['Bearer'] });
+
+  await runtime.emit({
+    emissionId: 'emit-report-ready-0001',
+    notificationId: 'report-ready-1',
+    notificationType: 'reporting.delivery_ready',
+    anchor: 'account',
+    tenantId: 'seller-us',
+    principalId: 'buyer-a',
+    accountId: 'account-1',
+    payload: { reporting_run_id: 'run-1' },
+  });
+  assert.equal(resolves, 1);
+});
+
+test('durable recovery round-trips non-secret authorization context and suppresses stale work', async () => {
+  const backend = { ...memoryWebhookDeliveryRecoveryBackend(), durability: 'durable' };
+  const recovery = createWebhookDeliveryRecovery({ backend });
+  const deliveryStore = memoryWebhookDeliveryStore();
+  const firstFetch = scriptedFetch([503]);
+  const first = createWebhookEmitter({
+    signerKey: signerKey(),
+    fetch: firstFetch,
+    sleep: async () => {},
+    retries: { maxAttempts: 1, initialDelayMs: 0, maxDelayMs: 0, jitter: 0 },
+    publisherScope: 'publisher',
+    tenantScope: 'tenant',
+    deliveryStore,
+    deliveryRecovery: recovery,
+    authorizeAttempt: async () => ({ decision: 'allow' }),
+  });
+  const authorizationContext = {
+    kind: 'adcp_notification_subscription',
+    version: 1,
+    destinationGeneration: 'dest_old',
+  };
+  const initial = await first.emit({
+    url: 'https://buyer.example/recovery',
+    payload: { notification_id: 'logical-1' },
+    delivery_id: 'durable-notification-delivery',
+    attemptAuthorizationContext: authorizationContext,
+  });
+  assert.equal(initial.delivered, false);
+
+  const [lease] = await recovery.claimPending({ ownerToken: 'recovery-worker', limit: 1 });
+  assert.deepEqual(lease.snapshot.attemptAuthorizationContext, authorizationContext);
+  const recoveredFetch = scriptedFetch([204]);
+  const recovered = createWebhookEmitter({
+    signerKey: signerKey(),
+    fetch: recoveredFetch,
+    sleep: async () => {},
+    publisherScope: 'publisher',
+    tenantScope: 'tenant',
+    deliveryStore,
+    deliveryRecovery: recovery,
+    authorizeAttempt: async info => {
+      assert.deepEqual(info.attemptAuthorizationContext, authorizationContext);
+      return { decision: 'suppress', reason: 'subscription_stale' };
+    },
+  });
+  const result = await recovered.emitRecovered(lease);
+  assert.equal(recoveredFetch.calls.length, 0);
+  assert.equal(result.attempts, 0);
+  assert.deepEqual(result.suppression, { reason: 'subscription_stale' });
+});
+
+test('PostgreSQL store migration and replacement use scoped generation CAS', async () => {
+  const migration = getNotificationSubscriptionMigration({ tableName: 'seller_notification_subs' });
+  assert.match(migration, /PRIMARY KEY \(tenant_scope, principal_id, anchor_kind, account_id\)/);
+  assert.match(migration, /anchor_kind = 'caller' AND account_id = ''/);
+  assert.match(migration, /jsonb_typeof\(subscriptions\) = 'array'/);
+
+  const queries = [];
+  const subscriptions = [
+    {
+      subscriberId: 'primary',
+      url: 'https://buyer.example/hook',
+      eventTypes: ['capabilities.changed'],
+      active: true,
+      allAuthorizedAccounts: false,
+      includeFutureEventTypes: false,
+      authentication: { mode: 'rfc9421' },
+      destinationGeneration: 'dest_1',
+      proofGeneration: 'dest_1',
+    },
+  ];
+  const db = {
+    async query(sql, params) {
+      queries.push({ sql, params });
+      return {
+        rows: [
+          {
+            tenant_scope: 'seller-us',
+            principal_id: 'buyer-a',
+            anchor_kind: 'caller',
+            account_id: '',
+            generation: 'cfg_next',
+            subscriptions,
+            content_fingerprint: canonicalJsonSha256(subscriptions),
+          },
+        ],
+        rowCount: 1,
+      };
+    },
+  };
+  const store = pgNotificationSubscriptionStore(db, { tableName: 'seller_notification_subs' });
+  const result = await store.replace({
+    scope: callerA,
+    expectedGeneration: 'cfg_previous',
+    nextGeneration: 'cfg_next',
+    subscriptions,
+  });
+  assert.equal(result.outcome, 'applied');
+  assert.match(queries[0].sql, /ON CONFLICT \(tenant_scope, principal_id, anchor_kind, account_id\)/);
+  assert.match(queries[0].sql, /WHERE \$8::text IS NOT NULL/);
+  assert.deepEqual(queries[0].params.slice(0, 5), ['seller-us', 'buyer-a', 'caller', '', 'cfg_next']);
+  assert.equal(queries[0].params[7], 'cfg_previous');
+});
+
+test('PostgreSQL persistent runtime never exposes its guarded emitter as server-wide config', () => {
+  const db = { query: async () => ({ rows: [], rowCount: 0 }) };
+  const runtime = createPostgresPersistentNotificationRuntime({
+    db,
+    publisherScope: 'notification-only',
+    subscriptions: { tableName: 'notification_only_subscriptions' },
+    webhooks: {
+      signerKey: signerKey(),
+      deliveries: { tableName: 'notification_only_deliveries' },
+      outbox: { tableName: 'notification_only_outbox' },
+    },
+    proofAdapter: { prove: async () => ({ proved: true }) },
+    authorizeDelivery: async () => ({ authorized: true }),
+    validateDestination: async () => ({ allowed: true }),
+  });
+
+  assert.equal(Object.hasOwn(runtime.webhooks, 'serverConfig'), false);
+});
+
+test('PostgreSQL notification store requires deployment isolation in production', () => {
+  const script = `
+    const { pgNotificationSubscriptionStore } = require(${JSON.stringify(
+      require.resolve('../../dist/lib/server/index.js')
+    )});
+    const db = { query: async () => ({ rows: [], rowCount: 0 }) };
+    try { pgNotificationSubscriptionStore(db); process.exit(8); }
+    catch (error) { if (!/deployment-unique tableName/.test(error.message)) throw error; }
+    pgNotificationSubscriptionStore(db, { tableName: 'seller_prod_notification_subs' });
+  `;
+  const result = spawnSync(process.execPath, ['-e', script], {
+    env: { ...process.env, NODE_ENV: 'production' },
+    encoding: 'utf8',
+  });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+});
+
+// Optional live multi-replica contract. CI environments that provide PostgreSQL
+// exercise subscription CAS and webhook recovery through separate runtime
+// instances sharing only durable state.
+if (process.env.DATABASE_URL) {
+  const { Pool } = require('pg');
+  const suffix = randomBytes(4).toString('hex');
+  const subscriptionTable = `adcp_ns_sub_${suffix}`;
+  const deliveryTable = `adcp_ns_delivery_${suffix}`;
+  const outboxTable = `adcp_ns_outbox_${suffix}`;
+  const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+  after(async () => {
+    await pool.query(`DROP TABLE IF EXISTS "${outboxTable}", "${deliveryTable}", "${subscriptionTable}"`);
+    await pool.end();
+  });
+
+  test('PostgreSQL runtimes preserve subscription, proof, CAS, and delivery state across replicas', async () => {
+    const firstFetch = scriptedFetch([503]);
+    const key = signerKey();
+    const common = {
+      db: pool,
+      publisherScope: `notification-test-${suffix}`,
+      subscriptions: { tableName: subscriptionTable },
+      proofAdapter: { prove: async () => ({ proved: true }) },
+      authorizeDelivery: async () => ({ authorized: true }),
+      validateDestination: async () => ({ allowed: true }),
+    };
+    const first = createPostgresPersistentNotificationRuntime({
+      ...common,
+      webhooks: {
+        signerKey: key,
+        fetch: firstFetch,
+        retries: { maxAttempts: 1, initialDelayMs: 0, maxDelayMs: 0, jitter: 0 },
+        deliveries: { tableName: deliveryTable },
+        outbox: { tableName: outboxTable },
+      },
+    });
+    for (const migration of first.migrations.all) await pool.query(migration);
+    await first.probe();
+
+    const config = {
+      subscriber_id: 'replicated',
+      url: 'https://receiver.example/events',
+      event_types: ['capabilities.changed'],
+    };
+    const applied = await first.replace(callerA, [config]);
+    assert.equal(applied.outcome, 'applied');
+    const initialDelivery = await first.emit({
+      emissionId: 'emission-pg-restart',
+      notificationId: 'notification-pg-restart',
+      notificationType: 'capabilities.changed',
+      anchor: 'caller',
+      tenantId: callerA.tenantId,
+      principalId: callerA.principalId,
+      payload: { repair: '/capabilities' },
+    });
+    assert.equal(initialDelivery.deliveries[0].result.delivered, false);
+
+    const recoveredFetch = scriptedFetch([204]);
+    const second = createPostgresPersistentNotificationRuntime({
+      ...common,
+      webhooks: {
+        signerKey: key,
+        fetch: recoveredFetch,
+        retries: { maxAttempts: 1, initialDelayMs: 0, maxDelayMs: 0, jitter: 0 },
+        deliveries: { tableName: deliveryTable },
+        outbox: { tableName: outboxTable },
+      },
+    });
+    await second.probe();
+    const readAfterRestart = await second.read(callerA);
+    assert.equal(readAfterRestart.generation, applied.generation);
+    assert.equal(
+      readAfterRestart.notificationConfigs[0].proof_generation,
+      readAfterRestart.notificationConfigs[0].destination_generation
+    );
+
+    const recovery = await second.recoverOnce({ ownerToken: `worker-${suffix}`, leaseMs: 5_000 });
+    assert.deepEqual(recovery, { claimed: 1, settled: 1, released: 0 });
+    assert.equal(recoveredFetch.calls.length, 1);
+    assert.equal(recoveredFetch.calls[0].body.idempotency_key, firstFetch.calls[0].body.idempotency_key);
+    assert.equal(recoveredFetch.calls[0].body.notification_id, 'notification-pg-restart');
+
+    const replacementA = { ...config, url: 'https://receiver-a.example/events' };
+    const replacementB = { ...config, url: 'https://receiver-b.example/events' };
+    const [raceA, raceB] = await Promise.all([
+      first.replace(callerA, [replacementA], { expectedGeneration: applied.generation }),
+      second.replace(callerA, [replacementB], { expectedGeneration: applied.generation }),
+    ]);
+    assert.deepEqual([raceA.outcome, raceB.outcome].sort(), ['applied', 'conflict']);
+    const finalState = await second.read(callerA);
+    assert.equal(finalState.notificationConfigs.length, 1);
+    assert.ok(
+      ['https://receiver-a.example/events', 'https://receiver-b.example/events'].includes(
+        finalState.notificationConfigs[0].url
+      )
+    );
+  });
+}


### PR DESCRIPTION
## Summary

- add an opt-in caller/account persistent notification subscription runtime with generation-fenced declarative replacement and exact-tuple activation proof
- require immutable, version-specific opaque credential bindings: rotations are staged before CAS, committed only after CAS succeeds, and discarded on proof failure or concurrent loss
- add PostgreSQL storage/migrations and compose delivery with the existing durable webhook recovery kernel
- re-authorize every live and recovered delivery attempt, resolve write-only credentials just in time, and suppress stale or revoked work
- bound adopter callbacks with abortable timeouts and fan out deliveries through a bounded concurrent pool with isolated failures
- document the supplied protocol handler as compatibility-only; applications own the atomic sync_principal transaction and shared configuration_version advancement
- add protocol handlers, readback projections, documentation, and regression coverage for proof failure, concurrent credential replacement, fanout, retries, deactivation, recovery, and multi-replica PostgreSQL state

## Verification

- `npm run build:lib`
- `npm run typecheck`
- focused persistent-runtime suite: 23 tests passing
- full pre-push validation
- independent DX, protocol, code, and security expert reviews; all findings resolved

Closes #2848

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/86613c50-0cf4-434c-8187-f9d6d5ea1dda)
