### PR TITLE
feat: add registrable BrandRef domain validation

### DIFF
--- a/.changeset/strict-brand-domains.md
+++ b/.changeset/strict-brand-domains.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': minor
+---
+
+Add Public Suffix List-backed BrandRef domain validation with explicit, narrow development-domain exceptions.

--- a/src/lib/brand/domain.ts
+++ b/src/lib/brand/domain.ts
@@ -5,6 +5,27 @@ import { canonicalizeHost } from '../signing/agent-resolver/canonicalize';
 const DOTTED_WIRE_DOMAIN = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$/;
 const DEVELOPMENT_SUFFIXES = ['localhost', 'test', 'example', 'invalid'] as const;
 const DEVELOPMENT_EXACT_NAMES = new Set(['example.com', 'example.net', 'example.org']);
+const SPECIAL_USE_SUFFIXES = [
+  'alt',
+  '6tisch.arpa',
+  'eap.arpa',
+  'eap-noob.arpa',
+  'home.arpa',
+  'in-addr.arpa',
+  'ip6.arpa',
+  'ipv4only.arpa',
+  'resolver.arpa',
+  'service.arpa',
+  'example',
+  'example.com',
+  'example.net',
+  'example.org',
+  'invalid',
+  'local',
+  'localhost',
+  'onion',
+  'test',
+] as const;
 
 export type BrandDomainValidationCode = 'invalid_syntax' | 'not_registrable' | 'special_use_not_allowed';
 
@@ -68,7 +89,7 @@ export function validateBrandDomain(domain: string, options: ValidateBrandDomain
     detectSpecialUse: true,
     extractHostname: false,
   });
