### PR TITLE
fix(testing): backport strict storyboard schema grading to SDK 13

### DIFF
--- a/.changeset/strict-storyboards-open-scenarios.md
+++ b/.changeset/strict-storyboards-open-scenarios.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Make SDK test clients, including `createTestClient`, and authored storyboard response-schema checks grade strict JSON Schema verdicts by default so local CLI and programmatic preflight results match hosted compliance grading. Add `strictResponseSchemaValidation: false` as a packaged-schema diagnostic migration escape hatch, and preserve implementation-specific strings in `compliance_testing.scenarios`.

--- a/bin/adcp.js
+++ b/bin/adcp.js
@@ -1047,6 +1047,10 @@ function parseAgentOptions(args) {
   const debug = args.includes('--debug') || process.env.ADCP_DEBUG === 'true';
   const dryRun = args.includes('--dry-run');
   const allowHttp = args.includes('--allow-http');
+  // Migration escape hatch for compatibility harnesses that are testing
+  // transport/version behavior against a known schema-invalid legacy seller.
+  // Normal local compliance runs remain strict by default.
+  const strictResponseSchemaValidation = !args.includes('--no-strict-response-schema-validation');
   // `--no-sandbox` forces `account.sandbox: false` (production) on every
   // request the runner builds. The default behavior leaves the field unset
   // (spec-equivalent to false), but agents that key sandbox routing on
@@ -1185,6 +1189,7 @@ function parseAgentOptions(args) {
     debug,
     dryRun,
     allowHttp,
+    strictResponseSchemaValidation,
     noSandbox,
     assertsSeededState,
     positionalArgs,
@@ -1965,6 +1970,9 @@ SUBCOMMANDS:
 RUN OPTIONS (full assessment):
   Response-schema checks are strict and grading by default, matching the
   hosted compliance grader. JSON output includes strict_validation_summary.
+  --no-strict-response-schema-validation
+                      Keep packaged-schema strict failures diagnostic-only.
+                      Intended only for temporary legacy migration harnesses.
   --tracks TRACKS     Comma-separated tracks to include in the report
   --storyboards IDS   Comma-separated storyboard/bundle IDs to run
   --compliance-version VERSION
@@ -2853,6 +2861,7 @@ async function handleStoryboardRun(args) {
     ...(fileComplianceOptions.complianceDir && { complianceDir: fileComplianceOptions.complianceDir }),
     ...(fileComplianceOptions.adcpVersion && { adcpVersion: fileComplianceOptions.adcpVersion }),
     ...(fileComplianceOptions.schemaRoot && { schemaRoot: fileComplianceOptions.schemaRoot }),
+    ...(!opts.strictResponseSchemaValidation && { strictResponseSchemaValidation: false }),
     ...(opts.noSandbox && { sandbox: false, disable_sandbox: true }),
     ...(opts.assertsSeededState && { assertsSeededState: true }),
     ...(mergedRunHeaders && { headers: mergedRunHeaders }),
@@ -3691,6 +3700,7 @@ async function handleLocalAgentStoryboardRun(modulePath, args, opts) {
       compliance: resolveOptions,
       ...(opts.complianceVersion ||
       opts.schemaRoot ||
+      !opts.strictResponseSchemaValidation ||
       opts.noSandbox ||
       opts.assertsSeededState ||
       opts.loadedTestKit !== undefined
@@ -3698,6 +3708,7 @@ async function handleLocalAgentStoryboardRun(modulePath, args, opts) {
             runStoryboardOptions: {
               ...(opts.complianceVersion && !opts.complianceDir && { adcpVersion: opts.complianceVersion }),
               ...(opts.schemaRoot && { schemaRoot: opts.schemaRoot }),
+              ...(!opts.strictResponseSchemaValidation && { strictResponseSchemaValidation: false }),
               ...(opts.noSandbox && { sandbox: false, disable_sandbox: true }),
               ...(opts.assertsSeededState && { assertsSeededState: true }),
               ...(opts.loadedTestKit !== undefined && { test_kit: opts.loadedTestKit }),
@@ -4131,6 +4142,7 @@ async function handleMultiInstanceStoryboardRun(args, opts, urls) {
     ...(runComplianceDir && { complianceDir: runComplianceDir }),
     ...(runAdcpVersion && { adcpVersion: runAdcpVersion }),
     ...(runSchemaRoot && { schemaRoot: runSchemaRoot }),
+    ...(!opts.strictResponseSchemaValidation && { strictResponseSchemaValidation: false }),
     ...(opts.noSandbox && { sandbox: false, disable_sandbox: true }),
     ...(opts.assertsSeededState && { assertsSeededState: true }),
     ...(opts.loadedTestKit !== undefined && { test_kit: opts.loadedTestKit }),
@@ -4411,6 +4423,7 @@ async function handleAgentsRoutedStoryboardRun(args, opts, routing) {
     ...(runComplianceDir && { complianceDir: runComplianceDir }),
     ...(runAdcpVersion && { adcpVersion: runAdcpVersion }),
     ...(runSchemaRoot && { schemaRoot: runSchemaRoot }),
+    ...(!opts.strictResponseSchemaValidation && { strictResponseSchemaValidation: false }),
     ...(opts.noSandbox && { sandbox: false, disable_sandbox: true }),
     ...(opts.assertsSeededState && { assertsSeededState: true }),
     ...(opts.loadedTestKit !== undefined && { test_kit: opts.loadedTestKit }),
@@ -4623,6 +4636,7 @@ async function runFullAssessment(agentArg, rawArgs, parsedOpts) {
     ...(opts.complianceVersion && { version: opts.complianceVersion }),
     ...(opts.complianceDir && { complianceDir: opts.complianceDir }),
     ...(opts.schemaRoot && { schemaRoot: opts.schemaRoot }),
+    ...(!opts.strictResponseSchemaValidation && { strictResponseSchemaValidation: false }),
     ...(opts.hostedStableLineAlias && { hostedStableLineAlias: opts.hostedStableLineAlias }),
   };
 
@@ -4764,7 +4778,9 @@ async function runFullAssessment(agentArg, rawArgs, parsedOpts) {
 async function handleStoryboardStepCmd(args) {
   const { getComplianceStoryboardById, runStoryboardStep } = await import('../dist/lib/testing/storyboard/index.js');
   let opts = parseAgentOptions(args);
-  let { authToken, authScheme, protocolFlag, jsonOutput, positionalArgs, complianceVersion, schemaRoot } = opts;
+  let opts = parseAgentOptions(args);
+  let { authToken, authScheme, protocolFlag, jsonOutput, positionalArgs, complianceVersion, schemaRoot, strictResponseSchemaValidation } =
+    opts;
 
   enforceStrictFlags(args, warnRemovedFlags(args));
 
@@ -4776,7 +4792,8 @@ async function handleStoryboardStepCmd(args) {
     exitTestKitSelectionError(err, jsonOutput);
   }
 
-  ({ authToken, authScheme, protocolFlag, jsonOutput, positionalArgs, complianceVersion, schemaRoot } = opts);
+  ({ authToken, authScheme, protocolFlag, jsonOutput, positionalArgs, complianceVersion, schemaRoot, strictResponseSchemaValidation } =
+    opts);
   const { resolveOptions } = parseComplianceSelection(args);
 
   const agentArg = positionalArgs[0];
@@ -4832,6 +4849,7 @@ async function handleStoryboardStepCmd(args) {
     ...(opts.complianceDir && { complianceDir: opts.complianceDir }),
     ...(schemaRoot && { schemaRoot }),
     ...(opts.loadedTestKit !== undefined && { test_kit: opts.loadedTestKit }),
+    ...(!strictResponseSchemaValidation && { strictResponseSchemaValidation: false }),
     ...buildResolvedAuthOption({
       resolvedAuth,
       resolvedAuthScheme,

--- a/bin/adcp.js
+++ b/bin/adcp.js
@@ -4778,9 +4778,16 @@ async function runFullAssessment(agentArg, rawArgs, parsedOpts) {
 async function handleStoryboardStepCmd(args) {
   const { getComplianceStoryboardById, runStoryboardStep } = await import('../dist/lib/testing/storyboard/index.js');
   let opts = parseAgentOptions(args);
-  let opts = parseAgentOptions(args);
-  let { authToken, authScheme, protocolFlag, jsonOutput, positionalArgs, complianceVersion, schemaRoot, strictResponseSchemaValidation } =
-    opts;
+  let {
+    authToken,
+    authScheme,
+    protocolFlag,
+    jsonOutput,
+    positionalArgs,
+    complianceVersion,
+    schemaRoot,
+    strictResponseSchemaValidation,
+  } = opts;
 
   enforceStrictFlags(args, warnRemovedFlags(args));
 
@@ -4792,8 +4799,16 @@ async function handleStoryboardStepCmd(args) {
     exitTestKitSelectionError(err, jsonOutput);
   }
 
-  ({ authToken, authScheme, protocolFlag, jsonOutput, positionalArgs, complianceVersion, schemaRoot, strictResponseSchemaValidation } =
-    opts);
+  ({
+    authToken,
+    authScheme,
+    protocolFlag,
+    jsonOutput,
+    positionalArgs,
+    complianceVersion,
+    schemaRoot,
+    strictResponseSchemaValidation,
+  } = opts);
   const { resolveOptions } = parseComplianceSelection(args);
 
   const agentArg = positionalArgs[0];

--- a/bin/adcp.js
+++ b/bin/adcp.js
@@ -1963,6 +1963,8 @@ SUBCOMMANDS:
   step <agent> <id> <step_id>  Run a single step (stateless, LLM-friendly)
 
 RUN OPTIONS (full assessment):
+  Response-schema checks are strict and grading by default, matching the
+  hosted compliance grader. JSON output includes strict_validation_summary.
   --tracks TRACKS     Comma-separated tracks to include in the report
   --storyboards IDS   Comma-separated storyboard/bundle IDs to run
   --compliance-version VERSION

--- a/docs/guides/VALIDATE-YOUR-AGENT.md
+++ b/docs/guides/VALIDATE-YOUR-AGENT.md
@@ -86,6 +86,8 @@ delta for diagnostics. Programmatic migration tooling can temporarily pass
 `strictResponseSchemaValidation: false` to `runStoryboard()` or `comply()` to
 restore the historical informational-only posture when using packaged schemas.
 An explicit external `schemaRoot` always remains authoritative.
+The CLI equivalent is `--no-strict-response-schema-validation`; reserve it for
+temporary legacy compatibility harnesses rather than routine compliance runs.
 
 **Flags you'll actually use:**
 

--- a/docs/guides/VALIDATE-YOUR-AGENT.md
+++ b/docs/guides/VALIDATE-YOUR-AGENT.md
@@ -78,6 +78,15 @@ npx @adcp/sdk@adcp-3.1 storyboard run http://localhost:3001/mcp --file ./my-wip.
 npx @adcp/sdk@adcp-3.1 storyboard run http://localhost:3001/mcp --json > report.json
 ```
 
+Storyboard `response_schema` checks use strict JSON Schema validation for
+grading by default, matching the hosted compliance grader. A strict failure
+therefore fails the owning step even when the generated lenient Zod projection
+would accept the response; `strict_validation_summary` still reports that
+delta for diagnostics. Programmatic migration tooling can temporarily pass
+`strictResponseSchemaValidation: false` to `runStoryboard()` or `comply()` to
+restore the historical informational-only posture when using packaged schemas.
+An explicit external `schemaRoot` always remains authoritative.
+
 **Flags you'll actually use:**
 
 - `--tracks <a,b,c>` — limit to named tracks (e.g., `core,products,security_baseline`)

--- a/scripts/ci/run_storyboard_strict_3_0_reference_seller.sh
+++ b/scripts/ci/run_storyboard_strict_3_0_reference_seller.sh
@@ -348,6 +348,7 @@ RUN_STATUS=0
 ADCP_AUTH_TOKEN="$ADCP_AUTH_TOKEN" "${RUNNER_CMD[@]}" storyboard run "http://127.0.0.1:$ADCP_PORT/mcp" "$ADCP_STORYBOARD_ID" \
   --json \
   --allow-http \
+  --no-strict-response-schema-validation \
   --timeout "$ADCP_RUNNER_TIMEOUT_SECONDS" >"$STORYBOARD_RESULT_PATH" 2>>"$SELLER_LOG_PATH" || RUN_STATUS=$?
 
 log "Probing get_products through candidate SDK with major-only envelope"

--- a/src/lib/server/decisioning/capabilities.ts
+++ b/src/lib/server/decisioning/capabilities.ts
@@ -618,11 +618,11 @@ export type BrandCapabilities = NonNullable<NonNullable<GetAdCPCapabilitiesRespo
  */
 export interface ComplianceTestingCapabilities {
   /**
-   * Scenarios this agent advertises support for. Wire enum is the
-   * canonical scenario enum, excluding `list_scenarios` because that
-   * is a discovery operation rather than a test capability. Framework
-   * defaults this from the adopter-supplied `complyTest` adapter set
-   * when omitted.
+   * Scenarios this agent advertises support for. The wire field is open to
+   * implementation-specific string values; canonical controller scenarios
+   * are recommendations, not an enum constraint. `list_scenarios` remains a
+   * discovery operation rather than a test capability. Framework defaults
+   * this from the adopter-supplied `complyTest` adapter set when omitted.
    */
   scenarios?: ReadonlyArray<_ComplianceTestingScenario>;
 }

--- a/src/lib/server/decisioning/decisioning.type-checks.ts
+++ b/src/lib/server/decisioning/decisioning.type-checks.ts
@@ -774,6 +774,13 @@ function _define_platform_with_compliance_accepts_ct(p: _PlatformWithCT): _Platf
   return definePlatformWithCompliance(p);
 }
 
+// Positive: the capability schema is deliberately open to seller-specific
+// scenario names; canonical controller constants are recommendations only.
+const _custom_compliance_scenario: ComplianceTestingCapabilities = {
+  scenarios: ['seller_custom_fixture_reset'],
+};
+void _custom_compliance_scenario;
+
 // Negative: definePlatformWithCompliance rejects a platform missing compliance_testing
 // (compliance_testing is optional on DecisioningPlatformCapabilities, required by the helper).
 function _define_platform_with_compliance_rejects_missing_ct() {

--- a/src/lib/testing/client.ts
+++ b/src/lib/testing/client.ts
@@ -31,6 +31,7 @@ interface TestClientVersionOptions {
   adcpVersion: string;
   wireAdcpVersion?: string;
   versionEnvelope: VersionEnvelopeMode;
+  strictResponseSchemaValidation: boolean;
   authMode?: string;
   fetchFn?: typeof fetch;
   maxResponseBytes?: number;
@@ -193,7 +194,10 @@ export function createTestClient(agentUrl: string, protocol: 'mcp' | 'a2a' = 'mc
 
   const multiClient = new ADCPMultiAgentClient([agentConfig], {
     headers,
-    validation: { logSchemaViolations: false },
+    validation: {
+      responses: options.strictResponseSchemaValidation === false ? 'warn' : 'strict',
+      logSchemaViolations: false,
+    },
     ...(options.adcpVersion !== undefined && { adcpVersion: options.adcpVersion }),
     ...(options.wireAdcpVersion !== undefined && { wireAdcpVersion: options.wireAdcpVersion }),
     ...(options.versionEnvelope !== undefined && { versionEnvelope: options.versionEnvelope }),
@@ -208,6 +212,7 @@ export function createTestClient(agentUrl: string, protocol: 'mcp' | 'a2a' = 'mc
       adcpVersion: multiClient.getAdcpVersion(),
       ...(options.wireAdcpVersion !== undefined && { wireAdcpVersion: options.wireAdcpVersion }),
       versionEnvelope: options.versionEnvelope ?? 'auto',
+      strictResponseSchemaValidation: options.strictResponseSchemaValidation !== false,
       ...(authMode !== undefined && { authMode }),
       ...(options.transport?.trustedFetchFn && { fetchFn: options.transport.trustedFetchFn }),
       ...(options.transport?.maxResponseBytes !== undefined && {
@@ -272,6 +277,7 @@ function testClientMatchesVersionOptions(client: TestClient, options: TestOption
     meta.adcpVersion === expectedAdcpVersion &&
     meta.wireAdcpVersion === expectedWireAdcpVersion &&
     meta.versionEnvelope === expectedVersionEnvelope &&
+    meta.strictResponseSchemaValidation === (effectiveOptions.strictResponseSchemaValidation !== false) &&
     meta.authMode === expectedAuthMode &&
     meta.fetchFn === effectiveOptions.transport?.trustedFetchFn &&
     meta.maxResponseBytes === effectiveOptions.transport?.maxResponseBytes &&

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -5364,6 +5364,7 @@ async function executeStep(
       taskName: effectiveStep.task,
       ...(options.adcpVersion && { adcpVersion: options.adcpVersion }),
       ...(options._serverAdcpVersion && { responseAdcpVersion: options._serverAdcpVersion }),
+      strictResponseSchemaValidation: options.strictResponseSchemaValidation !== false,
       ...(validationTaskResult && { taskResult: validationTaskResult }),
       ...(httpResult && { httpResult }),
       agentUrl: runState.agentUrl,
@@ -5473,6 +5474,7 @@ async function executeStep(
       taskName: effectiveStep.task,
       ...(options.adcpVersion && { adcpVersion: options.adcpVersion }),
       ...(options._serverAdcpVersion && { responseAdcpVersion: options._serverAdcpVersion }),
+      strictResponseSchemaValidation: options.strictResponseSchemaValidation !== false,
       ...(validationTaskResult && { taskResult: validationTaskResult }),
       agentUrl: runState.agentUrl,
       contributions: runState.contributions,
@@ -6185,6 +6187,7 @@ async function executeProbeStep(
     taskName: step.task === REPLAY_TRUSTED_MATCH_CONTEXT_VECTOR_TASK ? 'context_match' : step.task,
     ...(options.adcpVersion && { adcpVersion: options.adcpVersion }),
     ...(options._serverAdcpVersion && { responseAdcpVersion: options._serverAdcpVersion }),
+    strictResponseSchemaValidation: options.strictResponseSchemaValidation !== false,
     httpResult: redactedHttpResult,
     ...(step.task === REPLAY_TRUSTED_MATCH_CONTEXT_VECTOR_TASK &&
       redactedHttpResult && {

--- a/src/lib/testing/storyboard/runner.ts
+++ b/src/lib/testing/storyboard/runner.ts
@@ -4174,7 +4174,8 @@ export function listStrictOnlyFailures(
         if (v.check !== 'response_schema') continue;
         if (v.strict === undefined) continue;
         if (v.strict.valid) continue;
-        if (!v.passed) continue; // already counted by lenient path
+        const lenientAccepted = v.strict.lenient_valid === true || (v.strict.lenient_valid === undefined && v.passed);
+        if (!lenientAccepted) continue;
         rows.push({
           phase_id: phase.phase_id,
           step_id: step.step_id,
@@ -4192,6 +4193,8 @@ export function summarizeStrictValidation(phases: StoryboardPhaseResult[]): Stri
   let checked = 0;
   let passed = 0;
   let strictOnlyFailures = 0;
+  let lenientAlsoFailed = 0;
+  let lenientUnobserved = 0;
   for (const phase of phases) {
     for (const step of phase.steps) {
       for (const v of step.validations) {
@@ -4199,10 +4202,17 @@ export function summarizeStrictValidation(phases: StoryboardPhaseResult[]): Stri
         checked++;
         if (v.strict.valid) {
           passed++;
-        } else if (v.passed) {
-          // Lenient Zod accepted this response; strict AJV rejected it.
-          // That's the agent's strictness gap — the signal #820 wants.
-          strictOnlyFailures++;
+        } else {
+          const lenientValid = v.strict.lenient_valid;
+          if (lenientValid === true || (lenientValid === undefined && v.passed)) {
+            // Lenient Zod accepted this response; strict AJV rejected it.
+            // That's the agent's strictness gap — the signal #820 wants.
+            strictOnlyFailures++;
+          } else if (lenientValid === false || lenientValid === undefined) {
+            lenientAlsoFailed++;
+          } else {
+            lenientUnobserved++;
+          }
         }
       }
     }
@@ -4214,7 +4224,8 @@ export function summarizeStrictValidation(phases: StoryboardPhaseResult[]): Stri
     passed,
     failed,
     strict_only_failures: strictOnlyFailures,
-    lenient_also_failed: failed - strictOnlyFailures,
+    lenient_also_failed: lenientAlsoFailed,
+    ...(lenientUnobserved > 0 && { lenient_unobserved: lenientUnobserved }),
   };
 }
 

--- a/src/lib/testing/storyboard/types.ts
+++ b/src/lib/testing/storyboard/types.ts
@@ -6,7 +6,7 @@
  * SingleAgentClient method and includes validations.
  */
 
-import type { TestOptions } from '../types';
+import type { AgentProfile, TestOptions } from '../types';
 import type { BuyerAgent, BuyerAgentBillingMode, BuyerAgentStatus } from '../../server/decisioning/buyer-agent';
 import type { WebhookConformanceSigningOptions } from '../../conformance/types';
 
@@ -37,6 +37,12 @@ export interface Storyboard {
    * authored in storyboard YAML.
    */
   adcp_version?: string;
+  /**
+   * Compliance cache root this storyboard was loaded from. Injected by the
+   * cache loader so synthesized vectors and runtime probes use the same
+   * bundle even when process-level cache environment variables differ.
+   */
+  compliance_dir?: string;
   title: string;
   category: string;
   summary: string;
@@ -59,7 +65,7 @@ export interface Storyboard {
    * the whole storyboard with `requirement_unmet` and a
    * `missing_required_tool_family:` detail prefix. The standard `comply()`
    * path populates `agentTools` before this gate runs; direct callers that
-   * reuse a client should provide `agentTools` or `_profile.tools` so the
+   * reuse a profile should provide `agentTools` or `profile.tools` so the
    * runner can enforce it without discovery ambiguity.
    */
   required_any_of_tools?: RequiredToolFamily[];
@@ -72,7 +78,7 @@ export interface Storyboard {
    *
    * Recognised names:
    *   - `controller` — the agent must advertise `comply_test_controller`.
-   *     Detected from `options.agentTools`, `_profile.tools`, or discovery
+   *     Detected from `options.agentTools`, `profile.tools`, or discovery
    *     on reused clients. Direct callers that deliberately provide none of
    *     those surfaces bypass this check; their storyboard runs into the
    *     per-step `missing_test_controller` cascade instead.
@@ -198,6 +204,23 @@ export interface Storyboard {
    * `experimental_features contains trusted_match.core`).
    */
   requires_capability?: RequiresCapabilityPredicate;
+  /**
+   * Two or more capability predicates evaluated as one AND-composed
+   * applicability gate. When this field and `requires_capability` are both
+   * present, every predicate across both declarations must pass. A failed
+   * predicate skips the entire storyboard before runtime or tool gates.
+   *
+   * The loader rejects empty and single-entry arrays; use
+   * `requires_capability` for a singular gate.
+   *
+   * Compound gates fail closed when the raw capabilities payload is
+   * unavailable: advertised or auto-registered tools are not capability
+   * declarations. This is intentionally stricter than the compatibility
+   * fallback retained for legacy singular gates.
+   *
+   * Supported by @adcp/sdk starting in 14.0.0-beta.4.
+   */
+  requires_all_capabilities?: RequiresCapabilityPredicate[];
   /** Scenario IDs that must pass alongside this storyboard (loaded from storyboards/scenarios/) */
   requires_scenarios?: string[];
   agent: {
@@ -1600,8 +1623,24 @@ export interface TrustedMatchPublisherAuthRunner {
 }
 
 export interface StoryboardRunOptions extends TestOptions {
-  /** Caller-selected compliance cache root for bundle-scoped test kits. */
+  /** Compliance cache root for bundle-scoped fixtures and test vectors. */
   complianceDir?: string;
+  /**
+   * Pre-discovered agent profile to reuse instead of repeating capability
+   * discovery. When `agentTools` is omitted, the runner derives it from
+   * `profile.tools` so storyboard-level `required_tools` and step-level
+   * `requires_tool` gates remain enforced.
+   *
+   * Reuse a profile only for the same agent URL, authentication, AdCP version,
+   * and route that produced it. Route-specific profiles are not interchangeable.
+   * In an `agents` run this value supplies only the run-level/default-agent
+   * gating context; each routed agent is still discovered independently.
+   * Profile reuse does not retain or reuse a client or transport connection.
+   *
+   * `AgentProfile` does not carry the server's exact wire version. Pass
+   * `adcpVersion` separately when version-skew validation depends on it.
+   */
+  profile?: AgentProfile;
   /** Initial context (e.g., from a previous step invocation) */
   context?: StoryboardContext;
   /**
@@ -1684,11 +1723,11 @@ export interface StoryboardRunOptions extends TestOptions {
     /**
      * How the grader dispatches each vector to the agent.
      *
-     *   - `raw` (default) — POSTs each vector body directly to a per-
+     *   - `raw` — POSTs each vector body directly to a per-
      *     operation AdCP endpoint (e.g. `<baseUrl>/create_media_buy`).
      *     Works for agents that expose AdCP tools as discrete HTTP
      *     operations.
-     *   - `mcp` — wraps each vector body in a JSON-RPC `tools/call`
+     *   - `mcp` (default) — wraps each vector body in a JSON-RPC `tools/call`
      *     envelope and POSTs to the agent's single `/mcp` mount. Required
      *     for MCP-only agents that don't expose per-operation endpoints.
      *     The operation name is derived from the last path segment of the
@@ -1711,6 +1750,11 @@ export interface StoryboardRunOptions extends TestOptions {
      * streamable-HTTP agents that do not issue session IDs.
      */
     mcpSessionId?: string;
+    /**
+     * Negotiated MCP protocol version for a pre-provisioned session. When the
+     * runner auto-initializes, it uses the version returned by the server.
+     */
+    mcpProtocolVersion?: string;
   };
   /**
    * Distribution strategy across agent URLs in multi-instance mode.
@@ -2077,7 +2121,7 @@ export type RunnerDetailedSkipReason =
   /** A valid fixture strategy ladder exhausted without finding a binding. */
   | 'fixture_unsatisfied'
   /**
-   * A `requires_capability` predicate on the storyboard evaluated to false —
+   * A root capability predicate on the storyboard evaluated to false —
    * the agent explicitly declared it does not support the capability this
    * storyboard tests (e.g. `adcp.idempotency.supported: false`). The whole
    * storyboard is skipped before any phase runs. Maps to canonical
@@ -2370,36 +2414,38 @@ export interface ValidationResult {
   observations?: unknown[];
   /**
    * Non-fatal human-readable warning attached when a check `passed` but
-   * detected a softer issue the caller should still see — today used only
-   * by `response_schema` to surface the top strict-AJV issue when Zod
-   * accepts and AJV rejects (the "lenient-passes ∧ strict-fails" subset
-   * of issue #820). LLM-driven self-correction and CI graphs that scan
-   * `error`/`warning` fields can act on this without the runner flipping
-   * step pass/fail and breaking existing tests.
+   * detected a softer issue the caller should still see. `response_schema`
+   * uses this for variant-fallback diagnostics and, when strict grading is
+   * explicitly disabled, strict-only AJV findings. LLM-driven self-correction
+   * and CI graphs that scan `error`/`warning` fields can act on the warning.
    */
   warning?: string;
   /**
    * Issue #820 follow-up — strict JSON-schema (AJV) verdict for
-   * `response_schema` checks. `passed` remains the lenient Zod outcome
-   * (runner's historical pass/fail semantics); `strict` carries the
-   * AJV-with-formats-and-additionalProperties verdict separately so
-   * agent developers can see the strict/lenient delta without the
-   * runner failing a step that the Zod path accepts. Absent on non-
-   * response_schema checks or when no AJV schema is available.
+   * `response_schema` checks. Packaged-schema storyboard runs grade this
+   * verdict by default; `strictResponseSchemaValidation: false` restores the
+   * historical lenient grade while retaining the verdict as diagnostics.
+   * An external `schemaRoot` is always authoritative. Absent on
+   * non-response_schema checks or when no AJV schema is available.
    */
   strict?: StrictValidationVerdict;
 }
 
 /**
  * Strict (AJV JSON-schema) verdict attached to a response_schema
- * validation result. Informational — the step's pass/fail is driven by
- * the lenient Zod path. `valid: false` with `valid_lenient: true`
- * indicates the strict/lenient delta: the agent's response passes the
- * generated Zod shape but fails strict JSON-schema (typically a
- * `format` violation or an `additionalProperties: false` breach).
+ * validation result. Authoritative by default for packaged-cache storyboard
+ * runs and always authoritative for runs with an external `schemaRoot`.
+ * Packaged-cache callers may explicitly make it informational with
+ * `strictResponseSchemaValidation: false` during migrations.
  */
 export interface StrictValidationVerdict {
   valid: boolean;
+  /**
+   * Outcome from the SDK's packaged Zod snapshot, captured only as a
+   * comparison signal. `null` means that snapshot has no schema for the tool.
+   * External-schema runs never use this field to decide pass/fail.
+   */
+  lenient_valid?: boolean | null;
   /** Response variant AJV ultimately validated against. After fallback: `"sync"`. */
   variant: string;
   /** Concrete AJV issues (RFC 6901 pointers) when `valid: false`. Absent when valid. */
@@ -3103,18 +3149,26 @@ export interface StrictValidationSummary {
    * Count of validations where lenient Zod accepted AND strict AJV
    * rejected — the "silent failures" the agent ships today that a strict
    * dispatcher would block. Subset of `failed`. This is the actionable
-   * production-readiness signal for agent developers: a green lenient run
-   * with `strict_only_failures > 0` is a migration trap.
+   * production-readiness signal for agent developers. With the default
+   * strict grading these failures make the owning step fail; callers that
+   * explicitly disable strict grading can still use this count as migration
+   * telemetry.
    */
   strict_only_failures: number;
   /**
    * Count of validations where BOTH lenient Zod AND strict AJV rejected —
    * the step already failed under today's semantics, so strict rejection
-   * isn't new signal. Equals `failed - strict_only_failures`. Useful for
-   * dashboards that want to distinguish "already-failing" from
-   * "silently-failing" in the same run.
+   * isn't new signal. Useful for dashboards that want to distinguish
+   * "already-failing" from "silently-failing" in the same run. Strict
+   * failures without a packaged Zod comparator are reported separately as
+   * `lenient_unobserved`.
    */
   lenient_also_failed: number;
+  /**
+   * Strict AJV failures for tools with no packaged Zod schema to compare.
+   * Present only when non-zero so older serialized summaries remain stable.
+   */
+  lenient_unobserved?: number;
 }
 
 /**

--- a/src/lib/testing/storyboard/validations.ts
+++ b/src/lib/testing/storyboard/validations.ts
@@ -12,7 +12,7 @@ import { prepareResponseForSchemaValidation, TOOL_RESPONSE_SCHEMAS } from '../..
 import { injectLegacyEnvelopeStatus } from '../../utils/envelope-status-compat';
 import { TRANSPORT_SUFFIX_REGEX } from '../../utils/a2a-discovery';
 import { validateResponse, type ValidationIssue } from '../../validation/schema-validator';
-import { hasSchemaBundle } from '../../validation/schema-loader';
+import { hasSchemaBundle, isExternalSchemaRootActive } from '../../validation/schema-loader';
 import { ADCP_VERSION, LIBRARY_VERSION } from '../../version';
 import { isPre31AdcpVersion } from '../../utils/adcp-version-config';
 import { gte as semverGte, valid as validSemver } from 'semver';
@@ -59,6 +59,8 @@ export interface ValidationContext {
   adcpVersion?: string;
   /** Server-declared AdCP version to use for response-shape compatibility decisions. */
   responseAdcpVersion?: string;
+  /** Make a strict AJV response-schema rejection fail the validation. */
+  strictResponseSchemaValidation?: boolean;
   taskResult?: TaskResult;
   httpResult?: HttpProbeResult;
   agentUrl: string;
@@ -441,10 +443,13 @@ const SCHEMA_URL_BASE = 'https://adcontextprotocol.org';
  * convention used by `$id` in cached JSON schemas; the url dereferences
  * against the public docs origin so implementors can fetch it.
  */
-function resolveSchemaIdentity(schemaRef: string | undefined): { schema_id: string | null; schema_url: string | null } {
+function resolveSchemaIdentity(
+  schemaRef: string | undefined,
+  adcpVersion: string = ADCP_VERSION
+): { schema_id: string | null; schema_url: string | null } {
   if (!schemaRef) return { schema_id: null, schema_url: null };
   const trimmed = schemaRef.replace(/^\/+/, '');
-  const schemaId = `/schemas/${ADCP_VERSION}/${trimmed}`;
+  const schemaId = `/schemas/${adcpVersion}/${trimmed}`;
   const schemaUrl = `${SCHEMA_URL_BASE}${schemaId}`;
   return { schema_id: schemaId, schema_url: schemaUrl };
 }
@@ -520,7 +525,7 @@ function mapZodIssueToSchemaKeyword(issue: { code: string; message: string }): s
 }
 
 // ────────────────────────────────────────────────────────────
-// response_schema: validate against Zod
+// response_schema: validate against the active schema authority
 // ────────────────────────────────────────────────────────────
 
 function validateResponseSchema(
@@ -529,52 +534,90 @@ function validateResponseSchema(
   taskResult: TaskResult
 ): ValidationResult {
   const taskName = ctx.taskName;
-  const { schema_id, schema_url } = resolveSchemaIdentity(ctx.responseSchemaRef);
-  const schema = TOOL_RESPONSE_SCHEMAS[taskName];
-  if (!schema) {
-    return {
-      check: 'response_schema',
-      passed: false,
-      description: validation.description,
-      error: `No schema registered for task "${taskName}"`,
-      json_pointer: null,
-      expected: schema_id ?? `response schema for ${taskName}`,
-      // The runner failed before observing the agent — distinguish that from
-      // "agent returned null" so implementors don't chase a phantom agent bug.
-      actual: { reason: 'no_schema_registered', task: taskName },
-      schema_id,
-      schema_url,
-    };
-  }
+  const schemaIdentityVersion = ctx.adcpVersion ?? ctx.responseAdcpVersion ?? ADCP_VERSION;
+  const { schema_id, schema_url } = resolveSchemaIdentity(ctx.responseSchemaRef, schemaIdentityVersion);
 
   // Keep the raw payload separately from the object-form one below so the
   // shape-drift detector can recognize bare-array responses (a common drift
   // pattern for list tools). Strip _message when it's a top-level property —
   // bare arrays don't carry that field.
-  const rawData = taskResult.data ?? {};
+  const rawData: unknown = taskResult.data ?? {};
   const dataWithoutMessage = Array.isArray(rawData)
     ? rawData
     : (() => {
         const { _message, ...rest } = rawData as Record<string, unknown>;
         return rest;
       })();
-  // 3.0.x back-compat: synthesize envelope `status` for legacy peers
-  // before validating against the 3.1 envelope schema. See
-  // `utils/envelope-status-compat.ts`.
+  const schema = TOOL_RESPONSE_SCHEMAS[taskName];
+  // Evaluate the packaged validator for diagnostics even when an external
+  // bundle is authoritative. Its result must never gate that run, but it lets
+  // strict-summary consumers distinguish an actual strict/lenient delta from
+  // a response that both schema sources reject.
   const dataForValidation = Array.isArray(dataWithoutMessage)
     ? dataWithoutMessage
     : injectLegacyEnvelopeStatus(dataWithoutMessage as Record<string, unknown>, { toolName: taskName });
   const responseAdcpVersion = ctx.responseAdcpVersion ?? ctx.adcpVersion;
-  const parseResult = schema.safeParse(
+  const parseResult = schema?.safeParse(
     prepareResponseForSchemaValidation(taskName, dataForValidation, responseAdcpVersion)
   );
+  const computedStrict = computeStrictVerdict(taskName, dataWithoutMessage, ctx.adcpVersion, ctx.responseAdcpVersion);
+  const strict = computedStrict ? { ...computedStrict, lenient_valid: parseResult?.success ?? null } : undefined;
+  const externalSchemaIsAuthoritative = isExternalResponseSchemaAuthoritative(ctx);
 
-  // Strict (AJV) verdict runs alongside the lenient Zod check so the run
-  // report surfaces strictness deltas (issue #820 follow-up). The AJV path
-  // enforces `format` keywords and `additionalProperties: false` that Zod's
-  // `passthrough()` omits — a response can pass Zod and fail AJV. The step's
-  // overall pass/fail stays Zod-driven to preserve backwards compatibility.
-  const strict = computeStrictVerdict(taskName, dataWithoutMessage, ctx.adcpVersion, ctx.responseAdcpVersion);
+  // An explicit schemaRoot represents current source that may be newer than
+  // this SDK package's generated Zod snapshot. In that mode the external JSON
+  // Schema bundle is the source of truth for both known tools and tools added
+  // by the external build.
+  if (externalSchemaIsAuthoritative) {
+    if (!strict) {
+      return noResponseSchemaResult(validation, taskName, schema_id, schema_url);
+    }
+    if (strict.valid) {
+      const base: ValidationResult = {
+        check: 'response_schema',
+        passed: true,
+        description: validation.description,
+        schema_id,
+        schema_url,
+        strict,
+      };
+      const warning = buildStrictWarning(strict);
+      return warning ? { ...base, warning } : base;
+    }
+
+    const issues = strict.issues ?? [];
+    const firstIssue = issues[0];
+    return {
+      check: 'response_schema',
+      passed: false,
+      description: validation.description,
+      error:
+        issues.length > 0
+          ? issues
+              .slice(0, 5)
+              .map(issue => `${issue.instance_path || '/'}: ${issue.message}`)
+              .join('; ')
+          : `External JSON Schema rejected the ${taskName} response`,
+      json_pointer: firstIssue?.instance_path || null,
+      expected: schema_id ?? `response schema for ${taskName}`,
+      actual: issues,
+      schema_id,
+      schema_url,
+      strict,
+    };
+  }
+
+  if (!schema) {
+    return noResponseSchemaResult(validation, taskName, schema_id, schema_url, strict);
+  }
+  // `schema` is present, so optional chaining above necessarily produced a
+  // packaged verdict.
+  if (!parseResult) return noResponseSchemaResult(validation, taskName, schema_id, schema_url, strict);
+
+  // Strict (AJV) verdict runs alongside the lenient Zod check. Storyboard runs
+  // grade that verdict by default; direct validation callers and explicit
+  // migration runs can leave it informational. Explicit external bundles take
+  // the authoritative branch above instead.
 
   // Shape-drift no longer rides on `ValidationResult.warning` — issue #935
   // moved that diagnostic to `StoryboardStepResult.hints[]` as a structured
@@ -590,6 +633,25 @@ function validateResponseSchema(
       schema_id,
       schema_url,
     };
+    if (strict && !strict.valid && ctx.strictResponseSchemaValidation === true) {
+      const issues = strict.issues ?? [];
+      const firstIssue = issues[0];
+      return {
+        ...base,
+        passed: false,
+        error:
+          issues.length > 0
+            ? issues
+                .slice(0, 5)
+                .map(issue => `${issue.instance_path || '/'}: ${issue.message}`)
+                .join('; ')
+            : `Strict JSON Schema rejected the ${taskName} response`,
+        json_pointer: firstIssue?.instance_path || null,
+        expected: schema_id ?? `response schema for ${taskName}`,
+        actual: issues,
+        strict,
+      };
+    }
     // Surface strict-only / variant-fallback signal via `warning` so step-
     // level output (and LLM-driven self-correction that scans `error`/
     // `warning` fields) sees something without flipping `passed`.
@@ -621,6 +683,48 @@ function validateResponseSchema(
   return strict ? { ...failed, strict } : failed;
 }
 
+/** @internal Shared with the storyboard runner's Zod-rejection recovery path. */
+export function isExternalResponseSchemaAuthoritative(
+  ctx: Pick<ValidationContext, 'adcpVersion' | 'responseAdcpVersion'>
+): boolean {
+  const validationVersion = responseSchemaValidationVersion(ctx.adcpVersion, ctx.responseAdcpVersion);
+  return validationVersion !== undefined && isExternalSchemaRootActive(validationVersion);
+}
+
+function responseSchemaValidationVersion(
+  adcpVersion: string | undefined,
+  responseAdcpVersion: string | undefined
+): string | undefined {
+  // An explicit external root belongs to the caller-selected protocol source
+  // and must win over a packaged stable wire alias advertised by the server.
+  // The server version still feeds compatibility preparation separately.
+  if (adcpVersion && isExternalSchemaRootActive(adcpVersion)) return adcpVersion;
+  return responseAdcpVersion && hasSchemaBundle(responseAdcpVersion) ? responseAdcpVersion : adcpVersion;
+}
+
+function noResponseSchemaResult(
+  validation: StoryboardValidation,
+  taskName: string,
+  schema_id: string | null,
+  schema_url: string | null,
+  strict?: StrictValidationVerdict
+): ValidationResult {
+  const result: ValidationResult = {
+    check: 'response_schema',
+    passed: false,
+    description: validation.description,
+    error: `No schema registered for task "${taskName}"`,
+    json_pointer: null,
+    expected: schema_id ?? `response schema for ${taskName}`,
+    // The runner failed before observing the agent — distinguish that from
+    // "agent returned null" so implementors don't chase a phantom agent bug.
+    actual: { reason: 'no_schema_registered', task: taskName },
+    schema_id,
+    schema_url,
+  };
+  return strict ? { ...result, strict } : result;
+}
+
 /**
  * Run the strict AJV validator for `taskName` against the response payload.
  * Returns undefined when no AJV schema is available (the client can't
@@ -634,9 +738,14 @@ function computeStrictVerdict(
   adcpVersion?: string,
   responseAdcpVersion?: string
 ): StrictValidationVerdict | undefined {
-  const validationVersion =
-    responseAdcpVersion && hasSchemaBundle(responseAdcpVersion) ? responseAdcpVersion : adcpVersion;
-  if (responseAdcpVersion && isPre31AdcpVersion(responseAdcpVersion) && !hasSchemaBundle(responseAdcpVersion)) {
+  const externalVersionSelected = adcpVersion !== undefined && isExternalSchemaRootActive(adcpVersion);
+  const validationVersion = responseSchemaValidationVersion(adcpVersion, responseAdcpVersion);
+  if (
+    !externalVersionSelected &&
+    responseAdcpVersion &&
+    isPre31AdcpVersion(responseAdcpVersion) &&
+    !hasSchemaBundle(responseAdcpVersion)
+  ) {
     return undefined;
   }
   const payloadForValidation = prepareResponseForSchemaValidation(taskName, payload, responseAdcpVersion);

--- a/src/lib/testing/types.ts
+++ b/src/lib/testing/types.ts
@@ -108,6 +108,17 @@ export interface TestOptions {
    * `adcpVersion` (or the storyboard/compliance version when omitted).
    */
   schemaRoot?: string;
+  /**
+   * Whether strict AJV response-schema failures contribute to storyboard
+   * grading. Defaults to `true`, matching the hosted compliance grader.
+   *
+   * Set to `false` only for packaged-schema diagnostic migrations that need
+   * the historical lenient-Zod grade while inspecting
+   * `strict_validation_summary` and the per-validation `strict` verdicts.
+   * Strict validation still runs in that mode; it is informational rather
+   * than grading. An explicit external `schemaRoot` remains authoritative.
+   */
+  strictResponseSchemaValidation?: boolean;
   /** Custom User-Agent string sent with all outbound requests */
   userAgent?: string;
   // Brand reference for product discovery (preferred over brand_manifest)

--- a/src/lib/validation/schema-loader.ts
+++ b/src/lib/validation/schema-loader.ts
@@ -513,6 +513,23 @@ export function withExternalSchemaRoot<T>(version: string, root: string | undefi
   return scopedExternalSchemaRoots.run(next, fn);
 }
 
+/**
+ * Return whether validation for `version` currently resolves through a
+ * caller-supplied schema bundle rather than the SDK's packaged snapshot.
+ *
+ * Storyboard validation uses this to make an explicit external JSON Schema
+ * bundle authoritative.
+ *
+ * @internal — not part of the public API surface; may change without a major bump.
+ */
+export function isExternalSchemaRootActive(version: string): boolean {
+  const key = resolveBundleKey(version);
+  const scopedRoot = scopedExternalSchemaRoots.getStore()?.get(key);
+  if (scopedRoot && existsSync(scopedRoot)) return true;
+  const registeredRoot = externalSchemaRoots.get(key);
+  return registeredRoot !== undefined && existsSync(registeredRoot);
+}
+
 function walkJsonFiles(dir: string): string[] {
   if (!existsSync(dir)) return [];
   const out: string[] = [];

--- a/test/lib/cli-soft-fail.test.js
+++ b/test/lib/cli-soft-fail.test.js
@@ -65,6 +65,19 @@ test('--soft-fail does not affect a passing storyboard ID parse (positional inta
   assert.match(res.stdout, /Storyboards:\s+capability_discovery/);
 });
 
+test('--no-strict-response-schema-validation remains a boolean flag and preserves positionals', () => {
+  const res = runCli([
+    'storyboard',
+    'run',
+    UNREACHABLE,
+    STORYBOARD,
+    '--no-strict-response-schema-validation',
+    '--soft-fail',
+  ]);
+  assert.strictEqual(res.status, 0, `expected exit 0, got ${res.status}. stderr: ${res.stderr}`);
+  assert.match(res.stdout, /Storyboards:\s+capability_discovery/);
+});
+
 test('--summary-file PATH writes the Markdown summary to PATH', () => {
   const tmpDir = mkdtempSync(path.join(os.tmpdir(), 'adcp-soft-fail-'));
   try {

--- a/test/lib/storyboard-rejection-hints-e2e.test.js
+++ b/test/lib/storyboard-rejection-hints-e2e.test.js
@@ -82,6 +82,7 @@ const storyboard = {
 };
 
 const searchResponse = {
+  cache_scope: 'public',
   signals: [
     {
       // Shape matches get-signals-response.json required fields + their

--- a/test/lib/storyboard-security.test.js
+++ b/test/lib/storyboard-security.test.js
@@ -1502,6 +1502,9 @@ describe('security_baseline: unconditional PRM enforcement (#677)', () => {
     return {
       protocol: 'mcp',
       allow_http: true,
+      // These fixtures intentionally exercise auth-routing behavior with a
+      // minimal list_creatives envelope, not response-schema conformance.
+      strictResponseSchemaValidation: false,
       agentTools: ['list_creatives'],
       _profile: { name: 'T', tools: ['list_creatives'] },
       _client: {

--- a/test/lib/storyboard-strict-validation.test.js
+++ b/test/lib/storyboard-strict-validation.test.js
@@ -334,7 +334,7 @@ describe('storyboard validations: strict/lenient response_schema delta', () => {
     }
   });
 
-  test('implementation-specific compliance scenario strings pass strict validation', () => {
+  test('implementation-specific compliance scenario strings pass strict 3.1.20 cache validation', () => {
     const response = {
       adcp: { major_versions: [3], idempotency: { supported: false } },
       supported_protocols: ['media_buy'],
@@ -343,7 +343,7 @@ describe('storyboard validations: strict/lenient response_schema delta', () => {
     const [result] = runValidations(
       [{ check: 'response_schema', description: 'response conforms' }],
       ctxWith('get_adcp_capabilities', response, 'protocol/get-adcp-capabilities-response.json', {
-        adcpVersion: '3.1.18',
+        adcpVersion: '3.1.20',
         strictResponseSchemaValidation: true,
       })
     );

--- a/test/lib/storyboard-strict-validation.test.js
+++ b/test/lib/storyboard-strict-validation.test.js
@@ -1,18 +1,45 @@
 /**
  * Strict/lenient response-schema validation + run-level aggregation (issue
  * #820, fourth proposal). `runValidations` must attach an AJV-based strict
- * verdict to every `response_schema` ValidationResult without flipping the
- * step's pass/fail (which stays Zod-driven for backwards compatibility).
+ * verdict to every `response_schema` ValidationResult. Storyboard runs grade
+ * the strict verdict by default; direct validation callers can keep it
+ * informational, while an explicit external schema root is always
+ * authoritative for current-source validation.
  *
- * Tests hit the storyboard validation layer directly — `runValidations`
- * with a synthetic `ValidationContext`. No runner boot or network needed.
+ * Most tests hit the storyboard validation layer directly with a synthetic
+ * `ValidationContext`; one runner-level regression locks the public default.
  */
 
 const { describe, test } = require('node:test');
 const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 
+const { ProtocolClient } = require('../../dist/lib/index.js');
+const { createTestClient } = require('../../dist/lib/testing/client.js');
 const { runValidations } = require('../../dist/lib/testing/storyboard/validations.js');
-const { summarizeStrictValidation, listStrictOnlyFailures } = require('../../dist/lib/testing/storyboard/runner.js');
+const {
+  runStoryboardStep,
+  summarizeStrictValidation,
+  listStrictOnlyFailures,
+} = require('../../dist/lib/testing/storyboard/runner.js');
+const { _resetValidationLoader, withExternalSchemaRoot } = require('../../dist/lib/validation/schema-loader.js');
+
+const EXTERNAL_VERSION = '9.9.0-beta.1';
+
+function writeExternalResponseSchema(root, toolName, schema) {
+  const bundled = path.join(root, 'bundled');
+  fs.mkdirSync(bundled, { recursive: true });
+  fs.writeFileSync(
+    path.join(bundled, `${toolName.replaceAll('_', '-')}-response.json`),
+    JSON.stringify({
+      $schema: 'http://json-schema.org/draft-07/schema#',
+      $id: `/schemas/${EXTERNAL_VERSION}/test/${toolName.replaceAll('_', '-')}-response.json`,
+      ...schema,
+    })
+  );
+}
 
 function ctx(taskName, data, responseSchemaRef) {
   return {
@@ -28,7 +55,148 @@ function ctxWith(taskName, data, responseSchemaRef, extra) {
   return { ...ctx(taskName, data, responseSchemaRef), ...extra };
 }
 
+function strictDeltaCapabilitiesStoryboard() {
+  return {
+    id: 'strict_response_default',
+    version: '1.0.0',
+    title: 'Strict response default',
+    category: 'test',
+    summary: 'Verifies strict response-schema grading defaults.',
+    narrative: '',
+    agent: { interaction_model: 'sync', capabilities: [] },
+    caller: { role: 'buyer_agent' },
+    phases: [
+      {
+        id: 'capabilities',
+        title: 'Capabilities',
+        steps: [
+          {
+            id: 'discover',
+            title: 'Discover capabilities',
+            task: 'get_adcp_capabilities',
+            response_schema_ref: 'protocol/get-adcp-capabilities-response.json',
+            validations: [{ check: 'response_schema', description: 'response conforms' }],
+          },
+        ],
+      },
+    ],
+  };
+}
+
+function withoutAuthoredValidations(storyboard) {
+  const copy = structuredClone(storyboard);
+  delete copy.phases[0].steps[0].validations;
+  return copy;
+}
+
 describe('storyboard validations: strict/lenient response_schema delta', () => {
+  test('external schemaRoot accepts current-source responses rejected by packaged Zod', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'adcp-external-authority-'));
+    try {
+      writeExternalResponseSchema(root, 'list_creative_formats', {
+        type: 'object',
+        required: ['current_source_marker'],
+        properties: { current_source_marker: { const: true } },
+        additionalProperties: false,
+      });
+
+      const [result] = withExternalSchemaRoot(EXTERNAL_VERSION, root, () =>
+        runValidations(
+          [{ check: 'response_schema', description: 'response conforms to current source' }],
+          ctxWith('list_creative_formats', { current_source_marker: true }, 'test/list-response.json', {
+            adcpVersion: EXTERNAL_VERSION,
+          })
+        )
+      );
+
+      assert.strictEqual(result.passed, true, result.error);
+      assert.strictEqual(result.strict.valid, true);
+      assert.strictEqual(result.strict.lenient_valid, false);
+      assert.match(result.schema_id, new RegExp(`/schemas/${EXTERNAL_VERSION.replaceAll('.', '\\.')}/`));
+    } finally {
+      _resetValidationLoader(EXTERNAL_VERSION);
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('external schemaRoot rejects packaged-Zod responses that current source disallows', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'adcp-external-authority-'));
+    try {
+      writeExternalResponseSchema(root, 'list_creative_formats', {
+        type: 'object',
+        required: ['current_source_marker'],
+        properties: { current_source_marker: { const: true } },
+        additionalProperties: false,
+      });
+
+      const [result] = withExternalSchemaRoot(EXTERNAL_VERSION, root, () =>
+        runValidations(
+          [{ check: 'response_schema', description: 'response conforms to current source' }],
+          ctxWith('list_creative_formats', { formats: [] }, 'test/list-response.json', {
+            adcpVersion: EXTERNAL_VERSION,
+          })
+        )
+      );
+
+      assert.strictEqual(result.passed, false);
+      assert.strictEqual(result.strict.valid, false);
+      assert.strictEqual(result.strict.lenient_valid, true);
+      assert.ok(result.actual.some(issue => issue.keyword === 'required'));
+
+      const summary = summarizeStrictValidation([
+        { phase_id: 'external', steps: [{ step_id: 'reject', task: 'list_creative_formats', validations: [result] }] },
+      ]);
+      assert.strictEqual(summary.strict_only_failures, 1);
+      assert.strictEqual(summary.lenient_also_failed, 0);
+    } finally {
+      _resetValidationLoader(EXTERNAL_VERSION);
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('external schemaRoot validates tools absent from the packaged Zod map', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'adcp-external-authority-'));
+    try {
+      writeExternalResponseSchema(root, 'future_protocol_tool', {
+        type: 'object',
+        required: ['future_value'],
+        properties: { future_value: { type: 'string' } },
+        additionalProperties: false,
+      });
+
+      const [result] = withExternalSchemaRoot(EXTERNAL_VERSION, root, () =>
+        runValidations(
+          [{ check: 'response_schema', description: 'future tool response conforms' }],
+          ctxWith('future_protocol_tool', { future_value: 'same-change' }, 'test/future-tool-response.json', {
+            adcpVersion: EXTERNAL_VERSION,
+          })
+        )
+      );
+
+      assert.strictEqual(result.passed, true, result.error);
+      assert.strictEqual(result.strict.valid, true);
+      assert.strictEqual(result.strict.lenient_valid, null);
+
+      const [rejected] = withExternalSchemaRoot(EXTERNAL_VERSION, root, () =>
+        runValidations(
+          [{ check: 'response_schema', description: 'future tool response conforms' }],
+          ctxWith('future_protocol_tool', { future_value: 42 }, 'test/future-tool-response.json', {
+            adcpVersion: EXTERNAL_VERSION,
+          })
+        )
+      );
+      const summary = summarizeStrictValidation([
+        { phase_id: 'external', steps: [{ step_id: 'future', task: 'future_protocol_tool', validations: [rejected] }] },
+      ]);
+      assert.strictEqual(summary.strict_only_failures, 0);
+      assert.strictEqual(summary.lenient_also_failed, 0);
+      assert.strictEqual(summary.lenient_unobserved, 1);
+    } finally {
+      _resetValidationLoader(EXTERNAL_VERSION);
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   test('clean response: strict.valid=true, passed=true, no issues emitted', () => {
     // Minimal valid list_creative_formats response — `formats` is the only
     // required field at the root; an empty array satisfies both Zod and AJV.
@@ -43,6 +211,146 @@ describe('storyboard validations: strict/lenient response_schema delta', () => {
     assert.ok(v.strict, 'strict verdict attached');
     assert.strictEqual(v.strict.valid, true, 'AJV path accepts');
     assert.strictEqual(v.strict.issues, undefined, 'no issues on a valid response');
+  });
+
+  test('strict grading fails a packaged-schema violation that lenient Zod accepts', () => {
+    const response = {
+      adcp: { major_versions: [3], idempotency: { supported: false } },
+      supported_protocols: ['media_buy'],
+      // The JSON Schema requires at least one advertised scenario. The
+      // generated Zod projection intentionally remains more permissive.
+      compliance_testing: { scenarios: [] },
+    };
+    const [graded] = runValidations(
+      [{ check: 'response_schema', description: 'response conforms' }],
+      ctxWith('get_adcp_capabilities', response, 'protocol/get-adcp-capabilities-response.json', {
+        adcpVersion: '3.1.18',
+        strictResponseSchemaValidation: true,
+      })
+    );
+
+    assert.strictEqual(graded.strict.lenient_valid, true);
+    assert.strictEqual(graded.strict.valid, false);
+    assert.strictEqual(graded.passed, false);
+    assert.match(graded.error, /compliance_testing\/scenarios/);
+
+    const [diagnostic] = runValidations(
+      [{ check: 'response_schema', description: 'response conforms' }],
+      ctxWith('get_adcp_capabilities', response, 'protocol/get-adcp-capabilities-response.json', {
+        strictResponseSchemaValidation: false,
+      })
+    );
+    assert.strictEqual(diagnostic.passed, true, 'explicit opt-out preserves the diagnostic-only grade');
+    assert.match(diagnostic.warning, /strict JSON-schema rejected/);
+  });
+
+  test('storyboard runner grades strict response schemas by default and honors the opt-out', async () => {
+    const response = {
+      adcp: { major_versions: [3], idempotency: { supported: false } },
+      supported_protocols: ['media_buy'],
+      compliance_testing: { scenarios: [] },
+    };
+    const client = {
+      async getAdcpCapabilities() {
+        return { status: 'completed', data: response };
+      },
+    };
+    const profile = {
+      name: 'Strict response stub',
+      tools: ['get_adcp_capabilities'],
+      raw_capabilities: response,
+    };
+    const options = { protocol: 'mcp', _client: client, _profile: profile };
+
+    const graded = await runStoryboardStep(
+      'https://stub.example/mcp',
+      strictDeltaCapabilitiesStoryboard(),
+      'discover',
+      options
+    );
+    const gradedSchema = graded.validations.find(v => v.check === 'response_schema');
+    assert.strictEqual(gradedSchema.strict.lenient_valid, true);
+    assert.strictEqual(gradedSchema.strict.valid, false);
+    assert.strictEqual(gradedSchema.passed, false);
+    assert.strictEqual(graded.passed, false);
+
+    const diagnostic = await runStoryboardStep(
+      'https://stub.example/mcp',
+      strictDeltaCapabilitiesStoryboard(),
+      'discover',
+      { ...options, strictResponseSchemaValidation: false }
+    );
+    const diagnosticSchema = diagnostic.validations.find(v => v.check === 'response_schema');
+    assert.strictEqual(diagnosticSchema.passed, true);
+    assert.strictEqual(diagnostic.passed, true);
+  });
+
+  test('test client enforces strict responses when a step has no authored response_schema check', async () => {
+    const response = {
+      status: 'completed',
+      // Missing required idempotency proves transport-level strict validation
+      // protects steps that do not author a response_schema validation.
+      adcp: { major_versions: [3] },
+      supported_protocols: ['media_buy'],
+      compliance_testing: { scenarios: ['seller_custom_fixture_reset'] },
+    };
+    const profile = {
+      name: 'Strict response stub',
+      tools: ['get_adcp_capabilities'],
+      raw_capabilities: response,
+    };
+    const storyboard = withoutAuthoredValidations(strictDeltaCapabilitiesStoryboard());
+    const originalCallTool = ProtocolClient.callTool;
+    ProtocolClient.callTool = async () => response;
+
+    try {
+      const strictClient = createTestClient('https://stub.example/mcp');
+      strictClient.client.discoveredEndpoint = 'https://stub.example/mcp';
+      const graded = await runStoryboardStep('https://stub.example/mcp', storyboard, 'discover', {
+        protocol: 'mcp',
+        _client: strictClient,
+        _profile: profile,
+      });
+      assert.strictEqual(graded.passed, false);
+      assert.match(graded.error, /Schema validation failed.*idempotency/);
+
+      const diagnosticClient = createTestClient('https://stub.example/mcp', 'mcp', {
+        strictResponseSchemaValidation: false,
+      });
+      diagnosticClient.client.discoveredEndpoint = 'https://stub.example/mcp';
+      const diagnostic = await runStoryboardStep('https://stub.example/mcp', storyboard, 'discover', {
+        protocol: 'mcp',
+        strictResponseSchemaValidation: false,
+        _client: diagnosticClient,
+        _profile: profile,
+      });
+      assert.strictEqual(diagnostic.passed, true);
+      assert.strictEqual(
+        diagnostic.validations.some(v => v.check === 'response_schema'),
+        false
+      );
+    } finally {
+      ProtocolClient.callTool = originalCallTool;
+    }
+  });
+
+  test('implementation-specific compliance scenario strings pass strict validation', () => {
+    const response = {
+      adcp: { major_versions: [3], idempotency: { supported: false } },
+      supported_protocols: ['media_buy'],
+      compliance_testing: { scenarios: ['seller_custom_fixture_reset'] },
+    };
+    const [result] = runValidations(
+      [{ check: 'response_schema', description: 'response conforms' }],
+      ctxWith('get_adcp_capabilities', response, 'protocol/get-adcp-capabilities-response.json', {
+        adcpVersion: '3.1.18',
+        strictResponseSchemaValidation: true,
+      })
+    );
+
+    assert.strictEqual(result.passed, true, result.error);
+    assert.strictEqual(result.strict.valid, true);
+    assert.strictEqual(result.strict.lenient_valid, true);
   });
 
   test('response missing a required field: Zod and AJV both fail; strict.valid=false', () => {

--- a/test/lib/storyboard-version-negotiation.test.js
+++ b/test/lib/storyboard-version-negotiation.test.js
@@ -238,6 +238,15 @@ describe('storyboard runner AdCP version negotiation', () => {
       }),
       shared
     );
+    assert.notStrictEqual(
+      getOrCreateClient('https://example.com/mcp', {
+        _client: shared,
+        adcpVersion: CURRENT_PRERELEASE_VERSION,
+        versionEnvelope: 'auto',
+        strictResponseSchemaValidation: false,
+      }),
+      shared
+    );
   });
 
   test('discovery-only _client is not reused for executable storyboard calls', () => {

--- a/test/server-decisioning-comply-test.test.js
+++ b/test/server-decisioning-comply-test.test.js
@@ -285,7 +285,7 @@ describe('createAdcpServerFromPlatform — comply_test_controller wiring', () =>
     const platform = basePlatform({ withComplianceTesting: true });
     // Adopter wires three adapters but only wants to advertise two.
     platform.capabilities.compliance_testing = {
-      scenarios: ['force_creative_status', 'simulate_delivery'],
+      scenarios: ['force_creative_status', 'simulate_delivery', 'seller_custom_fixture_reset'],
     };
     const server = createAdcpServerFromPlatform(platform, {
       name: 'comply-host',
@@ -326,7 +326,7 @@ describe('createAdcpServerFromPlatform — comply_test_controller wiring', () =>
       params: { name: 'get_adcp_capabilities', arguments: {} },
     });
     const scenarios = result.structuredContent?.compliance_testing?.scenarios;
-    assert.deepStrictEqual(scenarios, ['force_creative_status', 'simulate_delivery']);
+    assert.deepStrictEqual(scenarios, ['force_creative_status', 'simulate_delivery', 'seller_custom_fixture_reset']);
   });
 
   it('does NOT project compliance_testing block when capability + complyTest are both omitted', async () => {


### PR DESCRIPTION
## Summary

- deterministically backport all of adcp-client#2663 (acdb49a7 and 71b5b472) to the active 13.x maintenance line
- retain 13.x-specific compliance-directory and declared test-kit wiring during conflict resolution
- include only the external-schema-authority and strict-summary prerequisite semantics consumed from adcp-client#2606
- make the custom `compliance_testing.scenarios` regression explicitly validate against the 3.1.20 cache

## Validation

- `npm run build:lib`
- `npm run typecheck`
- `npm run format:check`
- focused 79-test strict-storyboard, version-negotiation, CLI, and decisioning suite

## Release

The included patch changeset is the approved release mechanism. After this PR merges into `13.x`, the release workflow will create the release PR; merging that human-gated release PR publishes `@adcp/sdk` 13.0.3. No package version was edited manually.