### PR TITLE
feat(server): separate default and maximum AdCP versions

### DIFF
--- a/.changeset/quiet-versions-select.md
+++ b/.changeset/quiet-versions-select.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': minor
+---
+
+Separate a server's default served AdCP release from its maximum supported release, and expose the immutable selected release across handler contexts.

--- a/docs/guides/MEDIA-BUY-3.2-COMPATIBILITY.md
+++ b/docs/guides/MEDIA-BUY-3.2-COMPATIBILITY.md
@@ -76,9 +76,22 @@ const platform = {
 createAdcpServerFromPlatform(platform, {
   name: 'seller',
   version: '1.0.0',
+  // `adcpVersion` is the newest release explicit callers may select.
   adcpVersion: '3.2.0-rc.1',
+  // Keep callers that omit a version on the established 3.1 contract.
+  defaultAdcpVersion: '3.1.18',
+  capabilities: { supported_versions: ['3.1.18', '3.2.0-rc.1'] },
 });
 ```
+
+`adcpVersion` is the server's supported ceiling; `defaultAdcpVersion` is the
+release selected when the request has neither `adcp_version` nor
+`adcp_major_version`. The default must be bundled, included in the server's
+effective advertised releases, and no newer than the ceiling. An explicit 3.2
+request still selects 3.2. The selected release is exposed as immutable
+`servedAdcpVersion` on standard handler contexts, custom-tool extras,
+DecisioningPlatform request contexts, task handoff contexts, account/session
+resolvers, and the second argument to `responseEnhancer`.
 
 With the default `mcpToolProfile: 'auto'`, registering any compact lifecycle
 handler on a 3.2 server selects the active media-buy profile. The legacy
@@ -624,6 +637,7 @@ trusted namespaces, never a buyer-supplied proposal ID alone.
 | Compact-first coordinator | AdCP 3.2 dual-surface | Compact tools are preferred; `preferredLifecycle: 'established'` exercises the compatibility facade | Native by default; the forced established lane has the same explicit boundaries as older sellers. |
 | Compact-first coordinator | AdCP 3.2 compact-only | Compact lifecycle tools | Native compact guarantees. |
 | Existing AdCP 3.0/3.1 buyer | Dual-surface SDK 14 seller | Hidden legacy names remain directly callable even though compact names are the advertised profile | Existing buyer code does not need lifecycle negotiation. |
+| Unversioned caller and explicit AdCP 3.2 caller | Dual-surface SDK 14 seller with `defaultAdcpVersion: '3.1.18'` and a 3.2 `adcpVersion` ceiling | Unversioned discovery and calls use the 3.1 established surface; explicit 3.2 discovery and calls use the compact surface | Unversioned callers are never upgraded implicitly, while the 3.2 feature set remains reachable by explicit opt-in. |
 
 “Same application lifecycle” therefore means one coordinator API and the same
 commercial intent wherever that intent is representable. It does **not** mean
@@ -633,7 +647,9 @@ never label the weaker mutation as equivalent.
 
 The coordinator test matrix covers SDK 14 compact-first callers against v2.5,
 3.0, 3.1, 3.2 legacy-only, 3.2 dual-surface (compact preferred and established
-forced), and 3.2 compact-only discovery. Honest raw-MCP 3.0.25, 3.1.18, and
+forced), and 3.2 compact-only discovery. The dual-surface MCP lane also holds
+the maximum at 3.2 while defaulting unversioned discovery and dispatch to 3.1,
+then proves an explicit 3.2 caller reaches the compact surface. Honest raw-MCP 3.0.25, 3.1.18, and
 3.2 legacy-only fixtures execute direct purchase; pause, resume, cancellation,
 and readback; plus request, finalize, decline, accept, post-accept control, and
 readback for ordinary legacy proposals while

--- a/docs/migration-13-to-14.md
+++ b/docs/migration-13-to-14.md
@@ -21,6 +21,28 @@ convergence, webhook retry horizons, and crash-safe continuation generation
 replacement. Beta.6 adds coordinated placements, seller-rendered stateful
 display, creative component assets, and A2A 1.0 request-signing method names.
 
+### Separate the server default from its supported ceiling
+
+An SDK 14 server can advertise and serve 3.2 without silently moving
+unversioned callers off 3.1:
+
+```ts
+const server = createAdcpServer({
+  adcpVersion: '3.2.0-rc.1',
+  defaultAdcpVersion: '3.1.18',
+  capabilities: { supported_versions: ['3.1.18', '3.2.0-rc.1'] },
+  // handlers...
+});
+```
+
+`adcpVersion` is the maximum supported release; `defaultAdcpVersion` is used
+only when the caller supplies no version claim. Explicit 3.2 callers select
+3.2. Standard and custom handlers can read the immutable
+`servedAdcpVersion`, as can DecisioningPlatform request and task-handoff
+contexts. `responseEnhancer` receives the same value in its new optional
+second argument. Discovery without a version claim uses the default release,
+including MCP `tools/list`, generated capabilities, and A2A agent cards.
+
 ### A2A 1.0 peer upgrade
 
 SDK 14's AdCP 3.2 transport requires `@a2a-js/sdk` 1.x. Upgrade the peer

--- a/src/lib/core/SingleAgentClient.ts
+++ b/src/lib/core/SingleAgentClient.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 import * as schemas from '../types/schemas.generated';
 import type { AgentConfig } from '../types';
 import { ADCP_ENVELOPE_FIELDS } from '../types/adcp';
-import { parseAdcpMajorVersion, type AdcpVersion } from '../version';
+import { parseAdcpMajorVersion, toReleasePrecisionVersion, type AdcpVersion } from '../version';
 import {
   isAdcpVersionSupported,
   isAdcpVersionAtLeast,
@@ -7993,6 +7993,11 @@ export class SingleAgentClient {
       ...(options?.signal && { signal: options.signal }),
       ...(clientRequestTimeoutMs !== undefined && { timeout: clientRequestTimeoutMs }),
     };
+    const discoveryAdcpVersion = this.getWireAdcpVersion();
+    const mcpListParams =
+      parseAdcpMajorVersion(discoveryAdcpVersion) >= 3
+        ? { _meta: { adcp_version: toReleasePrecisionVersion(discoveryAdcpVersion) } }
+        : undefined;
     const ensureReadAuthToken = async (): Promise<string | undefined> => {
       if (!this.normalizedAgent.oauth_client_credentials) return this.normalizedAgent.auth_token;
       const { ensureClientCredentialsTokens, getAgentStorage } = await import('../auth/oauth');
@@ -8009,7 +8014,7 @@ export class SingleAgentClient {
       if (this.normalizedAgent._inProcessMcpClient) {
         const mcpClient = this.normalizedAgent._inProcessMcpClient;
         const toolsList = await withResponseSizeLimit(maxResponseBytes, () =>
-          mcpClient.listTools(undefined, mcpRequestOptions)
+          mcpClient.listTools(mcpListParams, mcpRequestOptions)
         );
         const tools = toolsList.tools.map(tool => ({
           name: tool.name,
@@ -8076,6 +8081,9 @@ export class SingleAgentClient {
           : await withResponseSizeLimit(maxResponseBytes, () =>
               tryListModernMCPTools(agent.agent_uri, readAuthToken, this.normalizedAgent.headers, {
                 authProvider,
+                ...(mcpListParams?._meta.adcp_version !== undefined && {
+                  adcpVersion: mcpListParams._meta.adcp_version,
+                }),
                 signal: options?.signal,
                 requestTimeoutMs: transport?.requestTimeoutMs,
                 fetchFn: transport?.trustedFetchFn,
@@ -8101,7 +8109,7 @@ export class SingleAgentClient {
       const { client: mcpClient } = await connectMCP(connectOptions);
       try {
         const toolsList = await withResponseSizeLimit(maxResponseBytes, () =>
-          mcpClient.listTools(undefined, mcpRequestOptions)
+          mcpClient.listTools(mcpListParams, mcpRequestOptions)
         );
 
         const tools = toolsList.tools.map(tool => ({

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1341,6 +1341,8 @@ export type {
   AdcpServerToolName,
   AdcpCapabilitiesConfig,
   LegacyAdcpCustomToolConfig,
+  LegacyAdcpCustomToolHandler,
+  LegacyAdcpCustomToolHandlerExtra,
   McpAppUiMeta,
   McpAppMeta,
   AdcpMcpResourceDefinition,

--- a/src/lib/protocols/mcp-modern.ts
+++ b/src/lib/protocols/mcp-modern.ts
@@ -57,6 +57,8 @@ export interface ModernMCPConnectionOptions {
   requestTimeoutMs?: number;
   fetchFn?: typeof fetch;
   allowPrivateIp?: boolean;
+  /** SDK-selected AdCP release-precision version for tools/list discovery. */
+  adcpVersion?: string;
   /** Use the v2 SDK's negotiated legacy client instead of handing off to v1. */
   handleLegacy?: boolean;
 }
@@ -716,10 +718,13 @@ export async function tryListModernMCPTools(
   const listTools = async (connectedClient: Client): Promise<ModernMCPListAttempt> => {
     if (connectedClient.getProtocolEra() !== 'modern') return { handled: false };
     const resolvedRequestTimeoutMs = resolveClientRequestTimeoutMs(options.requestTimeoutMs);
-    const result = await connectedClient.listTools(undefined, {
-      ...(options.signal && { signal: options.signal }),
-      ...(resolvedRequestTimeoutMs !== undefined && { timeout: resolvedRequestTimeoutMs }),
-    });
+    const result = await connectedClient.listTools(
+      options.adcpVersion === undefined ? undefined : { _meta: { adcp_version: options.adcpVersion } },
+      {
+        ...(options.signal && { signal: options.signal }),
+        ...(resolvedRequestTimeoutMs !== undefined && { timeout: resolvedRequestTimeoutMs }),
+      }
+    );
     return { handled: true, tools: result.tools };
   };
   try {

--- a/src/lib/server/a2a-adapter.ts
+++ b/src/lib/server/a2a-adapter.ts
@@ -84,6 +84,7 @@ import {
   getSdkServer,
   isToolAvailableForVersion,
   listRegisteredToolNames,
+  resolveDiscoveryVersion,
   type AdcpAuthInfo,
   type AdcpServer,
 } from './adcp-server';
@@ -810,9 +811,8 @@ function buildAgentCard(server: AdcpServer, overrides: A2AAgentCardOverrides): A
     throw new Error('createA2AAdapter: only the JSONRPC A2A transport is supported');
   }
   const registeredTools = listRegisteredTools(server);
-  const tools = registeredTools.filter(toolName =>
-    isToolAvailableForVersion(server, toolName, server.getAdcpVersion())
-  );
+  const discoveryVersion = resolveDiscoveryVersion(server);
+  const tools = registeredTools.filter(toolName => isToolAvailableForVersion(server, toolName, discoveryVersion));
   const availableTools = new Set(tools);
   const registeredToolSet = new Set(registeredTools);
   const skills = filterPublicAgentCardSkills(

--- a/src/lib/server/adcp-server.ts
+++ b/src/lib/server/adcp-server.ts
@@ -310,17 +310,27 @@ export interface AdcpServer {
   invoke(options: AdcpInvokeOptions): Promise<McpToolResponse>;
 
   /**
-   * Returns the AdCP protocol version this server is configured to speak.
+   * Returns the newest AdCP protocol version this server can serve.
    *
    * Defaults to {@link ADCP_VERSION} (the GA version the SDK ships against)
    * unless overridden via `createAdcpServer({ adcpVersion })`. This is the
    * protocol version, **not** the publisher's app version (`config.version`).
    *
    * Plumbing surface — Stage 2 of the multi-version refactor exposes the
-   * configured value but does not yet vary validator/schema selection by
+   * configured ceiling but does not yet vary validator/schema selection by
    * version. Wire-shape adapters key off this getter in subsequent stages.
    */
   getAdcpVersion(): string;
+
+  /**
+   * Returns the AdCP protocol version selected when a caller supplies no
+   * `adcp_version` or `adcp_major_version` claim.
+   *
+   * Defaults to {@link getAdcpVersion} unless the server config declares a
+   * lower `defaultAdcpVersion`. This lets one endpoint retain a conservative
+   * wire default while making newer explicitly versioned routes reachable.
+   */
+  getDefaultAdcpVersion(): string;
 }
 
 /**
@@ -446,10 +456,13 @@ export function setDiscoveryVersionResolver(server: AdcpServer, resolver: AdcpDi
   });
 }
 
-/** Resolve a requested discovery version, falling back to the server pin. @internal */
+/** Resolve a requested discovery version, falling back to the server default. @internal */
 export function resolveDiscoveryVersion(server: AdcpServer, requestedVersion?: string): string {
   const resolver = (server as AdcpServerInternal)[ADCP_DISCOVERY_VERSION_RESOLVER];
-  return resolver ? resolver(requestedVersion) : server.getAdcpVersion();
+  // The getter is required on current AdcpServer instances. Keep the runtime
+  // fallback for mixed dependency graphs that pass a wrapper created by an
+  // older SDK copy, while the public type exposes the new API as required.
+  return resolver ? resolver(requestedVersion) : (server.getDefaultAdcpVersion?.() ?? server.getAdcpVersion());
 }
 
 /** Attach the resolved static MCP catalog for transport adapters. @internal */
@@ -723,7 +736,10 @@ export function wrapMcpServer(
   inner: McpServer | AdcpServerInternal,
   compliance?: AdcpServerComplianceApi,
   adcpVersion: string = ADCP_VERSION,
-  options: { structuredContentTextFallback?: StructuredContentTextFallback } = {}
+  options: {
+    structuredContentTextFallback?: StructuredContentTextFallback;
+    defaultAdcpVersion?: string;
+  } = {}
 ): AdcpServerInternal {
   if (isAdcpServer(inner)) return inner;
   const mcp = inner as McpServer;
@@ -799,6 +815,7 @@ export function wrapMcpServer(
     dispatchTestRequest: dispatch as AdcpServerInternal['dispatchTestRequest'],
     invoke,
     getAdcpVersion: () => adcpVersion,
+    getDefaultAdcpVersion: () => options.defaultAdcpVersion ?? adcpVersion,
   };
   return wrapper;
 }

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -8804,6 +8804,11 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
   setToolVersionAvailabilityResolver(wrapped, (toolName, release) => {
     if (!toolAvailableForRelease(toolName, release)) return false;
     if (config.customTools?.[toolName] !== undefined) return true;
+    // Helpers such as createAdcpServerFromPlatform register gated or
+    // adopter-owned tools after createAdcpServer returns. They are not part of
+    // the canonical manifest snapshot above, so do not make modern discovery
+    // hide them merely because releaseDefinesTool cannot find a schema entry.
+    if (!registeredToolNames.has(toolName)) return true;
     return releaseDefinesTool(toolName, { validationVersion: release });
   });
   setDiscoveryVersionResolver(wrapped, requestedVersion => {

--- a/src/lib/server/create-adcp-server.ts
+++ b/src/lib/server/create-adcp-server.ts
@@ -58,14 +58,21 @@ import {
   isMovingAdcpPrereleaseFamilyAlias,
   resolveAdcpVersion,
 } from '../utils/adcp-version-config';
+import { ConfigurationError } from '../errors';
 import { getValidator, hasSchemaBundle, resolveBundleKey, getMcpProfileInputSchema } from '../validation/schema-loader';
 import { TOOL_INPUT_SHAPES } from '../schemas';
 import { TaskTypeValues } from '../types/enums.generated';
 import { bundleSupportsAdcpVersionField } from '../protocols';
 import { getToolsWithErrorArm, type ErrorArmDescriptor } from './error-arm-tools';
-import type { ToolCallback } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { BaseToolCallback } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type { ZodRawShapeCompat, AnySchema } from '@modelcontextprotocol/sdk/server/zod-compat.js';
-import type { ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
+import type { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol.js';
+import type {
+  CallToolResult,
+  ServerNotification,
+  ServerRequest,
+  ToolAnnotations,
+} from '@modelcontextprotocol/sdk/types.js';
 import type { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
 import { applyStructuredContentTextFallback, type StructuredContentTextFallback } from './structured-content-fallback';
 import {
@@ -499,9 +506,11 @@ export interface HandlerContext<TAccount = unknown> {
   /**
    * AdCP release selected for this request after applying the buyer pin to
    * `capabilities.adcp.supported_versions`. This may be older than the
-   * server's configured maximum release when the seller downshifts.
+   * server's configured maximum release when the seller downshifts. The
+   * framework always supplies it for dispatched calls; optionality preserves
+   * compatibility with legacy code that manually constructs this context.
    */
-  servedAdcpVersion?: string;
+  readonly servedAdcpVersion?: string;
   /**
    * Resolved buyer agent for this request, populated by `BuyerAgentRegistry`
    * when an `agentRegistry` is configured on the server (Phase 1 of #1269).
@@ -557,6 +566,8 @@ export interface HandlerContext<TAccount = unknown> {
 export interface SessionKeyContext<TAccount = unknown> {
   toolName: AdcpServerToolName;
   params: Record<string, unknown>;
+  /** Immutable SDK-selected AdCP release for this request. */
+  readonly servedAdcpVersion?: string;
   account?: TAccount;
   /** Resolved buyer agent (Phase 1 of #1269), when `agentRegistry` is configured. */
   agent?: BuyerAgent;
@@ -574,6 +585,8 @@ export interface SessionKeyContext<TAccount = unknown> {
 export interface ResolveAccountContext {
   /** The AdCP tool being called. */
   toolName: AdcpServerToolName;
+  /** Immutable SDK-selected AdCP release for this request. */
+  readonly servedAdcpVersion?: string;
   /**
    * Authentication info for the caller, populated from `extra.authInfo` on the
    * MCP request. Undefined when no `authenticate` is configured on `serve()`.
@@ -1574,6 +1587,16 @@ export const MEDIA_BUY_MCP_TOOL_PROFILE = [
 
 export type AdcpMcpToolProfile = 'auto' | 'media-buy' | 'all';
 
+/** MCP request facts supplied to a custom-tool handler by the AdCP framework. */
+export type AdcpCustomToolHandlerExtra = RequestHandlerExtra<ServerRequest, ServerNotification> & {
+  /** Immutable SDK-selected AdCP release for this request. */
+  readonly servedAdcpVersion: string;
+};
+
+/** Version-aware custom-tool callback preserving the MCP SDK's schema inference. */
+export type AdcpCustomToolHandler<InputArgs extends undefined | ZodRawShapeCompat | AnySchema = undefined> =
+  BaseToolCallback<CallToolResult, AdcpCustomToolHandlerExtra, InputArgs>;
+
 /**
  * Declarative registration for a tool outside {@link AdcpToolMap} — seller
  * extensions (e.g. collection-list helpers), test-harness endpoints
@@ -1627,7 +1650,7 @@ export interface AdcpCustomToolConfig<
    * must return a `CallToolResult`. Use `capabilitiesResponse`,
    * `mediaBuyResponse`, `adcpError`, or a hand-built `{ content, structuredContent? }`.
    */
-  handler: ToolCallback<InputArgs>;
+  handler: AdcpCustomToolHandler<InputArgs>;
 }
 
 // ---------------------------------------------------------------------------
@@ -1715,23 +1738,33 @@ export interface AdcpServerConfig<TAccount = unknown> {
   exposeToolSchemas?: boolean;
 
   /**
-   * AdCP protocol version this server speaks. Defaults to {@link ADCP_VERSION}
-   * — the GA version the SDK ships against. Override to pin to an older
-   * stable (e.g., `'3.0.0'`) or opt into a beta channel (`'3.1.0-beta.1'`)
-   * once that registry ships.
+   * Newest AdCP protocol version this server supports. Defaults to
+   * {@link ADCP_VERSION} — the version the SDK ships against. Override to pin
+   * the entire server to an older stable release or to set the supported
+   * ceiling independently from `defaultAdcpVersion`.
    *
    * Not the same as `version` (the publisher's app version, e.g., `'1.4.2'`).
    *
-   * Stage 2 plumbs the option through and validates it at construction
-   * time; cross-major pins (e.g. `'4.0.0-beta.1'` while the SDK ships
-   * against major 3) throw `ConfigurationError`. Stage 3 wires per-instance
-   * schema/validator selection off this field.
+   * Pins without a bundled schema release throw `ConfigurationError` at
+   * construction. Per-request schema and wire selection never exceeds this
+   * value.
    *
    * Typed as `AdcpVersion | (string & {})` so editors autocomplete
    * canonical values from {@link COMPATIBLE_ADCP_VERSIONS} while still
    * accepting forward-compatible strings.
    */
   adcpVersion?: AdcpVersion | (string & {});
+
+  /**
+   * AdCP release selected when a caller omits both version claims. Defaults
+   * to the newest release this server advertises at or below `adcpVersion`.
+   *
+   * Set this below `adcpVersion` to keep unversioned callers on a conservative
+   * wire contract while allowing explicit callers to opt into newer releases.
+   * The value must be bundled, included in the server's effective advertised
+   * releases, and no newer than `adcpVersion`.
+   */
+  defaultAdcpVersion?: AdcpVersion | (string & {});
 
   /**
    * Per-tool inclusive protocol-release availability. This narrows, but does
@@ -1989,7 +2022,10 @@ export interface AdcpServerConfig<TAccount = unknown> {
    * returned. Runs for framework tools, custom tools, and generated discovery
    * responses registered by `createAdcpServer`.
    */
-  responseEnhancer?: (response: McpToolResponse) => void;
+  responseEnhancer?: (
+    response: McpToolResponse,
+    context: { readonly toolName: string; readonly servedAdcpVersion: string }
+  ) => void;
   /**
    * Mirror final MCP `structuredContent` into a marked compact-JSON text block
    * for hosts that do not expose the structured channel to the model.
@@ -4340,6 +4376,16 @@ interface ServedAdcpRelease {
   wireVersion?: string;
 }
 
+function withImmutableServedAdcpVersion<T extends object>(context: T, servedAdcpVersion: string): T {
+  Object.defineProperty(context, 'servedAdcpVersion', {
+    value: servedAdcpVersion,
+    enumerable: true,
+    configurable: false,
+    writable: false,
+  });
+  return context;
+}
+
 function isMcpToolResponse(value: ServedAdcpRelease | McpToolResponse): value is McpToolResponse {
   return Array.isArray((value as McpToolResponse).content);
 }
@@ -4575,7 +4621,8 @@ function bundledReleasesForMajors(majors: readonly number[], configured: ParsedA
 function selectServedAdcpRelease(
   params: Record<string, unknown>,
   capConfig: AdcpCapabilitiesConfig | undefined,
-  serverPin: string
+  serverPin: string,
+  defaultPin?: string
 ): ServedAdcpRelease | McpToolResponse {
   const configured = parseAdcpRelease(serverPin);
   if (!configured) {
@@ -4650,10 +4697,17 @@ function selectServedAdcpRelease(
     // the server never upgrades its wire shape implicitly.
     selected = supported.filter(candidate => candidate.major === requestedMajor).sort(compareAdcpRelease)[0];
   } else {
-    // With no buyer claim, serve the newest release the seller actually
-    // advertises rather than silently using a configured pin omitted from
-    // supported_versions.
-    selected = [...supported].sort((left, right) => compareAdcpRelease(right, left))[0];
+    // An explicit server default is a ceiling just like an explicit buyer
+    // pin. Without one, preserve the historical behavior: select the newest
+    // release the seller actually advertises below the configured maximum.
+    const parsedDefault = defaultPin === undefined ? undefined : parseAdcpRelease(defaultPin);
+    selected = (
+      parsedDefault === undefined
+        ? supported
+        : supported.filter(
+            candidate => candidate.major === parsedDefault.major && compareAdcpRelease(candidate, parsedDefault) <= 0
+          )
+    ).sort((left, right) => compareAdcpRelease(right, left))[0];
   }
 
   if (!selected) {
@@ -4723,6 +4777,7 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
     name,
     version,
     adcpVersion: configuredAdcpVersion,
+    defaultAdcpVersion: configuredDefaultAdcpVersion,
     mcpToolProfile = 'auto',
     requireCompactMutationAccountScope = false,
     resolveAccount,
@@ -4858,6 +4913,48 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
       `createAdcpServer: capabilities.supported_versions contains moving prerelease-family alias ${JSON.stringify(movingSupportedVersion)}; pin ${JSON.stringify(toReleasePrecisionVersion(ADCP_VERSION))} instead`
     );
   }
+  const configuredDefaultVersion =
+    configuredDefaultAdcpVersion === undefined
+      ? undefined
+      : resolveAdcpVersion(configuredDefaultAdcpVersion, 'defaultAdcpVersion');
+  const maximumRelease = parseAdcpRelease(adcpVersion);
+  const requestedDefaultRelease =
+    configuredDefaultVersion === undefined ? undefined : parseAdcpRelease(configuredDefaultVersion);
+  if (maximumRelease === undefined) {
+    throw new ConfigurationError(
+      `adcpVersion ${JSON.stringify(adcpVersion)} is not a selectable AdCP release`,
+      'adcpVersion'
+    );
+  }
+  if (requestedDefaultRelease !== undefined && compareAdcpRelease(requestedDefaultRelease, maximumRelease) > 0) {
+    throw new ConfigurationError(
+      `defaultAdcpVersion ${JSON.stringify(configuredDefaultVersion)} must not be newer than ` +
+        `adcpVersion ${JSON.stringify(adcpVersion)}`,
+      'defaultAdcpVersion'
+    );
+  }
+  const selectedDefault = selectServedAdcpRelease({}, capConfig, adcpVersion, configuredDefaultVersion);
+  if (isMcpToolResponse(selectedDefault)) {
+    throw new ConfigurationError(
+      `defaultAdcpVersion ${JSON.stringify(configuredDefaultVersion)} must be present in ` +
+        `capabilities.supported_versions; advertised releases are ` +
+        `${JSON.stringify(buildSupportedVersionsList(capConfig, adcpVersion))}`,
+      'defaultAdcpVersion'
+    );
+  }
+  if (
+    requestedDefaultRelease !== undefined &&
+    compareAdcpRelease(parseAdcpRelease(selectedDefault.validationVersion)!, requestedDefaultRelease) !== 0
+  ) {
+    throw new ConfigurationError(
+      `defaultAdcpVersion ${JSON.stringify(configuredDefaultVersion)} must be present in ` +
+        `capabilities.supported_versions; advertised releases are ` +
+        `${JSON.stringify(buildSupportedVersionsList(capConfig, adcpVersion))}`,
+      'defaultAdcpVersion'
+    );
+  }
+  const defaultAdcpVersion =
+    configuredDefaultVersion ?? selectedDefault.advertisedVersion ?? selectedDefault.validationVersion;
   const proposalRefinementCapabilities = config.proposalNegotiation
     ? defineProposalRefinementCapabilities(config.proposalNegotiation.capabilities)
     : undefined;
@@ -4901,17 +4998,14 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
     );
   }
 
-  // Pre-resolved release-precision identifier the seller echoes on every
-  // response per AdCP 3.1 spec PR `adcontextprotocol/adcp#3493`. `undefined`
-  // when this seller pins a 3.0 bundle (3.0 schemas don't define the field).
-  // Computed once at construction since the seller's pin is fixed for the
-  // server's lifetime — every dispatch reuses the same value. Downshift
-  // (3.1 seller serving a 3.0 buyer at 3.0) is a follow-up; today this
-  // always reflects the seller's own pin.
+  // Pre-resolved release-precision identifier the seller echoes for
+  // unversioned requests per AdCP 3.1 spec PR `adcontextprotocol/adcp#3493`.
+  // Explicitly versioned dispatches replace it with their selected release;
+  // `undefined` means the default bundle predates the wire field.
   const protocolBundleKey = resolveBundleKey(adcpVersion);
   const frameworkToolMeta = { adcp_version: adcpVersion } as const;
   const servedAdcpVersion = (() => {
-    const bundleKey = protocolBundleKey;
+    const bundleKey = resolveBundleKey(defaultAdcpVersion);
     return bundleSupportsAdcpVersionField(bundleKey) ? bundleKey : undefined;
   })();
   const protocolTaskRelease = parseAdcpRelease(protocolBundleKey);
@@ -5345,13 +5439,17 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
   const registeredToolNames = new Set<string>();
   let warnedAboutOptionalReplayWithoutIdempotency = false;
 
-  const applyResponseEnhancer = (response: McpToolResponse): McpToolResponse => {
-    responseEnhancer?.(response);
+  const applyResponseEnhancer = (
+    response: McpToolResponse,
+    toolName: string,
+    servedVersion: string
+  ): McpToolResponse => {
+    responseEnhancer?.(response, Object.freeze({ toolName, servedAdcpVersion: servedVersion }));
     return response;
   };
 
   const requestServedRelease = (params: Record<string, unknown>): ServedAdcpRelease | undefined => {
-    const selected = selectServedAdcpRelease(params, capConfig, adcpVersion);
+    const selected = selectServedAdcpRelease(params, capConfig, adcpVersion, defaultAdcpVersion);
     return isMcpToolResponse(selected) ? undefined : selected;
   };
 
@@ -5371,7 +5469,7 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
     opts: { echoContext?: boolean } = {}
   ): McpToolResponse => {
     const release = requestServedRelease(params) ?? {
-      validationVersion: adcpVersion,
+      validationVersion: selectedDefault.validationVersion,
       ...(servedAdcpVersion !== undefined && { wireVersion: servedAdcpVersion }),
     };
     sanitizeAdcpErrorEnvelope(response);
@@ -5384,14 +5482,14 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
     }
     if (opts.echoContext !== false) injectContextIntoResponse(response, params.context);
     injectVersionIntoResponse(response, release.wireVersion);
-    return applyResponseEnhancer(response);
+    return applyResponseEnhancer(response, toolName, release.validationVersion);
   };
 
   const unsupportedVersionResponse = (
     toolName: 'get_task_status' | 'list_tasks',
     params: Record<string, unknown>
   ): McpToolResponse | undefined => {
-    const selected = selectServedAdcpRelease(params, capConfig, adcpVersion);
+    const selected = selectServedAdcpRelease(params, capConfig, adcpVersion, defaultAdcpVersion);
     if (isMcpToolResponse(selected)) return selected;
     const defined = releaseDefinesTool(toolName, selected);
     if (!defined || !toolAvailableForRelease(toolName, selected.validationVersion)) {
@@ -5566,14 +5664,15 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
   const resolveTaskQueryAccountId = async (
     params: Record<string, unknown>,
     extra: any,
-    toolName: 'get_task_status' | 'list_tasks'
+    toolName: 'get_task_status' | 'list_tasks',
+    servedVersion: string
   ): Promise<{
     accountId?: string;
     ownerScope?: string;
     accountResolutionAttempted: boolean;
     error?: McpToolResponse;
   }> => {
-    const ctx: HandlerContext<TAccount> = { store: stateStore };
+    const ctx: HandlerContext<TAccount> = withImmutableServedAdcpVersion({ store: stateStore }, servedVersion);
     let accountResolutionAttempted = false;
     if (extra?.authInfo) {
       const authInfo = extra.authInfo as ResolvedAuthInfo;
@@ -5626,12 +5725,18 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
         };
       }
       try {
-        const account = await resolveAccount(accountRef as AccountReference, {
-          toolName: toolName as AdcpServerToolName,
-          authInfo: ctx.authInfo,
-          ...(ctx.agent != null && { agent: ctx.agent }),
-          input: params,
-        });
+        const account = await resolveAccount(
+          accountRef as AccountReference,
+          withImmutableServedAdcpVersion(
+            {
+              toolName: toolName as AdcpServerToolName,
+              authInfo: ctx.authInfo,
+              ...(ctx.agent != null && { agent: ctx.agent }),
+              input: params,
+            },
+            servedVersion
+          )
+        );
         if (account != null) ctx.account = account;
         if (account == null) {
           return {
@@ -5659,12 +5764,17 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
       }
     } else if (resolveAccountFromAuth) {
       try {
-        const account = await resolveAccountFromAuth({
-          toolName,
-          authInfo: ctx.authInfo,
-          ...(ctx.agent != null && { agent: ctx.agent }),
-          input: params,
-        });
+        const account = await resolveAccountFromAuth(
+          withImmutableServedAdcpVersion(
+            {
+              toolName,
+              authInfo: ctx.authInfo,
+              ...(ctx.agent != null && { agent: ctx.agent }),
+              input: params,
+            },
+            servedVersion
+          )
+        );
         accountResolutionAttempted = true;
         if (account != null) {
           ctx.account = account;
@@ -5689,12 +5799,17 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
 
     if (resolveSessionKey) {
       try {
-        const sessionKey = await resolveSessionKey({
-          toolName: toolName as AdcpServerToolName,
-          params,
-          account: ctx.account,
-          ...(ctx.agent != null && { agent: ctx.agent }),
-        });
+        const sessionKey = await resolveSessionKey(
+          withImmutableServedAdcpVersion(
+            {
+              toolName: toolName as AdcpServerToolName,
+              params,
+              account: ctx.account,
+              ...(ctx.agent != null && { agent: ctx.agent }),
+            },
+            servedVersion
+          )
+        );
         if (sessionKey !== undefined) ctx.sessionKey = sessionKey;
       } catch (err) {
         const reason = err instanceof Error ? err.message : String(err);
@@ -5774,24 +5889,26 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
       const wrap = meta?.wrap ?? ((data: any, summary?: string) => genericResponse(toolName, data, summary));
       const toolHandler = async (params: any, extra: any) => {
         const callRequestValidationMode = effectiveRequestValidationMode(extra);
-        const releaseSelection = selectServedAdcpRelease(params, capConfig, adcpVersion);
+        const releaseSelection = selectServedAdcpRelease(params, capConfig, adcpVersion, defaultAdcpVersion);
         let releaseError: McpToolResponse | undefined;
         let requestRelease: ServedAdcpRelease;
         if (isMcpToolResponse(releaseSelection)) {
           releaseError = releaseSelection;
           requestRelease = {
-            validationVersion: adcpVersion,
+            validationVersion: selectedDefault.validationVersion,
             ...(servedAdcpVersion !== undefined && { wireVersion: servedAdcpVersion }),
           };
         } else {
           requestRelease = releaseSelection;
         }
         const requestErrorArms = getToolsWithErrorArm(requestRelease.validationVersion);
-        const ctx: HandlerContext<TAccount> = {
-          store: stateStore,
-          servedAdcpVersion: requestRelease.validationVersion,
-          ...(extra?.signal !== undefined && { signal: extra.signal }),
-        };
+        const ctx: HandlerContext<TAccount> = withImmutableServedAdcpVersion(
+          {
+            store: stateStore,
+            ...(extra?.signal !== undefined && { signal: extra.signal }),
+          },
+          requestRelease.validationVersion
+        );
         if (extra?.authInfo) {
           ctx.authInfo = extra.authInfo;
           // Hoist the kind-discriminated credential from MCP's `extra`
@@ -5841,7 +5958,7 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
           return response;
         };
         const finalize = (response: McpToolResponse): McpToolResponse =>
-          applyResponseEnhancer(finalizeProtocolEnvelope(response));
+          applyResponseEnhancer(finalizeProtocolEnvelope(response), toolName, requestRelease.validationVersion);
 
         if (releaseError) return finalize(releaseError);
         const definedForRelease = releaseDefinesTool(toolName, requestRelease);
@@ -6150,7 +6267,9 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
                     'Request args carry credential-shaped keys. Credentials must arrive on authInfo, not in the request body.',
                   recovery: 'correctable',
                   details: { scope: 'credentials', credential_paths: blockedPaths },
-                })
+                }),
+                toolName,
+                requestRelease.validationVersion
               );
             }
           }
@@ -6214,7 +6333,9 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
                     'Request authentication context carries credential-shaped keys. Configure your authenticator to keep credentials off authInfo.extra.',
                   recovery: 'terminal',
                   details: { scope: 'credentials' },
-                })
+                }),
+                toolName,
+                requestRelease.validationVersion
               );
             }
           }
