### PR TITLE
fix: isolate lazy capability probe operation IDs

### DIFF
--- a/.changeset/fresh-probes-register.md
+++ b/.changeset/fresh-probes-register.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Give lazy capability probes their own operation IDs so webhook registration cannot conflict with the mutation that triggered discovery, while preserving caller cancellation, transport safeguards, webhook suppression, and delegated callback authorization.

--- a/docs/guides/CONFORMANCE.md
+++ b/docs/guides/CONFORMANCE.md
@@ -227,6 +227,12 @@ nightly job to broaden coverage.
 
 - **Storyboards** — narrative flow, multi-step sequences, async task
   lifecycle. Use `@adcp/sdk/testing` storyboard runners.
+- **Buyer SDK configuration tests** — conformance grades the remote agent,
+  not interactions among client options. The storyboard runner also discovers
+  and caches the agent profile before functional steps, so it does not exercise
+  a cold client's lazy preflight path. Cover combinations such as capability
+  guards, webhook templates, durable registration stores, signing, and
+  caller-scoped cancellation in SDK integration tests.
 - **LLM red-team runner** — `adcp#2630`. Multi-step conversational
   fuzzing driven by an LLM.
 - **Semantic validation** — budget math, referential integrity across

--- a/package-lock.json
+++ b/package-lock.json
@@ -537,6 +537,19 @@
         "js-yaml": "^4.1.1"
       }
     },