-  if (parsed.isSpecialUse || developmentName) {
+  if (parsed.isSpecialUse || developmentName || isSpecialUseBrandDomain(canonical)) {
     throw new BrandDomainValidationError('special_use_not_allowed', domain);
   }
   if (parsed.isIp || !parsed.domain || (!parsed.isIcann && !parsed.isPrivate)) {
@@ -80,4 +101,8 @@ export function validateBrandDomain(domain: string, options: ValidateBrandDomain
 export function isDevelopmentBrandDomain(domain: string): boolean {
   if (DEVELOPMENT_EXACT_NAMES.has(domain)) return true;
   return DEVELOPMENT_SUFFIXES.some(suffix => domain.endsWith(`.${suffix}`));
+}
+
+export function isSpecialUseBrandDomain(domain: string): boolean {
+  return SPECIAL_USE_SUFFIXES.some(suffix => domain === suffix || domain.endsWith(`.${suffix}`));
 }

--- a/src/lib/brand/domain.ts
+++ b/src/lib/brand/domain.ts
@@ -1,0 +1,83 @@
+import { parse as parseTld } from 'tldts';
+
+import { canonicalizeHost } from '../signing/agent-resolver/canonicalize';
+
+const DOTTED_WIRE_DOMAIN = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$/;
+const DEVELOPMENT_SUFFIXES = ['localhost', 'test', 'example', 'invalid'] as const;
+const DEVELOPMENT_EXACT_NAMES = new Set(['example.com', 'example.net', 'example.org']);
+
+export type BrandDomainValidationCode = 'invalid_syntax' | 'not_registrable' | 'special_use_not_allowed';
+
+export class BrandDomainValidationError extends Error {
+  constructor(
+    readonly code: BrandDomainValidationCode,
+    readonly domain: string
+  ) {
+    const messages: Record<BrandDomainValidationCode, string> = {
+      invalid_syntax: 'Brand domain must be a bare, lowercase-compatible dotted hostname',
+      not_registrable: 'Brand domain must have a registrable public or private-suffix domain',
+      special_use_not_allowed: 'IANA special-use brand domain is not allowed in production',
+    };
+    super(messages[code]);
+    this.name = 'BrandDomainValidationError';
+  }
+}
+
+export interface ValidateBrandDomainOptions {
+  /**
+   * Admit the protocol's narrow development-name set: subdomains of
+   * `.localhost`, `.test`, `.example`, or `.invalid`, plus the reserved
+   * `example.com`, `example.net`, and `example.org` names. Default false.
+   *
+   * This option is deliberately explicit and is never inferred from
+   * `NODE_ENV`. Bare `localhost` remains invalid because BrandRef wire syntax
+   * always requires a dotted domain. `.local` remains forbidden because it
+   * participates in multicast DNS.
+   */
+  allowDevelopmentDomains?: boolean;
+}
+
+/**
+ * Validate and canonicalize a BrandRef/BrandKey domain.
+ *
+ * The JSON Schema enforces portable dotted wire syntax. This helper adds the
+ * runtime policy needed before brand discovery: a production name must have a
+ * registrable domain in the pinned ICANN+PRIVATE Public Suffix List and must
+ * not be an IANA special-use name.
+ */
+export function validateBrandDomain(domain: string, options: ValidateBrandDomainOptions = {}): string {
+  if (typeof domain !== 'string' || domain.length === 0 || /[\s/:@?#]/.test(domain)) {
+    throw new BrandDomainValidationError('invalid_syntax', domain);
+  }
+
+  let canonical: string;
+  try {
+    canonical = canonicalizeHost(domain);
+  } catch {
+    throw new BrandDomainValidationError('invalid_syntax', domain);
+  }
+  if (!DOTTED_WIRE_DOMAIN.test(canonical)) {
+    throw new BrandDomainValidationError('invalid_syntax', domain);
+  }
+
+  const developmentName = isDevelopmentBrandDomain(canonical);
+  if (developmentName && options.allowDevelopmentDomains === true) return canonical;
+
+  const parsed = parseTld(canonical, {
+    allowPrivateDomains: true,
+    detectSpecialUse: true,
+    extractHostname: false,
+  });
+  if (parsed.isSpecialUse || developmentName) {
+    throw new BrandDomainValidationError('special_use_not_allowed', domain);
+  }
+  if (parsed.isIp || !parsed.domain || (!parsed.isIcann && !parsed.isPrivate)) {
+    throw new BrandDomainValidationError('not_registrable', domain);
+  }
+  return canonical;
+}
+
+export function isDevelopmentBrandDomain(domain: string): boolean {
+  if (DEVELOPMENT_EXACT_NAMES.has(domain)) return true;
+  return DEVELOPMENT_SUFFIXES.some(suffix => domain.endsWith(`.${suffix}`));
+}

--- a/src/lib/brand/index.ts
+++ b/src/lib/brand/index.ts
@@ -1,6 +1,9 @@
 import type { RegistryClient, SaveBrandResponse } from '../registry';
 import type { GetBrandIdentitySuccess } from '../types/core.generated';
 
+export { BrandDomainValidationError, isDevelopmentBrandDomain, validateBrandDomain } from './domain';
+export type { BrandDomainValidationCode, ValidateBrandDomainOptions } from './domain';
+
 export type BrandJsonRecord = Record<string, unknown>;
 type ProtocolBrandLogo = NonNullable<GetBrandIdentitySuccess['logos']>[number];
 

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -144,13 +144,16 @@ export type {
 // ====== BRAND JSON HELPERS ======
 export {
   COMMON_LOGO_SLOTS,
+  BrandDomainValidationError,
   applyBrandAssetMappings,
   checkLogoSlotCoverage,
   extractBrandWebsiteAliasDomains,
   extractBrandWebsiteAliases,
+  isDevelopmentBrandDomain,
   selectLogoForSlot,
   updateBrandJsonFromMappings,
   validateBrandAssetMappings,
+  validateBrandDomain,
 } from './brand';
 export type {
   AppliedBrandAssetMapping,
@@ -168,6 +171,7 @@ export type {
   BrandWebsiteAliasRelationship,
   BrandWebsiteAliasSource,
   BrandJsonRecord,
+  BrandDomainValidationCode,
   BrandLogoBackground,
   BrandLogoOrientation,
   BrandLogoProposal,
@@ -180,6 +184,7 @@ export type {
   SkippedBrandAssetMapping,
   UpdateBrandJsonFromMappingsOptions,
   UpdateBrandJsonFromMappingsResult,
+  ValidateBrandDomainOptions,
 } from './brand';
 
 // ====== PROPERTY DISCOVERY (AdCP v2.2.0) ======

--- a/src/lib/signing/agent-resolver/etld.ts
+++ b/src/lib/signing/agent-resolver/etld.ts
@@ -15,6 +15,7 @@
  */
 import { parse as parseTld } from 'tldts';
 
+import { isSpecialUseBrandDomain } from '../../brand/domain';
 import { canonicalizeHost } from './canonicalize';
 
 export const PSL_SNAPSHOT_VERSION = 'tldts@7';
@@ -39,11 +40,20 @@ export class EtldComputationError extends Error {
  */
 export function eTldPlusOne(hostOrUrl: string): string {
   const host = canonicalizeHost(extractHost(hostOrUrl));
-  const result = parseTld(host, { allowPrivateDomains: true });
+  const result = parseTld(host, {
+    allowPrivateDomains: true,
+    detectSpecialUse: true,
+    extractHostname: false,
+  });
   if (result.isIp) {
     throw new EtldComputationError(`Cannot compute eTLD+1 for IP literal`, { hostOrUrl });
   }
-  if (!result.domain) {
+  if (
+    result.isSpecialUse ||
+    isSpecialUseBrandDomain(host) ||
+    !result.domain ||
+    (!result.isIcann && !result.isPrivate)
+  ) {
     throw new EtldComputationError(`No PSL match for hostname`, { hostOrUrl });
   }
   return canonicalizeHost(result.domain);

--- a/src/lib/signing/agent-resolver/resolve-agent.ts
+++ b/src/lib/signing/agent-resolver/resolve-agent.ts
@@ -29,6 +29,7 @@
  */
 
 import { createA2AClient, createMCPClient } from '../../protocols';
+import { isDevelopmentBrandDomain } from '../../brand/domain';
 
 import type { IdentityKeyOriginPurpose, IdentityPosture } from './capabilities-types';
 import { readBrandJsonUrl, readIdentityPosture } from './capabilities-types';
@@ -543,7 +544,10 @@ function findAuthorizedOperator(
   brandJson: unknown,
   agentEtld1: string,
   now: number,
-  options: Pick<ResolveAgentOptions, 'requiredOperatorBrand' | 'requiredOperatorScope' | 'requiredOperatorCountry'>
+  options: Pick<
+    ResolveAgentOptions,
+    'requiredOperatorBrand' | 'requiredOperatorScope' | 'requiredOperatorCountry' | 'allowPrivateIp'
+  >
 ): ActiveOperatorDelegation | undefined {
   if (!brandJson || typeof brandJson !== 'object') return undefined;
   const operators = (brandJson as { authorized_operators?: unknown }).authorized_operators;
@@ -561,7 +565,9 @@ function findAuthorizedOperator(
     try {
       if (eTldPlusOne(domain) !== agentEtld1) continue;
     } catch {
-      continue;
+      if (!(options.allowPrivateIp && isDevelopmentBrandDomain(domain) && domain === agentEtld1)) {
+        continue;
+      }
     }
 
     const scopes = candidate.scopes;

--- a/src/lib/signing/agent-resolver/resolve-agent.ts
+++ b/src/lib/signing/agent-resolver/resolve-agent.ts
@@ -28,9 +28,10 @@
  *     `SsrfRefusedError` carries.
  */
 
+import { parse as parseTld } from 'tldts';
+
 import { createA2AClient, createMCPClient } from '../../protocols';
 import { isDevelopmentBrandDomain } from '../../brand/domain';
-
 import type { IdentityKeyOriginPurpose, IdentityPosture } from './capabilities-types';
 import { readBrandJsonUrl, readIdentityPosture } from './capabilities-types';
 import { canonicalizeOrigin } from './canonicalize';
@@ -256,9 +257,28 @@ export async function resolveAgent(agentUrl: string, options: ResolveAgentOption
     if (allowPrivateIp) {
       const agentHost = new URL(agentUrl).hostname;
       const brandHost = new URL(brandJsonUrl).hostname;
-      agentEtld1 = agentHost;
-      brandEtld1 = brandHost;
-      sameOrigin = agentHost === brandHost;
+      const agentIsExplicitDevelopmentHost =
+        agentHost === 'localhost' ||
+        isDevelopmentBrandDomain(agentHost) ||
+        parseTld(agentHost, { extractHostname: false }).isIp;
+      const brandIsExplicitDevelopmentHost =
+        brandHost === 'localhost' ||
+        isDevelopmentBrandDomain(brandHost) ||
+        parseTld(brandHost, { extractHostname: false }).isIp;
+      if (agentIsExplicitDevelopmentHost && brandIsExplicitDevelopmentHost) {
+        agentEtld1 = agentHost;
+        brandEtld1 = brandHost;
+        sameOrigin = agentHost === brandHost;
+      } else {
+        const detail: AgentResolverErrorDetail = { agent_url: agentUrl, brand_json_url: brandJsonUrl };
+        pushTrace(trace, { step: 3, name: 'etld1_binding', ok: false, detail });
+        throw new AgentResolverError(
+          'request_signature_brand_origin_mismatch',
+          `Cannot compute eTLD+1 for agent or brand.json host`,
+          detail,
+          ['agent_url', 'brand_json_url']
+        );
+      }
     } else {
       const detail: AgentResolverErrorDetail = { agent_url: agentUrl, brand_json_url: brandJsonUrl };
       pushTrace(trace, { step: 3, name: 'etld1_binding', ok: false, detail });

--- a/test/agent-resolver-integration.test.js
+++ b/test/agent-resolver-integration.test.js
@@ -152,6 +152,21 @@ describe('resolveAgent — rejection codes', () => {
     );
   });
 
+  it('rejects unknown and special-use brand origins before fetching brand.json', async () => {
+    for (const [agentUrl, brandJsonUrl] of [
+      ['https://agent.company.unknown/mcp', 'https://brand.company.unknown/.well-known/brand.json'],
+      ['https://agent.10.in-addr.arpa/mcp', 'https://brand.10.in-addr.arpa/.well-known/brand.json'],
+    ]) {
+      await assertCode(
+        () =>
+          resolveAgent(agentUrl, {
+            fetchCapabilities: fakeCapabilities({ identity: { brand_json_url: brandJsonUrl } }),
+          }),
+        'request_signature_brand_origin_mismatch'
+      );
+    }
+  });
+
   it('request_signature_brand_json_unreachable on 404', async () => {
     routes['/.well-known/brand.json'] = { status: 404, body: {} };
     await assertCode(

--- a/test/agent-resolver-integration.test.js
+++ b/test/agent-resolver-integration.test.js
@@ -167,6 +167,35 @@ describe('resolveAgent — rejection codes', () => {
     }
   });
 
+  it('does not let allowPrivateIp admit reverse-DNS or unknown-suffix hosts', async () => {
+    for (const host of ['agent.10.in-addr.arpa', 'agent.company.unknown']) {
+      await assertCode(
+        () =>
+          resolveAgent(`https://${host}/mcp`, {
+            allowPrivateIp: true,
+            fetchCapabilities: fakeCapabilities({
+              identity: { brand_json_url: `https://${host}/.well-known/brand.json` },
+            }),
+          }),
+        'request_signature_brand_origin_mismatch'
+      );
+    }
+  });
+
+  it('keeps the explicit allowPrivateIp localhost development path', async () => {
+    const localhostBaseUrl = baseUrl.replace('127.0.0.1', 'localhost');
+    await assertCode(
+      () =>
+        resolveAgent(`${localhostBaseUrl}/mcp`, {
+          allowPrivateIp: true,
+          fetchCapabilities: fakeCapabilities({
+            identity: { brand_json_url: `${localhostBaseUrl}/missing-brand.json` },
+          }),
+        }),
+      'request_signature_brand_json_unreachable'
+    );
+  });
+
   it('request_signature_brand_json_unreachable on 404', async () => {
     routes['/.well-known/brand.json'] = { status: 404, body: {} };
     await assertCode(

--- a/test/agent-resolver-primitives.test.js
+++ b/test/agent-resolver-primitives.test.js
@@ -35,8 +35,8 @@ const { readBrandJsonUrl, readIdentityPosture } = require('../dist/lib/signing/a
 
 describe('eTLD+1 helper', () => {
   it('returns the registrable domain for ICANN suffixes', () => {
-    assert.equal(eTldPlusOne('https://buyer.example.com/mcp'), 'example.com');
-    assert.equal(eTldPlusOne('a.b.c.d.example.co.uk'), 'example.co.uk');
+    assert.equal(eTldPlusOne('https://buyer.adcontextprotocol.org/mcp'), 'adcontextprotocol.org');
+    assert.equal(eTldPlusOne('a.b.c.d.acme.co.uk'), 'acme.co.uk');
   });
   it('treats PSL PRIVATE-section suffixes as suffixes', () => {
     // The whole point of allowPrivateDomains: foo.vercel.app must NOT share
@@ -48,18 +48,18 @@ describe('eTLD+1 helper', () => {
     assert.notEqual(eTldPlusOne('foo.vercel.app'), eTldPlusOne('bar.vercel.app'));
   });
   it('lowercases hosts before comparison', () => {
-    assert.equal(eTldPlusOne('https://Example.COM/'), 'example.com');
+    assert.equal(eTldPlusOne('https://AdContextProtocol.ORG/'), 'adcontextprotocol.org');
   });
   it('handles IDN via Punycode', () => {
-    assert.equal(eTldPlusOne('https://Bücher.example/'), 'xn--bcher-kva.example');
+    assert.equal(eTldPlusOne('https://Bücher.de/'), 'xn--bcher-kva.de');
   });
   it('throws on IP literals', () => {
     assert.throws(() => eTldPlusOne('https://1.2.3.4/'), EtldComputationError);
     assert.throws(() => eTldPlusOne('https://[::1]/'), EtldComputationError);
   });
   it('sameEtldPlusOne returns false on either-side error rather than throwing', () => {
-    assert.equal(sameEtldPlusOne('https://example.com/', 'https://1.2.3.4/'), false);
-    assert.equal(sameEtldPlusOne('https://buyer.example.com/', 'https://api.example.com/'), true);
+    assert.equal(sameEtldPlusOne('https://adcontextprotocol.org/', 'https://1.2.3.4/'), false);
+    assert.equal(sameEtldPlusOne('https://buyer.adcontextprotocol.org/', 'https://api.adcontextprotocol.org/'), true);
   });
 });
 

--- a/test/lib/brand-domain.test.js
+++ b/test/lib/brand-domain.test.js
@@ -43,4 +43,14 @@ describe('BrandRef domain validation', () => {
       BrandDomainValidationError
     );
   });
+
+  it('rejects reverse-DNS and other IANA special-use namespaces', () => {
+    for (const domain of ['brand.10.in-addr.arpa', 'brand.ip6.arpa', 'brand.home.arpa', 'brand.onion']) {
+      assert.throws(
+        () => validateBrandDomain(domain),
+        error => error instanceof BrandDomainValidationError && error.code === 'special_use_not_allowed',
+        domain
+      );
+    }
+  });
 });

--- a/test/lib/brand-domain.test.js
+++ b/test/lib/brand-domain.test.js
@@ -1,0 +1,46 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+
+const { BrandDomainValidationError, isDevelopmentBrandDomain, validateBrandDomain } = require('@adcp/sdk/brand');
+
+describe('BrandRef domain validation', () => {
+  it('accepts and canonicalizes public and private-PSL domains', () => {
+    assert.strictEqual(validateBrandDomain('Ads.Brand.COM'), 'ads.brand.com');
+    assert.strictEqual(validateBrandDomain('brand.co.uk'), 'brand.co.uk');
+    assert.strictEqual(validateBrandDomain('tenant.github.io'), 'tenant.github.io');
+  });
+
+  it('rejects single-label, public-suffix, unknown-suffix, IP, and URL inputs', () => {
+    for (const domain of ['localhost', 'unknown', 'co.uk', 'brand.unknown', '1.2.3.4', 'https://brand.com']) {
+      assert.throws(() => validateBrandDomain(domain), BrandDomainValidationError, domain);
+    }
+  });
+
+  it('requires an explicit development-domain option', () => {
+    for (const domain of [
+      'brand.localhost',
+      'brand.test',
+      'brand.example',
+      'brand.invalid',
+      'example.com',
+      'example.net',
+      'example.org',
+    ]) {
+      assert.throws(
+        () => validateBrandDomain(domain),
+        error => error instanceof BrandDomainValidationError && error.code === 'special_use_not_allowed',
+        domain
+      );
+      assert.strictEqual(validateBrandDomain(domain, { allowDevelopmentDomains: true }), domain);
+      assert.strictEqual(isDevelopmentBrandDomain(domain), true);
+    }
+  });
+
+  it('never treats mDNS .local as a development exception', () => {
+    assert.strictEqual(isDevelopmentBrandDomain('brand.local'), false);
+    assert.throws(
+      () => validateBrandDomain('brand.local', { allowDevelopmentDomains: true }),
+      BrandDomainValidationError
+    );
+  });
+});

--- a/test/lib/brand-public-export.test.js
+++ b/test/lib/brand-public-export.test.js
@@ -17,6 +17,7 @@ describe('brand helpers public exports', () => {
     assert.strictEqual(typeof sdk.extractBrandWebsiteAliases, 'function');
     assert.strictEqual(typeof sdk.extractBrandWebsiteAliasDomains, 'function');
     assert.strictEqual(typeof sdk.updateBrandJsonFromMappings, 'function');
+    assert.strictEqual(typeof sdk.validateBrandDomain, 'function');
 
     assert.strictEqual(typeof brand.applyBrandAssetMappings, 'function');
     assert.strictEqual(typeof brand.validateBrandAssetMappings, 'function');
@@ -25,11 +26,13 @@ describe('brand helpers public exports', () => {
     assert.strictEqual(typeof brand.extractBrandWebsiteAliases, 'function');
     assert.strictEqual(typeof brand.extractBrandWebsiteAliasDomains, 'function');
     assert.strictEqual(typeof brand.updateBrandJsonFromMappings, 'function');
+    assert.strictEqual(typeof brand.validateBrandDomain, 'function');
 
     assert.strictEqual(sdk.applyBrandAssetMappings, brand.applyBrandAssetMappings);
     assert.strictEqual(sdk.selectLogoForSlot, brand.selectLogoForSlot);
     assert.strictEqual(sdk.extractBrandWebsiteAliases, brand.extractBrandWebsiteAliases);
     assert.strictEqual(sdk.extractBrandWebsiteAliasDomains, brand.extractBrandWebsiteAliasDomains);
+    assert.strictEqual(sdk.validateBrandDomain, brand.validateBrandDomain);
     assert.deepStrictEqual([...sdk.COMMON_LOGO_SLOTS], [...brand.COMMON_LOGO_SLOTS]);
 
     const esmSdk = await import('@adcp/sdk');
@@ -62,6 +65,8 @@ describe('brand helpers public exports', () => {
       'BrandWebsiteAliasRelationship',
       'BrandWebsiteAliasSource',
       'ExtractBrandWebsiteAliasesOptions',
+      'validateBrandDomain',
+      'ValidateBrandDomainOptions',
     ]) {
       assert.ok(rootDeclarations.includes(name), `dist/lib/index.d.ts must declare ${name}`);
       assert.ok(brandDeclarations.includes(name), `dist/lib/brand/index.d.ts must declare ${name}`);


### PR DESCRIPTION
## Summary
- add a public `validateBrandDomain` helper backed by `tldts`
- require ICANN or PRIVATE PSL registrability in production
- support explicit `.localhost`, `.test`, `.example`, and `.invalid` development names while excluding `.local`

## Tests
- `npm run build`
- `node --test test/lib/brand-domain.test.js test/lib/brand-public-export.test.js`
- `npm run typecheck`
- pre-push validation