@@ -6312,12 +6433,18 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
         // --- Account resolution ---
         if (hasAccount && params.account != null && resolveAccount) {
           try {
-            const account = await resolveAccount(params.account, {
-              toolName: toolName as AdcpServerToolName,
-              authInfo: ctx.authInfo,
-              ...(ctx.agent != null && { agent: ctx.agent }),
-              input: params,
-            });
+            const account = await resolveAccount(
+              params.account,
+              withImmutableServedAdcpVersion(
+                {
+                  toolName: toolName as AdcpServerToolName,
+                  authInfo: ctx.authInfo,
+                  ...(ctx.agent != null && { agent: ctx.agent }),
+                  input: params,
+                },
+                requestRelease.validationVersion
+              )
+            );
             if (account == null) {
               logger.warn('Account not found', { tool: toolName, account: params.account });
               return finalize(
@@ -6359,12 +6486,17 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
           // return is allowed — handler sees ctx.account undefined and
           // either tolerates it (publisher-wide reads) or throws AdcpError.
           try {
-            const account = await resolveAccountFromAuth({
-              toolName: toolName as AdcpServerToolName,
-              authInfo: ctx.authInfo,
-              ...(ctx.agent != null && { agent: ctx.agent }),
-              input: params,
-            });
+            const account = await resolveAccountFromAuth(
+              withImmutableServedAdcpVersion(
+                {
+                  toolName: toolName as AdcpServerToolName,
+                  authInfo: ctx.authInfo,
+                  ...(ctx.agent != null && { agent: ctx.agent }),
+                  input: params,
+                },
+                requestRelease.validationVersion
+              )
+            );
             if (account != null) ctx.account = account;
           } catch (err) {
             // Same typed-error pass-through as the explicit `resolveAccount`
@@ -6422,12 +6554,17 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
         // --- Session key resolution ---
         if (resolveSessionKey) {
           try {
-            const sessionKey = await resolveSessionKey({
-              toolName: toolName as AdcpServerToolName,
-              params,
-              account: ctx.account,
-              ...(ctx.agent != null && { agent: ctx.agent }),
-            });
+            const sessionKey = await resolveSessionKey(
+              withImmutableServedAdcpVersion(
+                {
+                  toolName: toolName as AdcpServerToolName,
+                  params,
+                  account: ctx.account,
+                  ...(ctx.agent != null && { agent: ctx.agent }),
+                },
+                requestRelease.validationVersion
+              )
+            );
             if (sessionKey !== undefined) ctx.sessionKey = sessionKey;
           } catch (err) {
             const reason = err instanceof Error ? err.message : String(err);
@@ -7774,11 +7911,13 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
         if (boundsError) return finalizeProtocolTaskToolResponse('get_task_status', params ?? {}, boundsError);
         const versionError = unsupportedVersionResponse('get_task_status', params ?? {});
         if (versionError) return finalizeProtocolTaskToolResponse('get_task_status', params ?? {}, versionError);
+        const requestRelease = requestServedRelease(params ?? {}) ?? selectedDefault;
         const taskId = typeof params?.task_id === 'string' ? params.task_id : '';
         const { accountId, ownerScope, error } = await resolveTaskQueryAccountId(
           params ?? {},
           extra,
-          'get_task_status'
+          'get_task_status',
+          requestRelease.validationVersion
         );
         if (error) return finalizeProtocolTaskToolResponse('get_task_status', params ?? {}, error);
         let task: TaskRecord | null = null;
@@ -7870,7 +8009,13 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
         if (boundsError) return finalizeProtocolTaskToolResponse('list_tasks', params ?? {}, boundsError);
         const versionError = unsupportedVersionResponse('list_tasks', params ?? {});
         if (versionError) return finalizeProtocolTaskToolResponse('list_tasks', params ?? {}, versionError);
-        const { accountId, ownerScope, error } = await resolveTaskQueryAccountId(params ?? {}, extra, 'list_tasks');
+        const requestRelease = requestServedRelease(params ?? {}) ?? selectedDefault;
+        const { accountId, ownerScope, error } = await resolveTaskQueryAccountId(
+          params ?? {},
+          extra,
+          'list_tasks',
+          requestRelease.validationVersion
+        );
         if (error) return finalizeProtocolTaskToolResponse('list_tasks', params ?? {}, error);
         let cursorStart = 0;
         try {
@@ -7992,11 +8137,19 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
         if (customName === 'tasks_get') {
           injectVersionIntoResponse(response, taskRelease?.wireVersion ?? servedAdcpVersion);
         }
-        return applyResponseEnhancer(response);
+        return applyResponseEnhancer(
+          response,
+          customName,
+          taskRelease?.validationVersion ?? selectedDefault.validationVersion
+        );
       };
       const wrappedHandler = (async (...args: unknown[]) => {
+        // Preserve the MCP SDK's runtime callback shape exactly. In
+        // particular, legacy dispatch may still pass a request arguments
+        // object to schema-less custom tools; version selection must inspect
+        // it even though the public callback type exposes only `extra`.
         const params = isPlainObject(args[0]) ? args[0] : {};
-        const selectedRelease = selectServedAdcpRelease(params, capConfig, adcpVersion);
+        const selectedRelease = selectServedAdcpRelease(params, capConfig, adcpVersion, defaultAdcpVersion);
         if (isMcpToolResponse(selectedRelease)) return finalizeCustomResponse(selectedRelease);
         if (!toolAvailableForRelease(customName, selectedRelease.validationVersion)) {
           return finalizeCustomResponse(
@@ -8010,7 +8163,16 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
           );
         }
         try {
-          return finalizeCustomResponse(await rawHandler(...args), selectedRelease);
+          const extraIndex = Math.max(0, args.length - 1);
+          const rawExtra = args[extraIndex] as Record<string, unknown> | undefined;
+          const versionedExtra = withImmutableServedAdcpVersion(
+            { ...(rawExtra ?? {}) },
+            selectedRelease.validationVersion
+          );
+          const versionedArgs = [...args];
+          versionedArgs[extraIndex] = versionedExtra;
+          const response = await rawHandler(...versionedArgs);
+          return finalizeCustomResponse(response, selectedRelease);
         } catch (err) {
           if (isThrownAdcpError(err)) return finalizeCustomResponse(err, selectedRelease);
           if (err instanceof AdcpError) return finalizeCustomResponse(projectThrownAdcpError(err), selectedRelease);
@@ -8263,10 +8425,10 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
     (async (params: any, extra: { authInfo?: ResolvedAuthInfo } = {}) => {
       const callRequestValidationMode = effectiveRequestValidationMode(extra);
       const requestParams = isPlainObject(params) ? params : {};
-      const releaseSelection = selectServedAdcpRelease(requestParams, capConfig, adcpVersion);
+      const releaseSelection = selectServedAdcpRelease(requestParams, capConfig, adcpVersion, defaultAdcpVersion);
       const release = isMcpToolResponse(releaseSelection)
         ? {
-            validationVersion: adcpVersion,
+            validationVersion: selectedDefault.validationVersion,
             ...(servedAdcpVersion !== undefined && { wireVersion: servedAdcpVersion }),
           }
         : releaseSelection;
@@ -8274,7 +8436,7 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
         sanitizeAdcpErrorEnvelope(response);
         injectContextIntoResponse(response, requestParams.context);
         injectVersionIntoResponse(response, release.wireVersion);
-        return applyResponseEnhancer(response);
+        return applyResponseEnhancer(response, 'get_adcp_capabilities', release.validationVersion);
       };
 
       if (isMcpToolResponse(releaseSelection)) {
@@ -8447,7 +8609,7 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
           }
         }
       }
-      return applyResponseEnhancer(response);
+      return applyResponseEnhancer(response, 'get_adcp_capabilities', release.validationVersion);
     }) as Parameters<typeof server.registerTool>[2]
   );
   registeredToolNames.add('get_adcp_capabilities');
@@ -8492,10 +8654,15 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
         ? listParams.adcp_version
         : typeof listMeta.adcp_version === 'string'
           ? listMeta.adcp_version
-          : adcpVersion;
-    const selectedListRelease = selectServedAdcpRelease({ adcp_version: requestedListRelease }, capConfig, adcpVersion);
+          : undefined;
+    const selectedListRelease = selectServedAdcpRelease(
+      { adcp_version: requestedListRelease },
+      capConfig,
+      adcpVersion,
+      defaultAdcpVersion
+    );
     const listRelease: ServedAdcpRelease = isMcpToolResponse(selectedListRelease)
-      ? { validationVersion: adcpVersion }
+      ? { validationVersion: selectedDefault.validationVersion }
       : selectedListRelease;
     const parsedListRelease = parseAdcpRelease(listRelease.validationVersion);
     const listServes32OrNewer =
@@ -8632,12 +8799,23 @@ export function createAdcpServer<TAccount = unknown>(config: AdcpServerConfig<TA
   };
   const wrapped: AdcpServerInternal = wrapMcpServer(server, compliance, adcpVersion, {
     structuredContentTextFallback,
+    defaultAdcpVersion,
   });
-  setToolVersionAvailabilityResolver(wrapped, toolAvailableForRelease);
+  setToolVersionAvailabilityResolver(wrapped, (toolName, release) => {
+    if (!toolAvailableForRelease(toolName, release)) return false;
+    if (config.customTools?.[toolName] !== undefined) return true;
+    return releaseDefinesTool(toolName, { validationVersion: release });
+  });
   setDiscoveryVersionResolver(wrapped, requestedVersion => {
-    if (requestedVersion === undefined) return adcpVersion;
-    const selected = selectServedAdcpRelease({ adcp_version: requestedVersion }, capConfig, adcpVersion);
-    return isMcpToolResponse(selected) ? adcpVersion : (selected.advertisedVersion ?? selected.validationVersion);
+    const selected = selectServedAdcpRelease(
+      { adcp_version: requestedVersion },
+      capConfig,
+      adcpVersion,
+      defaultAdcpVersion
+    );
+    return isMcpToolResponse(selected)
+      ? defaultAdcpVersion
+      : (selected.advertisedVersion ?? selected.validationVersion);
   });
   setMcpToolProfile(wrapped, activeMcpToolProfile);
   setMcpAppResources(wrapped, mcpAppResources);

--- a/src/lib/server/decisioning/account.ts
+++ b/src/lib/server/decisioning/account.ts
@@ -386,6 +386,8 @@ export interface ResolveContext {
   authInfo?: ResolvedAuthInfo;
   /** Tool the buyer is calling — useful for tool-aware tenant routing. */
   toolName?: string;
+  /** Immutable AdCP release selected by the SDK for this request. */
+  readonly servedAdcpVersion?: string;
   /**
    * Resolved buyer agent from `BuyerAgentRegistry.resolve()`, when an
    * `agentRegistry` is configured (Phase 1 of #1269). The framework calls

--- a/src/lib/server/decisioning/async-outcome.ts
+++ b/src/lib/server/decisioning/async-outcome.ts
@@ -272,6 +272,8 @@ export interface TaskHandoff<TResult> {
  */
 export interface TaskHandoffContext {
   readonly id: string;
+  /** Immutable AdCP release selected for the request that created this task. */
+  readonly servedAdcpVersion?: string;
   /**
    * Trusted serializable handle for durable out-of-process settlement.
    * Persist the complete value; never project it onto the buyer wire.
@@ -299,6 +301,8 @@ export interface TaskHandoffContext {
  */
 export interface ExternalTaskHandoffContext {
   readonly id: string;
+  /** Immutable AdCP release selected for the request that created this task. */
+  readonly servedAdcpVersion?: string;
   /** Trusted serializable handle for the durable worker settlement record. */
   readonly taskRef: ScopedTaskRef;
   update(progress: TaskHandoffProgress): Promise<void>;

--- a/src/lib/server/decisioning/context.ts
+++ b/src/lib/server/decisioning/context.ts
@@ -51,6 +51,9 @@ export interface RequestContext<TAccount = Account> {
   /** Resolved account for this request. */
   account: TAccount;
 
+  /** Immutable AdCP release selected by the SDK for this request. */
+  readonly servedAdcpVersion?: string;
+
   /**
    * Verified incoming request principal, when the transport authenticated
    * the caller. This is the same request-local value supplied to

--- a/src/lib/server/decisioning/runtime/from-platform.ts
+++ b/src/lib/server/decisioning/runtime/from-platform.ts
@@ -180,6 +180,18 @@ const DEFAULT_FRAMEWORK_LOGGER: AdcpLogger = {
   // eslint-disable-next-line no-console
   error: console.error.bind(console),
 };
+
+function withImmutableServedAdcpVersion<T extends object>(context: T, servedAdcpVersion?: string): T {
+  if (servedAdcpVersion !== undefined) {
+    Object.defineProperty(context, 'servedAdcpVersion', {
+      value: servedAdcpVersion,
+      enumerable: true,
+      configurable: false,
+      writable: false,
+    });
+  }
+  return context;
+}
 import { createInMemoryStatusChangeBus, type StatusChangeBus, type PublishStatusChangeOpts } from '../status-changes';
 import {
   _handleComplyControllerWithResolvedAuthority,
@@ -3479,7 +3491,10 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
           description: controller.toolDefinition.description,
           inputSchema: gatedInputSchema,
         },
-        (async (input: Record<string, unknown>, extra: { authInfo?: ResolvedAuthInfo } | undefined) => {
+        (async (
+          input: Record<string, unknown>,
+          extra: { authInfo?: ResolvedAuthInfo; readonly servedAdcpVersion?: string } | undefined
+        ) => {
           const principalAuthority = await resolveComplyPrincipalAuthority(extra, 'comply_test_controller', input);
           if (!isComplyControllerVisible(principalAuthority.principalAccount)) {
             throw new McpError(ErrorCode.MethodNotFound, 'Method not found');
@@ -3504,6 +3519,9 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
               toResolveCtx(
                 {
                   ...(extra?.authInfo !== undefined && { authInfo: extra.authInfo }),
+                  ...(extra?.servedAdcpVersion !== undefined && {
+                    servedAdcpVersion: extra.servedAdcpVersion,
+                  }),
                   ...(agent !== undefined && { agent }),
                 },
                 'comply_test_controller',
@@ -3607,14 +3625,19 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
           let sessionKey: string | undefined;
           if (opts.resolveSessionKey !== undefined && resolvedAccount !== null && taskLookupParams !== undefined) {
             try {
-              sessionKey = await opts.resolveSessionKey({
-                // Resolve exactly the scope the framework's tasks/get path
-                // would authorize for this task-oriented controller action.
-                toolName: 'tasks_get' as AdcpServerToolName,
-                params: taskLookupParams,
-                account: resolvedAccount,
-                ...(agent !== undefined && { agent }),
-              });
+              sessionKey = await opts.resolveSessionKey(
+                withImmutableServedAdcpVersion(
+                  {
+                    // Resolve exactly the scope the framework's tasks/get path
+                    // would authorize for this task-oriented controller action.
+                    toolName: 'tasks_get' as AdcpServerToolName,
+                    params: taskLookupParams,
+                    account: resolvedAccount,
+                    ...(agent !== undefined && { agent }),
+                  },
+                  extra?.servedAdcpVersion
+                )
+              );
             } catch (err) {
               fwLogger.warn?.('Session key resolution failed during comply controller dispatch', {
                 error: redactCredentialPatterns(err instanceof Error ? err.message : String(err)),
@@ -3628,13 +3651,16 @@ export function createAdcpServerFromPlatform<P extends DecisioningPlatform<any, 
 
           let taskScope: Readonly<TaskRegistryScope> | undefined;
           if (resolvedAccount !== null) {
-            const ownerCtx: HandlerContext<Account> = {
-              store: {} as HandlerContext<Account>['store'],
-              account: resolvedAccount,
-              ...(extra?.authInfo !== undefined && { authInfo: extra.authInfo }),
-              ...(agent !== undefined && { agent }),
-              ...(sessionKey !== undefined && { sessionKey }),
-            };
+            const ownerCtx: HandlerContext<Account> = withImmutableServedAdcpVersion(
+              {
+                store: {} as HandlerContext<Account>['store'],
+                account: resolvedAccount,
+                ...(extra?.authInfo !== undefined && { authInfo: extra.authInfo }),
+                ...(agent !== undefined && { agent }),
+                ...(sessionKey !== undefined && { sessionKey }),
+              },
+              extra?.servedAdcpVersion
+            );
             taskScope = Object.freeze({
               accountId: resolvedAccount.id,
               ownerScope: taskOwnerScopeFor(ownerCtx, resolvedAccount.id),
@@ -3741,7 +3767,7 @@ function buildTasksGetTool<P extends DecisioningPlatform<any, any>>(
     credentialPolicy === undefined || typeof credentialPolicy === 'string' ? undefined : credentialPolicy.patterns;
   const credentialPolicyError = (
     args: Record<string, unknown>,
-    extra: { authInfo?: ResolvedAuthInfo } | undefined
+    extra: { authInfo?: ResolvedAuthInfo; servedAdcpVersion?: string } | undefined
   ): AdcpErrorResponse | undefined => {
     if (credentialPolicy === undefined) return undefined;
     const effectivePolicy = resolveCredentialPolicyForTool(credentialPolicy, 'tasks_get');
@@ -3850,7 +3876,7 @@ function buildTasksGetTool<P extends DecisioningPlatform<any, any>>(
         adcp_version?: string;
         adcp_major_version?: number;
       },
-      extra: { authInfo?: ResolvedAuthInfo }
+      extra: { authInfo?: ResolvedAuthInfo; readonly servedAdcpVersion?: string }
     ) => {
       const policyError = credentialPolicyError(args as Record<string, unknown>, extra);
       if (policyError) return policyError;
@@ -3907,11 +3933,14 @@ function buildTasksGetTool<P extends DecisioningPlatform<any, any>>(
           });
         }
       }
-      const resolveCtx = {
-        ...(extra?.authInfo !== undefined && { authInfo: extra.authInfo }),
-        toolName: 'tasks_get',
-        ...(agent !== undefined && { agent }),
-      };
+      const resolveCtx = withImmutableServedAdcpVersion(
+        {
+          ...(extra?.authInfo !== undefined && { authInfo: extra.authInfo }),
+          toolName: 'tasks_get',
+          ...(agent !== undefined && { agent }),
+        },
+        extra?.servedAdcpVersion
+      );
       let resolvedAccountId: string | undefined;
       let resolvedAccount: Account | undefined;
       if (ref) {
@@ -3955,12 +3984,17 @@ function buildTasksGetTool<P extends DecisioningPlatform<any, any>>(
       let sessionKey: string | undefined;
       if (resolveSessionKey !== undefined) {
         try {
-          sessionKey = await resolveSessionKey({
-            toolName: 'tasks_get' as AdcpServerToolName,
-            params: args,
-            ...(resolvedAccount !== undefined && { account: resolvedAccount }),
-            ...(agent !== undefined && { agent }),
-          });
+          sessionKey = await resolveSessionKey(
+            withImmutableServedAdcpVersion(
+              {
+                toolName: 'tasks_get' as AdcpServerToolName,
+                params: args,
+                ...(resolvedAccount !== undefined && { account: resolvedAccount }),
+                ...(agent !== undefined && { agent }),
+              },
+              extra?.servedAdcpVersion
+            )
+          );
         } catch (err) {
           logger.error?.('Session key resolution failed during tasks_get poll', {
             error: err instanceof Error ? err.message : String(err),
@@ -3977,13 +4011,16 @@ function buildTasksGetTool<P extends DecisioningPlatform<any, any>>(
           field: 'task_id',
         });
       }
-      const ownerCtx: HandlerContext<Account> = {
-        store: {} as HandlerContext<Account>['store'],
-        ...(extra?.authInfo !== undefined && { authInfo: extra.authInfo }),
-        ...(agent !== undefined && { agent }),
-        ...(sessionKey !== undefined && { sessionKey }),
-        account: resolvedAccount ?? ({ id: resolvedAccountId } as Account),
-      };
+      const ownerCtx: HandlerContext<Account> = withImmutableServedAdcpVersion(
+        {
+          store: {} as HandlerContext<Account>['store'],
+          ...(extra?.authInfo !== undefined && { authInfo: extra.authInfo }),
+          ...(agent !== undefined && { agent }),
+          ...(sessionKey !== undefined && { sessionKey }),
+          account: resolvedAccount ?? ({ id: resolvedAccountId } as Account),
+        },
+        extra?.servedAdcpVersion
+      );
       const expectedOwnerScope = taskOwnerScopeFor(ownerCtx, resolvedAccountId);
 
       let record;
@@ -4772,7 +4809,7 @@ async function routeIfHandoff<TInner, TWire>(
         taskRegistry,
         opts,
         async taskRef => {
-          await externalTaskFn(buildExternalHandoffContext(taskRegistry, taskRef));
+          await externalTaskFn(buildExternalHandoffContext(taskRegistry, taskRef, opts.servedAdcpVersion));
         },
         options.task_id,
         'external'
@@ -4787,7 +4824,7 @@ async function routeIfHandoff<TInner, TWire>(
           handoffTaskStarted = true;
           let inner: TInner;
           try {
-            inner = await taskFn(buildHandoffContext(taskRegistry, taskRef));
+            inner = await taskFn(buildHandoffContext(taskRegistry, taskRef, opts.servedAdcpVersion));
           } catch (error) {
             // A business rejection still abandons proposal-backed work. The
             // callback releases the reservation before the rejection signal
@@ -5279,16 +5316,19 @@ function makeCtxFor(ctxMetadataStore?: CtxMetadataStore): CtxForFn {
  * can use `'authInfo' in ctx` as a presence check.
  */
 function toResolveCtx(
-  ctx: { authInfo?: ResolvedAuthInfo; agent?: BuyerAgent },
+  ctx: { authInfo?: ResolvedAuthInfo; agent?: BuyerAgent; servedAdcpVersion?: string },
   toolName: string | undefined,
   input?: Readonly<Record<string, unknown>>
 ): ResolveContext {
-  return {
-    ...(ctx.authInfo !== undefined && { authInfo: ctx.authInfo }),
-    ...(toolName !== undefined && { toolName }),
-    ...(ctx.agent != null && { agent: ctx.agent }),
-    ...(input != null && { input }),
-  };
+  return withImmutableServedAdcpVersion(
+    {
+      ...(ctx.authInfo !== undefined && { authInfo: ctx.authInfo }),
+      ...(toolName !== undefined && { toolName }),
+      ...(ctx.agent != null && { agent: ctx.agent }),
+      ...(input != null && { input }),
+    },
+    ctx.servedAdcpVersion
+  );
 }
 
 /**

--- a/src/lib/server/decisioning/runtime/to-context.ts
+++ b/src/lib/server/decisioning/runtime/to-context.ts
@@ -251,7 +251,7 @@ export function buildRequestContext<TCtxMeta = Record<string, unknown>>(
       ? buildCtxMetadataAccessor(ctxMetadataStore, account.id)
       : undefined;
 
-  return {
+  const context: RequestContext<Account<TCtxMeta>> = {
     account,
     ...(handlerCtx.authInfo != null && { authInfo: cloneAndFreezeAuthValue(handlerCtx.authInfo) }),
     ...(handlerCtx.agent != null && { agent: handlerCtx.agent }),
@@ -276,6 +276,15 @@ export function buildRequestContext<TCtxMeta = Record<string, unknown>>(
     ctxMetadata,
     handoffToTask: createContextTaskHandoff,
   };
+  if (handlerCtx.servedAdcpVersion !== undefined) {
+    Object.defineProperty(context, 'servedAdcpVersion', {
+      value: handlerCtx.servedAdcpVersion,
+      enumerable: true,
+      configurable: false,
+      writable: false,
+    });
+  }
+  return context;
 }
 
 /**
@@ -298,10 +307,11 @@ export function buildRequestContext<TCtxMeta = Record<string, unknown>>(
  */
 export function buildExternalHandoffContext(
   taskRegistry: TaskRegistry,
-  taskRef: ScopedTaskRef
+  taskRef: ScopedTaskRef,
+  servedAdcpVersion?: string
 ): ExternalTaskHandoffContext {
   const { taskId } = taskRef;
-  return {
+  const context: ExternalTaskHandoffContext = {
     id: taskId,
     taskRef,
     update: async progress => {
@@ -321,12 +331,24 @@ export function buildExternalHandoffContext(
       await Promise.resolve();
     },
   };
+  if (servedAdcpVersion !== undefined) {
+    Object.defineProperty(context, 'servedAdcpVersion', {
+      value: servedAdcpVersion,
+      enumerable: true,
+      configurable: false,
+      writable: false,
+    });
+  }
+  return context;
 }
 
 /** @internal Construct the framework-settled context, including reject(). */
-export function buildHandoffContext(taskRegistry: TaskRegistry, taskRef: ScopedTaskRef): TaskHandoffContext {
-  return {
-    ...buildExternalHandoffContext(taskRegistry, taskRef),
-    reject: (result, reason) => throwTaskHandoffRejection(result, reason),
-  };
+export function buildHandoffContext(
+  taskRegistry: TaskRegistry,
+  taskRef: ScopedTaskRef,
+  servedAdcpVersion?: string
+): TaskHandoffContext {
+  return Object.assign(buildExternalHandoffContext(taskRegistry, taskRef, servedAdcpVersion), {
+    reject: <TResult = never>(result: TResult, reason?: string): never => throwTaskHandoffRejection(result, reason),
+  });
 }

--- a/src/lib/server/index.ts
+++ b/src/lib/server/index.ts
@@ -377,6 +377,8 @@ export type {
   AdcpCapabilitiesOverrides,
   AdcpToolVersionRange,
   AdcpCustomToolConfig as LegacyAdcpCustomToolConfig,
+  AdcpCustomToolHandler as LegacyAdcpCustomToolHandler,
+  AdcpCustomToolHandlerExtra as LegacyAdcpCustomToolHandlerExtra,
   McpAppUiMeta,
   McpAppMeta,
   AdcpLogger,

--- a/src/lib/server/legacy/v5/index.ts
+++ b/src/lib/server/legacy/v5/index.ts
@@ -94,6 +94,8 @@ export type {
   AdcpCapabilitiesConfig,
   AdcpCapabilitiesOverrides,
   AdcpCustomToolConfig,
+  AdcpCustomToolHandler,
+  AdcpCustomToolHandlerExtra,
   McpAppUiMeta,
   McpAppMeta,
   AdcpLogger,

--- a/src/lib/utils/adcp-version-config.ts
+++ b/src/lib/utils/adcp-version-config.ts
@@ -50,25 +50,25 @@ export function isValidAdcpVersion(version: string | undefined): version is stri
  * 3.1.0-beta.1/` exists). Pins of the SDK's currently-pinned `ADCP_VERSION`
  * always succeed without an fs check — the bundle is guaranteed.
  */
-export function resolveAdcpVersion(adcpVersion: string | undefined): string {
+export function resolveAdcpVersion(adcpVersion: string | undefined, optionName = 'adcpVersion'): string {
   if (adcpVersion === undefined) return ADCP_VERSION;
 
   const currentReleasePrecision = toReleasePrecisionWire(ADCP_VERSION);
   if (isMovingAdcpPrereleaseFamilyAlias(adcpVersion)) {
     throw new ConfigurationError(
-      `adcpVersion ${JSON.stringify(adcpVersion)} is a moving prerelease-family alias. ` +
+      `${optionName} ${JSON.stringify(adcpVersion)} is a moving prerelease-family alias. ` +
         `Pin the exact 3.2 prerelease artifact (${JSON.stringify(currentReleasePrecision)}) instead.`,
-      'adcpVersion'
+      optionName
     );
   }
 
   const major = parseAdcpMajorVersion(adcpVersion);
   if (!Number.isFinite(major)) {
     throw new ConfigurationError(
-      `adcpVersion ${JSON.stringify(adcpVersion)} is not a valid AdCP version. ` +
+      `${optionName} ${JSON.stringify(adcpVersion)} is not a valid AdCP version. ` +
         `Expected a semver string (e.g. '3.0.1', '3.1.0-beta.1') or a legacy alias. ` +
         `Currently bundled: ${listBundledAdcpVersions().join(', ')}.`,
-      'adcpVersion'
+      optionName
     );
   }
 
@@ -83,13 +83,13 @@ export function resolveAdcpVersion(adcpVersion: string | undefined): string {
   if (!hasSchemaBundle(adcpVersion)) {
     const resolvedKey = resolveBundleKey(adcpVersion);
     throw new ConfigurationError(
-      `adcpVersion ${JSON.stringify(adcpVersion)} resolves to bundle key "${resolvedKey}", ` +
+      `${optionName} ${JSON.stringify(adcpVersion)} resolves to bundle key "${resolvedKey}", ` +
         `but no schema bundle for that key ships with this SDK build. ` +
         `Currently bundled: ${listBundledAdcpVersions().join(', ')}. ` +
         `If you're testing against a beta that the spec repo has tagged but the SDK hasn't synced yet, ` +
         `run \`npm run sync-schemas\` and \`npm run build:lib\` to populate the cache, ` +
         `then re-construct.`,
-      'adcpVersion'
+      optionName
     );
   }
 

--- a/test/lib/media-buy-lifecycle-compatibility.test.js
+++ b/test/lib/media-buy-lifecycle-compatibility.test.js
@@ -31,6 +31,7 @@ async function withDualSurfaceSeller(serverAdcpVersion, buyerAdcpVersion, run, o
     name: 'dual-surface-seller',
     version: '1.0.0',
     adcpVersion: serverAdcpVersion,
+    ...(options.defaultAdcpVersion && { defaultAdcpVersion: options.defaultAdcpVersion }),
     idempotency: createIdempotencyStore({ backend: memoryBackend({ sweepIntervalMs: 0 }) }),
     resolveSessionKey: () => 'dual-surface-seller',
     ...(options.mcpToolProfile && { mcpToolProfile: options.mcpToolProfile }),
@@ -131,6 +132,43 @@ async function withDualSurfaceSeller(serverAdcpVersion, buyerAdcpVersion, run, o
     await Promise.allSettled([mcpClient.close(), server.close()]);
   }
 }
+
+test('dual-surface seller defaults unversioned MCP callers to 3.1 while explicit 3.2 remains reachable', async () => {
+  await withDualSurfaceSeller(
+    '3.2.0-rc.1',
+    '3.2.0-rc.1',
+    async ({ mcpClient, calls }) => {
+      const defaultTools = await mcpClient.listTools();
+      assert.strictEqual(defaultTools._meta.adcp_version, '3.1.18');
+      assert.ok(defaultTools.tools.some(tool => tool.name === 'get_products'));
+      assert.ok(!defaultTools.tools.some(tool => tool.name === 'list_products'));
+
+      const explicitTools = await mcpClient.listTools({ _meta: { adcp_version: '3.2.0-rc.1' } });
+      assert.strictEqual(explicitTools._meta.adcp_version, '3.2.0-rc.1');
+      assert.ok(explicitTools.tools.some(tool => tool.name === 'list_products'));
+      assert.ok(!explicitTools.tools.some(tool => tool.name === 'get_products'));
+
+      const established = await mcpClient.callTool({
+        name: 'get_products',
+        arguments: { buying_mode: 'wholesale' },
+      });
+      assert.notStrictEqual(established.isError, true, JSON.stringify(established.structuredContent));
+      assert.strictEqual(established.structuredContent.adcp_version, '3.1');
+
+      const compact = await mcpClient.callTool({
+        name: 'list_products',
+        arguments: { adcp_version: '3.2-rc.1', max_results: 10 },
+      });
+      assert.notStrictEqual(compact.isError, true, JSON.stringify(compact.structuredContent));
+      assert.strictEqual(compact.structuredContent.adcp_version, '3.2-rc.1');
+      assert.deepStrictEqual(
+        calls.map(([tool]) => tool),
+        ['get_products', 'list_products']
+      );
+    },
+    { defaultAdcpVersion: '3.1.18' }
+  );
+});
 
 test('forced established diagnostics use actual MCP tool discovery on an all-tools 3.2 seller', async () => {
   await withDualSurfaceSeller(

--- a/test/lib/media-buy-lifecycle-compatibility.test.js
+++ b/test/lib/media-buy-lifecycle-compatibility.test.js
@@ -138,6 +138,13 @@ test('dual-surface seller defaults unversioned MCP callers to 3.1 while explicit
     '3.2.0-rc.1',
     '3.2.0-rc.1',
     async ({ mcpClient, calls }) => {
+      const sdkTools = await AgentClient.fromMCPClient(mcpClient, {
+        adcpVersion: '3.2.0-rc.1',
+        validation: { requests: 'strict', responses: 'off' },
+      }).getAgentInfo();
+      assert.ok(sdkTools.tools.some(tool => tool.name === 'list_products'));
+      assert.ok(!sdkTools.tools.some(tool => tool.name === 'get_products'));
+
       const defaultTools = await mcpClient.listTools();
       assert.strictEqual(defaultTools._meta.adcp_version, '3.1.18');
       assert.ok(defaultTools.tools.some(tool => tool.name === 'get_products'));

--- a/test/server-a2a-adapter.test.js
+++ b/test/server-a2a-adapter.test.js
@@ -381,6 +381,25 @@ describe('createA2AAdapter', () => {
       assert.ok(!skillIds.includes('get_signals'));
     });
 
+    it('derives unversioned A2A discovery from the default rather than the supported ceiling', async () => {
+      const adcp = createAdcpServer({
+        name: 'dual-version A2A seller',
+        version: '1.0.0',
+        adcpVersion: '3.2.0-rc.1',
+        defaultAdcpVersion: '3.1.18',
+        capabilities: { supported_versions: ['3.1.18', '3.2.0-rc.1'] },
+        mediaBuy: {
+          getProducts: async () => ({ products: [] }),
+          listProducts: async () => ({ outcome: 'listed', products: [], feed_version: 'feed-1' }),
+        },
+      });
+
+      const card = await createA2AAdapter({ server: adcp, agentCard: baseCard() }).getAgentCard();
+      const skillIds = card.skills.map(skill => skill.id);
+      assert.ok(skillIds.includes('get_products'));
+      assert.ok(!skillIds.includes('list_products'));
+    });
+
     it('cannot reintroduce an unavailable tasks/get through A2A skill overrides', async () => {
       const adcp = createAdcpServer({
         name: '3.2 A2A task seller',

--- a/test/server-create-adcp-server.test.js
+++ b/test/server-create-adcp-server.test.js
@@ -96,6 +96,141 @@ describe('createAdcpServer', () => {
     assert.strictEqual(typeof sdk._registeredTools, 'object');
   });
 
+  it('separates the unversioned default from the supported ceiling across dispatch and discovery', async () => {
+    const { z } = require('zod');
+    const standardContexts = [];
+    const customContexts = [];
+    const enhancedContexts = [];
+    const accountResolverContexts = [];
+    const sessionResolverContexts = [];
+    const server = createAdcpServer({
+      name: 'Dual-version seller',
+      version: '1.0.0',
+      adcpVersion: '3.2.0-rc.1',
+      defaultAdcpVersion: '3.1.18',
+      capabilities: { supported_versions: ['3.1.18', '3.2.0-rc.1'] },
+      resolveAccountFromAuth: async context => {
+        accountResolverContexts.push(context);
+        return undefined;
+      },
+      resolveSessionKey: async context => {
+        sessionResolverContexts.push(context);
+        return undefined;
+      },
+      mediaBuy: {
+        getProducts: async (_params, ctx) => {
+          standardContexts.push({
+            version: ctx.servedAdcpVersion,
+            descriptor: Object.getOwnPropertyDescriptor(ctx, 'servedAdcpVersion'),
+          });
+          return { products: [], cache_scope: 'public' };
+        },
+        listProducts: async () => ({
+          outcome: 'listed',
+          products: [],
+          feed_version: 'feed-1',
+          cache_scope: 'public',
+        }),
+      },
+      customTools: {
+        version_probe: {
+          inputSchema: { adcp_version: z.string().optional() },
+          handler: async (_args, extra) => {
+            customContexts.push({
+              version: extra.servedAdcpVersion,
+              descriptor: Object.getOwnPropertyDescriptor(extra, 'servedAdcpVersion'),
+            });
+            return { content: [{ type: 'text', text: 'ok' }], structuredContent: { ok: true } };
+          },
+        },
+      },
+      responseEnhancer: (_response, context) => enhancedContexts.push(context),
+    });
+
+    assert.strictEqual(server.getAdcpVersion(), '3.2.0-rc.1');
+    assert.strictEqual(server.getDefaultAdcpVersion(), '3.1.18');
+
+    const defaultProducts = await callTool(server, 'get_products', {});
+    const modernProducts = await callTool(server, 'get_products', { adcp_version: '3.2.0-rc.1' });
+    assert.strictEqual(defaultProducts.adcp_version, '3.1');
+    assert.strictEqual(modernProducts.adcp_version, '3.2-rc.1');
+    assert.deepStrictEqual(
+      standardContexts.map(context => context.version),
+      ['3.1', '3.2-rc.1']
+    );
+    assert.ok(standardContexts.every(context => context.descriptor?.writable === false));
+    for (const contexts of [accountResolverContexts, sessionResolverContexts]) {
+      const getProductsContexts = contexts.filter(context => context.toolName === 'get_products');
+      assert.deepStrictEqual(
+        getProductsContexts.map(context => context.servedAdcpVersion),
+        ['3.1', '3.2-rc.1']
+      );
+      assert.ok(
+        getProductsContexts.every(
+          context => Object.getOwnPropertyDescriptor(context, 'servedAdcpVersion')?.writable === false
+        )
+      );
+    }
+
+    await callTool(server, 'version_probe', {});
+    await callTool(server, 'version_probe', { adcp_version: '3.2.0-rc.1' });
+    assert.deepStrictEqual(
+      customContexts.map(context => context.version),
+      ['3.1', '3.2-rc.1']
+    );
+    assert.ok(customContexts.every(context => context.descriptor?.writable === false));
+
+    const defaultCapabilities = await callTool(server, 'get_adcp_capabilities', {});
+    const modernCapabilities = await callTool(server, 'get_adcp_capabilities', {
+      adcp_version: '3.2.0-rc.1',
+    });
+    assert.strictEqual(defaultCapabilities.adcp_version, '3.1');
+    assert.strictEqual(defaultCapabilities.media_buy.lifecycle_tools, undefined);
+    assert.strictEqual(modernCapabilities.adcp_version, '3.2-rc.1');
+    assert.deepStrictEqual(modernCapabilities.media_buy.lifecycle_tools, ['list_products']);
+
+    const defaultTools = await server.dispatchTestRequest({ method: 'tools/list' });
+    const modernTools = await server.dispatchTestRequest({
+      method: 'tools/list',
+      params: { _meta: { adcp_version: '3.2.0-rc.1' } },
+    });
+    assert.strictEqual(defaultTools._meta.adcp_version, '3.1.18');
+    assert.ok(defaultTools.tools.some(tool => tool.name === 'get_products'));
+    assert.ok(!defaultTools.tools.some(tool => tool.name === 'list_products'));
+    assert.strictEqual(modernTools._meta.adcp_version, '3.2.0-rc.1');
+    assert.ok(modernTools.tools.some(tool => tool.name === 'list_products'));
+    assert.ok(!modernTools.tools.some(tool => tool.name === 'get_products'));
+
+    assert.ok(enhancedContexts.some(context => context.toolName === 'get_products'));
+    assert.ok(enhancedContexts.some(context => context.toolName === 'version_probe'));
+    assert.ok(enhancedContexts.some(context => context.toolName === 'get_adcp_capabilities'));
+    assert.ok(enhancedContexts.every(Object.isFrozen));
+  });
+
+  it('rejects an unadvertised or newer defaultAdcpVersion at construction', () => {
+    assert.throws(
+      () =>
+        createAdcpServer({
+          name: 'Bad default',
+          version: '1.0.0',
+          adcpVersion: '3.2.0-rc.1',
+          defaultAdcpVersion: '3.1.18',
+          capabilities: { supported_versions: ['3.2.0-rc.1'] },
+        }),
+      /defaultAdcpVersion .*must be present/
+    );
+    assert.throws(
+      () =>
+        createAdcpServer({
+          name: 'Newer default',
+          version: '1.0.0',
+          adcpVersion: '3.1.18',
+          defaultAdcpVersion: '3.2.0-rc.1',
+        }),
+      /defaultAdcpVersion .*must not be newer/
+    );
+  });
+
   it('applies per-tool version ranges consistently to discovery, dispatch, and capabilities', async () => {
     const calls = [];
     const server = createAdcpServer({

--- a/test/server-decisioning-comply-gate.test.js
+++ b/test/server-decisioning-comply-gate.test.js
@@ -10,7 +10,7 @@ const { describe, it, beforeEach, after } = require('node:test');
 const assert = require('node:assert');
 const { createAdcpServerFromPlatform } = require('../dist/lib/server/decisioning/runtime/from-platform');
 const { __resetObservedAccountModes } = require('../dist/lib/server/decisioning/runtime/observed-modes');
-const { getSdkServer } = require('../dist/lib/server/adcp-server');
+const { getSdkServer, isToolAvailableForVersion } = require('../dist/lib/server/adcp-server');
 const { BuyerAgentRegistry } = require('../dist/lib/server/decisioning/buyer-agent');
 
 function makePlatform(resolveAccount, overrides = {}) {
@@ -197,6 +197,7 @@ describe('createAdcpServerFromPlatform — sandbox-authority gate (resolver path
 
     const listed = await listTools(server);
     assert.ok(listed.tools.some(tool => tool.name === 'comply_test_controller'));
+    assert.strictEqual(isToolAvailableForVersion(server, 'comply_test_controller', '3.2.0-rc.1'), true);
 
     const result = await callForceCreative(server, { account: { account_id: 'sb_acc' } });
 

--- a/test/server-decisioning-from-platform.test.js
+++ b/test/server-decisioning-from-platform.test.js
@@ -8561,7 +8561,7 @@ describe('tasks_get wire tool (B9)', () => {
   // task_id (+ optional account for tenant scoping) and receive the
   // spec-flat lifecycle shape.
 
-  function buildHitlPlatform(taskFn) {
+  function buildHitlPlatform(taskFn, onRequestContext = () => {}, onResolveContext = () => {}) {
     return {
       capabilities: {
         specialisms: ['sales-non-guaranteed'],
@@ -8571,17 +8571,23 @@ describe('tasks_get wire tool (B9)', () => {
         config: {},
       },
       accounts: {
-        resolve: async ref => ({
-          id: ref?.account_id ?? 'acc_1',
-          name: 'Acme',
-          status: 'active',
-          metadata: {},
-          authInfo: { kind: 'api_key' },
-        }),
+        resolve: async (ref, context) => {
+          onResolveContext(context);
+          return {
+            id: ref?.account_id ?? 'acc_1',
+            name: 'Acme',
+            status: 'active',
+            metadata: {},
+            authInfo: { kind: 'api_key' },
+          };
+        },
       },
       sales: {
         getProducts: async () => ({ products: [], cache_scope: 'account' }),
-        createMediaBuy: (_req, ctx) => ctx.handoffToTask(async taskCtx => taskFn(taskCtx)),
+        createMediaBuy: (_req, ctx) => {
+          onRequestContext(ctx);
+          return ctx.handoffToTask(async taskCtx => taskFn(taskCtx));
+        },
         updateMediaBuy: async () => ({ media_buy_id: 'mb_42' }),
         syncCreatives: async () => [],
         getMediaBuyDelivery: async () => ({ media_buys: [] }),
@@ -8589,7 +8595,7 @@ describe('tasks_get wire tool (B9)', () => {
     };
   }
 
-  async function createTask(server, accountId) {
+  async function createTask(server, accountId, adcpVersion) {
     const result = await server.dispatchTestRequest({
       method: 'tools/call',
       params: {
@@ -8601,9 +8607,12 @@ describe('tasks_get wire tool (B9)', () => {
           start_time: '2026-05-01T00:00:00Z',
           end_time: '2026-06-01T00:00:00Z',
           account: { account_id: accountId },
+          ...(adcpVersion !== undefined && { adcp_version: adcpVersion }),
         },
       },
     });
+    assert.notStrictEqual(result.isError, true, JSON.stringify(result.structuredContent));
+    assert.ok(result.structuredContent.task_id, JSON.stringify(result.structuredContent));
     await server.awaitTaskUnsafe(result.structuredContent.task_id);
     return result.structuredContent.task_id;
   }
@@ -8621,6 +8630,75 @@ describe('tasks_get wire tool (B9)', () => {
     const toolNames = listed.tools.map(tool => tool.name);
     assert.ok(toolNames.includes('tasks_get'), 'tasks_get should be advertised');
     assert.ok(!toolNames.includes('tasks/get'), 'slash alias should not be registered as an MCP tool');
+  });
+
+  it('retains the immutable selected version in platform and deferred task contexts', async () => {
+    const requestContexts = [];
+    const taskContexts = [];
+    const accountResolverContexts = [];
+    const sessionResolverContexts = [];
+    const server = createAdcpServerFromPlatform(
+      buildHitlPlatform(
+        async taskCtx => {
+          taskContexts.push(taskCtx);
+          return { media_buy_id: `mb_${taskContexts.length}` };
+        },
+        ctx => requestContexts.push(ctx),
+        ctx => accountResolverContexts.push(ctx)
+      ),
+      {
+        name: 'versioned-handoff',
+        version: '0.0.1',
+        adcpVersion: '3.2.0-rc.1',
+        defaultAdcpVersion: '3.1.18',
+        capabilities: { supported_versions: ['3.1.18', '3.2.0-rc.1'] },
+        resolveSessionKey: async context => {
+          sessionResolverContexts.push(context);
+          return 'session-version-probe';
+        },
+        validation: { requests: 'off', responses: 'off' },
+      }
+    );
+
+    const defaultTaskId = await createTask(server, 'acc_default');
+    const modernTaskId = await createTask(server, 'acc_modern', '3.2.0-rc.1');
+    for (const [taskId, accountId, adcpVersion] of [
+      [defaultTaskId, 'acc_default', undefined],
+      [modernTaskId, 'acc_modern', '3.2.0-rc.1'],
+    ]) {
+      await server.dispatchTestRequest({
+        method: 'tools/call',
+        params: {
+          name: 'tasks_get',
+          arguments: {
+            task_id: taskId,
+            account: { account_id: accountId },
+            ...(adcpVersion !== undefined && { adcp_version: adcpVersion }),
+          },
+        },
+      });
+    }
+
+    assert.deepStrictEqual(
+      requestContexts.map(ctx => ctx.servedAdcpVersion),
+      ['3.1', '3.2-rc.1']
+    );
+    assert.deepStrictEqual(
+      taskContexts.map(ctx => ctx.servedAdcpVersion),
+      ['3.1', '3.2-rc.1']
+    );
+    for (const context of [
+      ...requestContexts,
+      ...taskContexts,
+      ...accountResolverContexts,
+      ...sessionResolverContexts,
+    ]) {
+      assert.strictEqual(Object.getOwnPropertyDescriptor(context, 'servedAdcpVersion').writable, false);
+    }
+    assert.ok(accountResolverContexts.some(ctx => ctx.servedAdcpVersion === '3.1'));
+    assert.ok(accountResolverContexts.some(ctx => ctx.servedAdcpVersion === '3.2-rc.1'));
+    assert.ok(sessionResolverContexts.some(ctx => ctx.servedAdcpVersion === '3.1'));
+    assert.ok(sessionResolverContexts.some(ctx => ctx.servedAdcpVersion === '3.2-rc.1'));
   });
 
   it('returns spec-flat lifecycle shape for a completed task', async () => {


### PR DESCRIPTION
## Summary

- separate the unversioned default served AdCP release from the maximum supported release
- preserve the immutable SDK-selected release across standard, custom-tool, discovery, resolver, deferred, and task handlers
- add an executable official-MCP compatibility-matrix lane proving unversioned 3.1 and explicit 3.2 callers can share one server

## Validation

- `npm run format:check`
- `npm run typecheck`
- `npm run build:lib`
- `node --test --test-timeout=180000 --test-force-exit test/lib/media-buy-lifecycle-compatibility.test.js` (9/9)
- focused server and adapter suites (435 tests)

## Local full-suite note

The broad local batched runner exposed two VM-only harness signals: an inherited `DATABASE_URL` changed a CLI scaffold expectation (the file passes 11/11 with it unset), and one unrelated batch reported cancellations with zero assertion failures. GitHub Actions runs in a clean, authoritative CI environment.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/09001d5a-6275-48af-bccb-dbb7d664b71c)