+    "node_modules/@changesets/parse/node_modules/js-yaml": {
+      "version": "3.15.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.2.tgz",
+      "integrity": "sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/@changesets/pre": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@changesets/pre/-/pre-2.0.2.tgz",
@@ -2139,9 +2152,9 @@
       "license": "Python-2.0"
     },
     "node_modules/@redocly/openapi-core/node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "dev": true,
       "funding": [
         {
@@ -2153,7 +2166,6 @@
           "url": "https://github.com/sponsors/nodeca"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -3922,9 +3934,9 @@
       "license": "Python-2.0"
     },
     "node_modules/cosmiconfig/node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "dev": true,
       "funding": [
         {
@@ -3936,7 +3948,6 @@
           "url": "https://github.com/sponsors/nodeca"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -5092,10 +5103,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.0.tgz",
-      "integrity": "sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==",
-      "license": "MIT",
+      "version": "4.13.7",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.7.tgz",
+      "integrity": "sha512-c8/gF9ac8Y78/agExVocyLevgR+JlpNB444Py0FSX8pJoPdYUfUzRcXtYEYGwt6l19qIlVZPN5Mfsw9jFShmQQ==",
       "engines": {
         "node": ">=16.9.0"
       }
@@ -5484,20 +5494,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/js-yaml": {
-      "version": "3.15.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
-      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -5561,9 +5557,9 @@
       "license": "Python-2.0"
     },
     "node_modules/json-schema-to-typescript/node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "dev": true,
       "funding": [
         {
@@ -5575,7 +5571,6 @@
           "url": "https://github.com/sponsors/nodeca"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -7025,9 +7020,9 @@
       "license": "Python-2.0"
     },
     "node_modules/read-yaml-file/node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "dev": true,
       "funding": [
         {
@@ -7039,7 +7034,6 @@
           "url": "https://github.com/sponsors/nodeca"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },

--- a/package.json
+++ b/package.json
@@ -700,7 +700,7 @@
       "js-yaml": "^5.2.2"
     },
     "@changesets/parse": {
-      "js-yaml": "^3.14.1"
+      "js-yaml": "^3.15.2"
     },
     "minimatch": "^10.2.1"
   },

--- a/src/lib/core/SingleAgentClient.ts
+++ b/src/lib/core/SingleAgentClient.ts
@@ -283,6 +283,10 @@ import { isProjectionProductInput, type V1FormatId, type V1Product } from '../v2
 import { canonicalize as canonicalizeJson } from '../utils/jcs';
 
 type ReadRequestOptions = Pick<TaskOptions, 'signal' | 'transport'>;
+type CapabilityProbeRequestOptions = Pick<
+  TaskOptions,
+  'signal' | 'transport' | 'disableWebhook' | 'delegatedOperatorAuthorization'
+>;
 type ToolSchemaMap = Map<string, Record<string, unknown>>;
 type CapabilityDiscoveryContext = {
   toolSchemas?: ToolSchemaMap;
@@ -6142,10 +6146,7 @@ export class SingleAgentClient {
       this.validateBeforeCreativeCapabilityProbe('create_media_buy', params, taskOptions);
     }
     const wireMode = hasCreativeFormatData
-      ? this.resolveCreativeFormatWireMode(
-          'create_media_buy',
-          await this.getCapabilities({ signal: taskOptions.signal, transport: taskOptions.transport })
-        )
+      ? this.resolveCreativeFormatWireMode('create_media_buy', await this.getCapabilities(taskOptions))
       : 'canonical';
     // Merge library defaults with consumer-provided reporting_webhook config
     // Library provides url/auth/frequency defaults, consumer can override any field
@@ -6320,10 +6321,7 @@ export class SingleAgentClient {
       this.validateBeforeCreativeCapabilityProbe('update_media_buy', params, taskOptions);
     }
     const wireMode = hasCreativeFormatData
-      ? this.resolveCreativeFormatWireMode(
-          'update_media_buy',
-          await this.getCapabilities({ signal: taskOptions.signal, transport: taskOptions.transport })
-        )
+      ? this.resolveCreativeFormatWireMode('update_media_buy', await this.getCapabilities(taskOptions))
       : 'canonical';
     const result = await this.executeAndHandle<UpdateMediaBuyResponse>(
       'update_media_buy',
@@ -6422,10 +6420,7 @@ export class SingleAgentClient {
       projectionCatalogs ?? this.config.projectionCatalogs
     );
     this.validateBeforeCreativeCapabilityProbe('sync_creatives', params, taskOptions);
-    const wireMode = this.resolveCreativeFormatWireMode(
-      'sync_creatives',
-      await this.getCapabilities({ signal: taskOptions.signal, transport: taskOptions.transport })
-    );
+    const wireMode = this.resolveCreativeFormatWireMode('sync_creatives', await this.getCapabilities(taskOptions));
     const configuredSelectorContainers = [
       ...((creativeFormatProjection?.selectorContainers ?? []) as ReadonlyArray<CreativeFormatSelectorContainer>),
     ];
@@ -8284,7 +8279,28 @@ export class SingleAgentClient {
         // executor then hits ProtocolClient.callTool which reads _inProcessMcpClient directly,
         // so the sentinel adcp-in-process:// URI never reaches validateAgentUrl.
         const agent = await this.ensureEndpointDiscovered(options);
-        const result = await this.executor.executeTask<any>(agent, 'get_adcp_capabilities', {}, undefined, options);
+        // Capability discovery can run inside another task's deadline scope. Do
+        // not forward that scope's private operation ID: the probe is a
+        // separate physical task with its own webhook registration. Preserve
+        // the caller's cancellation, transport safeguards, callback policy,
+        // and callback authorization provenance. The active OpenTelemetry
+        // context remains in the async chain, correlating both physical tasks.
+        const callerOptions = options as CapabilityProbeRequestOptions | undefined;
+        const probeOptions: CapabilityProbeRequestOptions = {
+          ...(options?.signal !== undefined && { signal: options.signal }),
+          ...(options?.transport !== undefined && { transport: options.transport }),
+          ...(callerOptions?.disableWebhook !== undefined && { disableWebhook: callerOptions.disableWebhook }),
+          ...(callerOptions?.delegatedOperatorAuthorization !== undefined && {
+            delegatedOperatorAuthorization: { ...callerOptions.delegatedOperatorAuthorization },
+          }),
+        };
+        const result = await this.executor.executeTask<any>(
+          agent,
+          'get_adcp_capabilities',
+          {},
+          undefined,
+          probeOptions
+        );
         throwIfAborted(options?.signal);
         const requestTimeoutMs = resolveRequestTimeoutMs(
           options?.transport?.requestTimeoutMs ?? this.config.transport?.requestTimeoutMs

--- a/test/lib/capability-probe-operation-id.test.js
+++ b/test/lib/capability-probe-operation-id.test.js
@@ -1,0 +1,408 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { AsyncLocalStorage } = require('node:async_hooks');
+
+const { trace } = require('@opentelemetry/api');
+const { Client } = require('@modelcontextprotocol/sdk/client/index.js');
+const { InMemoryTransport } = require('@modelcontextprotocol/sdk/inMemory.js');
+const { McpServer } = require('@modelcontextprotocol/sdk/server/mcp.js');
+const z = require('zod');
+
+const {
+  ADCPMultiAgentClient,
+  InMemoryWebhookRegistrationStore,
+  SingleAgentClient,
+  withSpan,
+} = require('../../dist/lib/index.js');
+const { getTaskOperationId, withTaskDeadline } = require('../../dist/lib/core/task-deadline.js');
+
+const WEBHOOK_TEMPLATE = 'https://buyer.example/webhooks/{task_type}/{agent_id}/{operation_id}';
+const WEBHOOK_SECRET = 'capability-probe-operation-id-secret';
+
+function toolResult(payload) {
+  return {
+    content: [{ type: 'text', text: JSON.stringify(payload) }],
+    structuredContent: payload,
+  };
+}
+
+function deferred() {
+  let resolve;
+  const promise = new Promise(resolvePromise => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+async function createHarness(mutationName, { clientConfig = {}, beforeCapabilitiesResponse } = {}) {
+  const calls = [];
+  const registrations = [];
+  const backingStore = new InMemoryWebhookRegistrationStore();
+  const registrationStore = {
+    async putIfAbsent(registration) {
+      registrations.push(structuredClone(registration));
+      await backingStore.putIfAbsent(registration);
+    },
+    get: (...args) => backingStore.get(...args),
+    delete: (...args) => backingStore.delete(...args),
+    markRequiresDurableSettlement: (...args) => backingStore.markRequiresDurableSettlement(...args),
+  };
+
+  const server = new McpServer({ name: `${mutationName}-seller`, version: '1.0.0' });
+  server.registerTool(
+    'get_adcp_capabilities',
+    {
+      inputSchema: {
+        adcp_major_version: z.number().optional(),
+        adcp_version: z.string().optional(),
+        push_notification_config: z.any().optional(),
+      },
+    },
+    async args => {
+      calls.push({ tool: 'get_adcp_capabilities', args: structuredClone(args) });
+      await beforeCapabilitiesResponse?.();
+      return toolResult({
+        status: 'completed',
+        adcp_version: '3.2.0-rc.1',
+        adcp: {
+          major_versions: [3],
+          supported_versions: ['3.2.0-rc.1'],
+          idempotency: { supported: true, replay_ttl_seconds: 86400 },
+        },
+        supported_protocols: ['media_buy'],
+        specialisms: [],
+      });
+    }
+  );
+  server.registerTool(
+    mutationName,
+    {
+      inputSchema: {
+        account: z.any().optional(),
+        accounts: z.array(z.any()).optional(),
+        media_buy_id: z.string().optional(),
+        packages: z.array(z.any()).optional(),
+        paused: z.boolean().optional(),
+        idempotency_key: z.string().optional(),
+        adcp_major_version: z.number().optional(),
+        adcp_version: z.string().optional(),
+        push_notification_config: z.any().optional(),
+      },
+    },
+    async args => {
+      calls.push({ tool: mutationName, args: structuredClone(args) });
+      return toolResult(
+        mutationName === 'sync_accounts'
+          ? { status: 'completed', accounts: [] }
+          : { status: 'completed', media_buy_id: 'mb_1', revision: 2 }
+      );
+    }
+  );
+
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+  const mcpClient = new Client({ name: 'capability-probe-operation-id-test', version: '1.0.0' });
+  await mcpClient.connect(clientTransport);
+
+  const client = new ADCPMultiAgentClient(
+    [
+      {
+        id: `${mutationName}-agent`,
+        name: `${mutationName} agent`,
+        agent_uri: `in-process://${mutationName}-agent`,
+        protocol: 'mcp',
+        _inProcessMcpClient: mcpClient,
+      },
+    ],
+    {
+      requireV3ForMutations: true,
+      validateFeatures: false,
+      webhookUrlTemplate: WEBHOOK_TEMPLATE,
+      webhookSecret: WEBHOOK_SECRET,
+      webhookRegistrationStore: registrationStore,
+      validation: { requests: 'off', responses: 'off' },
+      ...clientConfig,
+    }
+  );
+
+  return {
+    agent: client.agent(`${mutationName}-agent`),
+    calls,
+    registrations,
+    async close() {
+      await mcpClient.close();
+      await server.close();
+    },
+  };
+}
+
+function invokeMutation(agent, mutationName, options) {
+  return mutationName === 'sync_accounts'
+    ? agent.syncAccounts({ idempotency_key: 'sync-accounts-idempotency-key', accounts: [] }, undefined, options)
+    : agent.updateMediaBuyLegacy(
+        {
+          account: { account_id: 'acc_1' },
+          media_buy_id: 'mb_1',
+          idempotency_key: 'update-media-buy-idempotency-key',
+          paused: true,
+        },
+        undefined,
+        options
+      );
+}
+
+function invokeCanonicalCreativeUpdate(agent, options) {
+  return agent.updateMediaBuy(
+    {
+      account: { account_id: 'acc_1' },
+      media_buy_id: 'mb_1',
+      idempotency_key: 'canonical-update-idempotency-key',
+      packages: [{ package_id: 'pkg_1', creatives: [] }],
+    },
+    undefined,
+    options
+  );
+}
+
+for (const mutationName of ['update_media_buy', 'sync_accounts']) {
+  test(`lazy capability discovery uses a child operation ID before ${mutationName}`, async t => {
+    const harness = await createHarness(mutationName);
+    t.after(() => harness.close());
+
+    let parentOperationId;
+    const result = await withTaskDeadline({}, async options => {
+      parentOperationId = getTaskOperationId(options);
+      return invokeMutation(harness.agent, mutationName, options);
+    });
+
+    assert.equal(result.success, true, result.error);
+    assert.deepEqual(
+      harness.calls.map(call => call.tool),
+      ['get_adcp_capabilities', mutationName],
+      'the mutation must reach the seller after capability discovery'
+    );
+    assert.equal(harness.registrations.length, 2);
+
+    const probeRegistration = harness.registrations.find(
+      registration => registration.taskType === 'get_adcp_capabilities'
+    );
+    const mutationRegistration = harness.registrations.find(registration => registration.taskType === mutationName);
+    assert.ok(probeRegistration);
+    assert.ok(mutationRegistration);
+    assert.notEqual(probeRegistration.operationId, mutationRegistration.operationId);
+    assert.equal(mutationRegistration.operationId, parentOperationId, 'the mutation retains its parent operation ID');
+    assert.equal(result.metadata.taskId, parentOperationId);
+    assert.equal(harness.calls[0].args.push_notification_config.operation_id, probeRegistration.operationId);
+    assert.equal(harness.calls[1].args.push_notification_config.operation_id, mutationRegistration.operationId);
+  });
+}
+
+test('lazy capability discovery preserves webhook suppression for the probe and mutation', async t => {
+  const harness = await createHarness('sync_accounts');
+  t.after(() => harness.close());
+
+  const result = await invokeMutation(harness.agent, 'sync_accounts', { disableWebhook: true });
+
+  assert.equal(result.success, true, result.error);
+  assert.deepEqual(
+    harness.calls.map(call => call.tool),
+    ['get_adcp_capabilities', 'sync_accounts']
+  );
+  assert.equal(harness.registrations.length, 0);
+  assert.equal(harness.calls[0].args.push_notification_config, undefined);
+  assert.equal(harness.calls[1].args.push_notification_config, undefined);
+});
+
+test('creative-format preflight preserves webhook suppression on a cold client', async t => {
+  const harness = await createHarness('update_media_buy');
+  t.after(() => harness.close());
+
+  const result = await invokeCanonicalCreativeUpdate(harness.agent, { disableWebhook: true });
+
+  assert.equal(result.success, true, result.error);
+  assert.deepEqual(
+    harness.calls.map(call => call.tool),
+    ['get_adcp_capabilities', 'update_media_buy']
+  );
+  assert.equal(harness.registrations.length, 0);
+  assert.equal(harness.calls[0].args.push_notification_config, undefined);
+  assert.equal(harness.calls[1].args.push_notification_config, undefined);
+});
+
+test('lazy capability discovery preserves per-call callback authorization provenance', async t => {
+  const defaultAuthorization = { brand: 'tenant_a', scope: 'media_buying', country: 'US' };
+  const delegatedOperatorAuthorization = { brand: 'tenant_b', scope: 'governance', country: 'GB' };
+  const harness = await createHarness('sync_accounts', {
+    clientConfig: {
+      webhookVerification: {
+        resolverOptions: {
+          requiredOperatorBrand: defaultAuthorization.brand,
+          requiredOperatorScope: defaultAuthorization.scope,
+          requiredOperatorCountry: defaultAuthorization.country,
+        },
+      },
+    },
+  });
+  t.after(() => harness.close());
+
+  const result = await invokeMutation(harness.agent, 'sync_accounts', { delegatedOperatorAuthorization });
+
+  assert.equal(result.success, true, result.error);
+  assert.equal(harness.registrations.length, 2);
+  for (const registration of harness.registrations) {
+    assert.deepEqual(registration.delegatedOperatorAuthorization, delegatedOperatorAuthorization);
+  }
+});
+
+test('creative-format preflight preserves per-call callback authorization provenance', async t => {
+  const delegatedOperatorAuthorization = { brand: 'tenant_b', scope: 'governance', country: 'GB' };
+  const harness = await createHarness('update_media_buy', {
+    clientConfig: {
+      webhookVerification: {
+        resolverOptions: {
+          requiredOperatorBrand: 'tenant_a',
+          requiredOperatorScope: 'media_buying',
+          requiredOperatorCountry: 'US',
+        },
+      },
+    },
+  });
+  t.after(() => harness.close());
+
+  const result = await invokeCanonicalCreativeUpdate(harness.agent, { delegatedOperatorAuthorization });
+
+  assert.equal(result.success, true, result.error);
+  assert.equal(harness.registrations.length, 2);
+  for (const registration of harness.registrations) {
+    assert.deepEqual(registration.delegatedOperatorAuthorization, delegatedOperatorAuthorization);
+  }
+});
+
+for (const cancellation of ['caller abort', 'task deadline']) {
+  test(`lazy capability discovery honors ${cancellation} before dispatching the mutation`, async t => {
+    const started = deferred();
+    const release = deferred();
+    const harness = await createHarness('sync_accounts', {
+      beforeCapabilitiesResponse: async () => {
+        started.resolve();
+        await release.promise;
+      },
+    });
+    t.after(async () => {
+      release.resolve();
+      await harness.close();
+    });
+
+    const controller = new AbortController();
+    const options =
+      cancellation === 'caller abort'
+        ? { signal: controller.signal, transport: { requestTimeoutMs: 0 } }
+        : { timeout: 2000, transport: { requestTimeoutMs: 0 } };
+    const pending = invokeMutation(harness.agent, 'sync_accounts', options);
+    await started.promise;
+    if (cancellation === 'caller abort') controller.abort();
+
+    try {
+      await assert.rejects(pending, error =>
+        cancellation === 'caller abort'
+          ? error?.name === 'AbortError' || /\bAbortError\b/.test(String(error))
+          : error?.name === 'TaskTimeoutError'
+      );
+    } finally {
+      release.resolve();
+    }
+    assert.deepEqual(
+      harness.calls.map(call => call.tool),
+      ['get_adcp_capabilities']
+    );
+  });
+}
+
+test('probe and mutation spans retain their shared caller trace parent', async t => {
+  const harness = await createHarness('sync_accounts');
+  t.after(() => harness.close());
+
+  const activeSpan = new AsyncLocalStorage();
+  const spans = [];
+  const originalGetTracer = trace.getTracer;
+  trace.getTracer = () => ({
+    startActiveSpan(name, _options, fn) {
+      const record = {
+        id: `span-${spans.length + 1}`,
+        name,
+        parentId: activeSpan.getStore()?.id,
+      };
+      spans.push(record);
+      const span = {
+        setStatus() {},
+        recordException() {},
+        end() {},
+      };
+      return activeSpan.run(record, () => fn(span));
+    },
+  });
+
+  try {
+    const result = await withSpan('buyer.dispatch', {}, () => invokeMutation(harness.agent, 'sync_accounts', {}));
+    assert.equal(result.success, true, result.error);
+  } finally {
+    trace.getTracer = originalGetTracer;
+  }
+
+  const parent = spans.find(span => span.name === 'buyer.dispatch');
+  assert.ok(parent);
+  const physicalTasks = spans.filter(span => span.name === 'adcp.mcp.call_tool' && span.parentId === parent.id);
+  assert.equal(physicalTasks.length, 2);
+});
+
+test('capability child options preserve request policy without inheriting the parent operation ID', async () => {
+  const agent = {
+    id: 'probe-options-agent',
+    name: 'Probe options agent',
+    agent_uri: 'https://seller.example/mcp',
+    protocol: 'mcp',
+  };
+  const client = new SingleAgentClient(agent, {
+    validation: { requests: 'off', responses: 'off' },
+  });
+  client.getAgentInfo = async () => ({
+    name: agent.name,
+    protocol: 'mcp',
+    url: agent.agent_uri,
+    tools: [{ name: 'get_adcp_capabilities' }],
+  });
+  client.ensureEndpointDiscovered = async () => agent;
+
+  let receivedOptions;
+  client.executor.executeTask = async (_agent, _task, _params, _handler, options) => {
+    receivedOptions = options;
+    return {
+      success: true,
+      status: 'completed',
+      data: {
+        adcp: { major_versions: [3], idempotency: { supported: true, replay_ttl_seconds: 86400 } },
+        supported_protocols: ['media_buy'],
+      },
+    };
+  };
+
+  const controller = new AbortController();
+  const transport = { requestTimeoutMs: 4321, maxResponseBytes: 9876 };
+  const delegatedOperatorAuthorization = { brand: 'tenant_b', scope: 'governance', country: 'GB' };
+  let parentOperationId;
+  await withTaskDeadline(
+    { signal: controller.signal, transport, disableWebhook: true, delegatedOperatorAuthorization },
+    async options => {
+      parentOperationId = getTaskOperationId(options);
+      await client.getCapabilities(options);
+    }
+  );
+
+  assert.ok(parentOperationId);
+  assert.equal(getTaskOperationId(receivedOptions), undefined);
+  assert.equal(receivedOptions.signal, controller.signal);
+  assert.deepEqual(receivedOptions.transport, transport);
+  assert.equal(receivedOptions.disableWebhook, true);
+  assert.deepEqual(receivedOptions.delegatedOperatorAuthorization, delegatedOperatorAuthorization);
+  assert.notEqual(receivedOptions.delegatedOperatorAuthorization, delegatedOperatorAuthorization);
+});


### PR DESCRIPTION
## Summary

- Give lazy get_adcp_capabilities probes their own operation IDs instead of inheriting the triggering mutation ID.
- Preserve caller cancellation, transport safeguards, webhook suppression, and delegated callback authorization at the probe boundary.
- Route creative-format preflights through the same central option allowlist.
- Add real MCP client/server coverage for update_media_buy and sync_accounts, cancellation, deadlines, trace ancestry, webhook policy, and tenant authorization.
- Document why seller conformance and pre-warmed storyboards do not cover cold buyer-SDK configuration interactions.

Closes #2866

## Why existing QA missed this

Conformance grades the remote seller. Storyboards discover and cache the agent profile before functional steps. Neither exercises a cold SingleAgentClient where lazy capability discovery and a mutation share task options, webhook templates, and a durable registration store. This PR adds that missing buyer-side configuration matrix.

## Validation

- npm run build
- 64 focused capability, deadline, webhook, and pre-dispatch tests
- Four independent Claude expert lenses: DX, protocol, code, security
- Independent Codex protocol, code, and security reviews
- Pre-push formatting, typecheck, and build gates
- Local full-suite environmental failures reproduced cleanly: scaffold test passes without the VM-injected DATABASE_URL; handler-flow test passes with the repository's 8 GB Node heap setting

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/3e4aaba5-a277-4a7f-9773-67c3f9b1cc3c)

