### PR TITLE
fix(testing): canonicalize agent URLs in storyboard validation

### DIFF
--- a/.changeset/calm-runners-canonicalize.md
+++ b/.changeset/calm-runners-canonicalize.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Canonicalize agent URL identity fields before storyboard runner comparisons so schema-conformant URL forms grade equivalently without changing resource URL assertions.

--- a/src/lib/testing/storyboard/validations.ts
+++ b/src/lib/testing/storyboard/validations.ts
@@ -33,6 +33,7 @@ import type { RecordedCall, UpstreamTrafficSuccess } from '../test-controller';
 import { isJsonContentType } from '../test-controller';
 import { globToRegExp } from '../../utils/glob';
 import {
+  parsePath,
   resolvePath,
   resolvePathAll,
   resolvePortableIdentifierPathAll,
@@ -40,6 +41,7 @@ import {
   validatePortableIdentifierPath,
   type PortableIdentifierPathIssue,
 } from './path';
+import { canonicalTargetUri } from '../../signing/canonicalize';
 import { detectShapeDriftHints } from './shape-drift-hints';
 import { PROBE_TASK_ALLOWLIST } from './test-kit';
 import { validateCanonicalFormatSatisfaction } from './canonical-format-satisfaction';
@@ -974,24 +976,94 @@ function validateFieldAbsent(validation: StoryboardValidation, taskResult: TaskR
 // field_value: check a path equals expected value
 // ────────────────────────────────────────────────────────────
 
-function valuesMatch(actual: unknown, expected: unknown): boolean {
+function comparisonKeyFromPath(path: string): string | undefined {
+  const segments = parsePath(path);
+  for (let i = segments.length - 1; i >= 0; i -= 1) {
+    const segment = segments[i];
+    if (typeof segment === 'string') return segment;
+  }
+  return undefined;
+}
+
+function isAgentUrlComparisonKey(key: string | undefined): boolean {
+  const normalized = key?.toLowerCase();
+  return normalized === 'agent_url' || normalized?.endsWith('_agent_url') === true;
+}
+
+function agentUrlValuesMatch(actual: string, expected: string): boolean {
+  try {
+    // The 3.1.18 and 3.2 protocol bundles share this canonical target-URI
+    // profile, including empty-path normalization and byte-preserved query
+    // strings. Reuse its signed-vector-tested implementation here.
+    return canonicalTargetUri(actual, '3.2') === canonicalTargetUri(expected, '3.2');
+  } catch {
+    // agent_url fields are schema-declared URIs. Malformed values must
+    // not pass merely because the same malformed bytes appear on both sides.
+    return false;
+  }
+}
+
+function normalizeAgentUrlsForDistinctCount(
+  value: unknown,
+  comparisonKey?: string
+): { value: unknown; valid: boolean } {
+  if (isAgentUrlComparisonKey(comparisonKey)) {
+    if (typeof value !== 'string') return { value, valid: false };
+    try {
+      return { value: canonicalTargetUri(value, '3.2'), valid: true };
+    } catch {
+      return { value, valid: false };
+    }
+  }
+
+  if (Array.isArray(value)) {
+    const normalized: unknown[] = [];
+    for (const item of value) {
+      const result = normalizeAgentUrlsForDistinctCount(item, comparisonKey);
+      if (!result.valid) return { value, valid: false };
+      normalized.push(result.value);
+    }
+    return { value: normalized, valid: true };
+  }
+
+  if (typeof value === 'object' && value !== null) {
+    const normalized: Record<string, unknown> = {};
+    for (const [key, item] of Object.entries(value)) {
+      const result = normalizeAgentUrlsForDistinctCount(item, key);
+      if (!result.valid) return { value, valid: false };
+      normalized[key] = result.value;
+    }
+    return { value: normalized, valid: true };
+  }
+
+  return { value, valid: true };
+}
+
+function valuesMatch(actual: unknown, expected: unknown, comparisonKey?: string): boolean {
+  if (isAgentUrlComparisonKey(comparisonKey)) {
+    return typeof actual === 'string' && typeof expected === 'string' && agentUrlValuesMatch(actual, expected);
+  }
   if (typeof actual === 'object' && actual !== null) {
-    return deepEqualJsonValue(actual, expected);
+    return deepEqualJsonValue(actual, expected, comparisonKey);
   }
   return actual === expected;
 }
 
 /**
  * JSON deep equality for `field_value`-family checks: object member order is
- * NOT significant (RFC 8259 section 4), array element order IS, scalars are
- * strict. Mirrors the sibling implementations in `webhook-receiver.ts` and
- * `canonical-format-satisfaction.ts`. Previously this was a
+ * NOT significant (RFC 8259 section 4), array element order IS, and scalars
+ * are strict except for agent URL identity fields, which use AdCP URL
+ * canonicalization. Mirrors the sibling implementations in
+ * `webhook-receiver.ts` and `canonical-format-satisfaction.ts`. Previously this was a
  * `JSON.stringify(a) === JSON.stringify(b)` comparison, which false-negatived
  * content-equal objects whose members serialize in a different order (e.g. a
  * format_id `{id, agent_url}` echoed by the agent as `{agent_url, id}`) —
  * adcp-client#2327.
  */
-function deepEqualJsonValue(a: unknown, b: unknown): boolean {
+function deepEqualJsonValue(a: unknown, b: unknown, comparisonKey?: string): boolean {
+  if (isAgentUrlComparisonKey(comparisonKey)) {
+    return typeof a === 'string' && typeof b === 'string' && agentUrlValuesMatch(a, b);
+  }
   if (a === b) return true;
   if (typeof a !== typeof b) return false;
   if (a === null || b === null) return a === b;
@@ -1000,7 +1072,7 @@ function deepEqualJsonValue(a: unknown, b: unknown): boolean {
     if (!Array.isArray(a) || !Array.isArray(b)) return false;
     if (a.length !== b.length) return false;
     for (let i = 0; i < a.length; i++) {
-      if (!deepEqualJsonValue(a[i], b[i])) return false;
+      if (!deepEqualJsonValue(a[i], b[i], comparisonKey)) return false;
     }
     return true;
   }
@@ -1009,7 +1081,7 @@ function deepEqualJsonValue(a: unknown, b: unknown): boolean {
   if (keysA.length !== keysB.length) return false;
   for (const k of keysA) {
     if (!Object.prototype.hasOwnProperty.call(b, k)) return false;
-    if (!deepEqualJsonValue((a as Record<string, unknown>)[k], (b as Record<string, unknown>)[k])) return false;
+    if (!deepEqualJsonValue((a as Record<string, unknown>)[k], (b as Record<string, unknown>)[k], k)) return false;
   }
   return true;
 }
@@ -1031,14 +1103,14 @@ function isRecord(value: unknown): value is Record<string, unknown> {
  * without requiring the seller to omit additional optional fields or keep a
  * fixed array order.
  */
-function containsValueMatches(actual: unknown, expected: unknown): boolean {
+function containsValueMatches(actual: unknown, expected: unknown, comparisonKey?: string): boolean {
   if (Array.isArray(expected)) {
     if (!Array.isArray(actual)) return false;
     if (expected.length === 0) return actual.length === 0;
     const used = new Set<number>();
     return expected.every(expectedItem => {
       const matchIndex = actual.findIndex(
-        (actualItem, index) => !used.has(index) && containsValueMatches(actualItem, expectedItem)
+        (actualItem, index) => !used.has(index) && containsValueMatches(actualItem, expectedItem, comparisonKey)
       );
       if (matchIndex === -1) return false;
       used.add(matchIndex);
@@ -1050,11 +1122,11 @@ function containsValueMatches(actual: unknown, expected: unknown): boolean {
     if (!isRecord(actual)) return false;
     return Object.entries(expected).every(
       ([key, expectedValue]) =>
-        Object.prototype.hasOwnProperty.call(actual, key) && containsValueMatches(actual[key], expectedValue)
+        Object.prototype.hasOwnProperty.call(actual, key) && containsValueMatches(actual[key], expectedValue, key)
     );
   }
 
-  return valuesMatch(actual, expected);
+  return valuesMatch(actual, expected, comparisonKey);
 }
 
 function pathUsesWildcardSyntax(path: string): boolean {
@@ -1099,7 +1171,8 @@ function validateFieldValue(validation: StoryboardValidation, taskResult: TaskRe
 
   // allowed_values: pass if actual matches any value in the list
   if (validation.allowed_values?.length) {
-    const passed = validation.allowed_values.some(v => valuesMatch(actual, v));
+    const comparisonKey = comparisonKeyFromPath(validation.path);
+    const passed = validation.allowed_values.some(v => valuesMatch(actual, v, comparisonKey));
     if (passed) {
       return {
         check: checkName,
@@ -1122,7 +1195,7 @@ function validateFieldValue(validation: StoryboardValidation, taskResult: TaskRe
   }
 
   // Exact match against value
-  const passed = valuesMatch(actual, validation.value);
+  const passed = valuesMatch(actual, validation.value, comparisonKeyFromPath(validation.path));
 
   if (passed) {
     return {
@@ -1197,7 +1270,8 @@ function validateFieldValueOrAbsent(validation: StoryboardValidation, taskResult
 
   // Present → fall through to the same value / allowed_values semantics as field_value.
   if (validation.allowed_values?.length) {
-    const passed = validation.allowed_values.some(v => valuesMatch(actual, v));
+    const comparisonKey = comparisonKeyFromPath(validation.path);
+    const passed = validation.allowed_values.some(v => valuesMatch(actual, v, comparisonKey));
     if (passed) {
       return {
         check: checkName,
@@ -1219,7 +1293,7 @@ function validateFieldValueOrAbsent(validation: StoryboardValidation, taskResult
     };
   }
 
-  const passed = valuesMatch(actual, validation.value);
+  const passed = valuesMatch(actual, validation.value, comparisonKeyFromPath(validation.path));
   if (passed) {
     return {
       check: checkName,
@@ -1394,7 +1468,8 @@ function validateFieldContains(validation: StoryboardValidation, taskResult: Tas
   const pointer = toJsonPointer(validation.path);
 
   const candidates = validation.allowed_values?.length ? validation.allowed_values : [validation.value];
-  const matched = resolved.some(actual => candidates.some(c => containsValueMatches(actual, c)));
+  const comparisonKey = comparisonKeyFromPath(validation.path);
+  const matched = resolved.some(actual => candidates.some(c => containsValueMatches(actual, c, comparisonKey)));
 
   if (matched) {
     return {
@@ -2998,7 +3073,7 @@ function validateFieldEqualsContext(validation: StoryboardValidation, ctx: Valid
   const expected = comparandResult.value;
   const pointer = toJsonPointer(validation.path);
 
-  const passed = valuesMatch(actual, expected);
+  const passed = valuesMatch(actual, expected, comparisonKeyFromPath(validation.path));
   if (passed) {
     return {
       check: 'field_equals_context',
@@ -3070,7 +3145,8 @@ function validateFieldInContextArray(validation: StoryboardValidation, ctx: Vali
     };
   }
 
-  if (allowed.some(candidate => valuesMatch(actual, candidate))) {
+  const comparisonKey = comparisonKeyFromPath(validation.path);
+  if (allowed.some(candidate => valuesMatch(actual, candidate, comparisonKey))) {
     return {
       check: 'field_in_context_array',
       passed: true,
@@ -3142,7 +3218,8 @@ function validateAllFieldsInContextArray(validation: StoryboardValidation, ctx: 
     };
   }
 
-  const passed = actual.every(value => allowed.some(candidate => deepEqualJsonValue(value, candidate)));
+  const comparisonKey = comparisonKeyFromPath(validation.path);
+  const passed = actual.every(value => allowed.some(candidate => deepEqualJsonValue(value, candidate, comparisonKey)));
   if (passed) {
     return {
       check,
@@ -3747,7 +3824,8 @@ function validateCrossResponseFieldEqual(validation: StoryboardValidation, ctx: 
   }
   const values = cr.resolved.map(tr => resolvePath(tr.data as Record<string, unknown> | undefined, path));
   const first = values[0];
-  const allEqual = values.every(v => deepEqual(v, first));
+  const comparisonKey = comparisonKeyFromPath(path);
+  const allEqual = values.every(v => valuesMatch(v, first, comparisonKey));
   if (allEqual) {
     return {
       check: validation.check,
@@ -3896,13 +3974,29 @@ function validateCrossResponseCountDistinct(
       schema_url: null,
     };
   }
-  const distinct = new Set<string>();
+  const comparisonKey = comparisonKeyFromPath(path);
+  const exactValues = new Set<string>();
   for (const tr of cr.resolved) {
     const v = resolvePath(tr.data as Record<string, unknown> | undefined, path);
-    if (v === undefined || v === null) continue;
-    distinct.add(JSON.stringify(v));
+    if (v === undefined || (v === null && !isAgentUrlComparisonKey(comparisonKey))) continue;
+    const normalized = normalizeAgentUrlsForDistinctCount(v, comparisonKey);
+    if (!normalized.valid) {
+      return {
+        check: validation.check,
+        passed: false,
+        description: validation.description,
+        json_pointer: toJsonPointer(path),
+        expected: 'valid URI strings in all agent URL identity fields',
+        actual: v,
+        schema_id: null,
+        schema_url: null,
+      };
+    }
+    // Preserve the check's historical serialization distinctness for all
+    // non-agent fields; object member order remains observable here.
+    exactValues.add(JSON.stringify(normalized.value));
   }
-  const distinctCount = distinct.size;
+  const distinctCount = exactValues.size;
   const allowed = validation.allowed_values as number[];
   if (allowed.includes(distinctCount)) {
     return {

--- a/test/lib/storyboard-parallel-dispatch.test.js
+++ b/test/lib/storyboard-parallel-dispatch.test.js
@@ -75,6 +75,24 @@ describe('cross_response_field_equal', () => {
     assert.strictEqual(r.actual, 'mb_1');
   });
 
+  it('canonicalizes agent_url identity across dispatches', () => {
+    const crossResponses = {
+      dispatches: [
+        { correlation_id: 'a', duration_ms: 10, taskResult: { success: true, data: {} } },
+        { correlation_id: 'b', duration_ms: 12, taskResult: { success: true, data: {} } },
+      ],
+      resolved: [
+        { success: true, data: { agent_url: 'https://formats.example' } },
+        { success: true, data: { agent_url: 'https://formats.example/' } },
+      ],
+    };
+    const [r] = runValidations(
+      [{ check: 'cross_response_field_equal', path: 'agent_url', description: 'same agent identity' }],
+      { ...baseCtx, crossResponses }
+    );
+    assert.strictEqual(r.passed, true, r.error);
+  });
+
   it('fails when resolved dispatches disagree', () => {
     const crossResponses = {
       dispatches: [
@@ -135,6 +153,119 @@ describe('cross_response_count_distinct', () => {
     const [r] = runValidations([check([1])], { ...baseCtx, crossResponses });
     assert.strictEqual(r.passed, true);
     assert.strictEqual(r.actual, 1);
+  });
+
+  it('counts canonical-equivalent agent_url values once', () => {
+    const crossResponses = {
+      dispatches: [
+        { correlation_id: 'a', duration_ms: 10, taskResult: { success: true, data: {} } },
+        { correlation_id: 'b', duration_ms: 12, taskResult: { success: true, data: {} } },
+      ],
+      resolved: [
+        { success: true, data: { agent_url: 'https://formats.example' } },
+        { success: true, data: { agent_url: 'https://formats.example/' } },
+      ],
+    };
+    const [r] = runValidations(
+      [
+        {
+          check: 'cross_response_count_distinct',
+          path: 'agent_url',
+          allowed_values: [1],
+          description: 'one canonical agent identity',
+        },
+      ],
+      { ...baseCtx, crossResponses }
+    );
+    assert.strictEqual(r.passed, true, r.error);
+    assert.strictEqual(r.actual, 1);
+  });
+
+  it('canonicalizes nested agent_url values in object identities', () => {
+    const crossResponses = {
+      dispatches: [
+        { correlation_id: 'a', duration_ms: 10, taskResult: { success: true, data: {} } },
+        { correlation_id: 'b', duration_ms: 12, taskResult: { success: true, data: {} } },
+      ],
+      resolved: [
+        {
+          success: true,
+          data: { format_id: { agent_url: 'https://formats.example', id: 'display' } },
+        },
+        {
+          success: true,
+          data: { format_id: { agent_url: 'https://formats.example/', id: 'display' } },
+        },
+      ],
+    };
+    const [r] = runValidations(
+      [
+        {
+          check: 'cross_response_count_distinct',
+          path: 'format_id',
+          allowed_values: [1],
+          description: 'one canonical format identity',
+        },
+      ],
+      { ...baseCtx, crossResponses }
+    );
+    assert.strictEqual(r.passed, true, r.error);
+    assert.strictEqual(r.actual, 1);
+  });
+
+  for (const [label, value] of [
+    ['null', null],
+    ['numeric', 42],
+    ['malformed', 'not-a-url'],
+  ]) {
+    for (const nested of [false, true]) {
+      it(`fails closed for ${nested ? 'nested' : 'direct'} ${label} agent_url values`, () => {
+        const data = nested ? { format_id: { agent_url: value, id: 'display' } } : { agent_url: value };
+        const crossResponses = {
+          dispatches: [{ correlation_id: 'a', duration_ms: 10, taskResult: { success: true, data } }],
+          resolved: [{ success: true, data }],
+        };
+        const [r] = runValidations(
+          [
+            {
+              check: 'cross_response_count_distinct',
+              path: nested ? 'format_id' : 'agent_url',
+              allowed_values: [0, 1],
+              description: 'invalid agent identity must fail before cardinality grading',
+            },
+          ],
+          { ...baseCtx, crossResponses }
+        );
+        assert.strictEqual(r.passed, false);
+        assert.match(String(r.expected), /valid URI strings/);
+      });
+    }
+  }
+
+  it('preserves serialized distinctness for non-agent object values', () => {
+    const crossResponses = {
+      dispatches: [
+        { correlation_id: 'a', duration_ms: 10, taskResult: { success: true, data: {} } },
+        { correlation_id: 'b', duration_ms: 12, taskResult: { success: true, data: {} } },
+      ],
+      resolved: [
+        { success: true, data: { value: { a: 1, b: 2 } } },
+        { success: true, data: { value: { b: 2, a: 1 } } },
+      ],
+    };
+    const [r] = runValidations(
+      [
+        {
+          check: 'cross_response_count_distinct',
+          path: 'value',
+          allowed_values: [2],
+          description: 'non-agent values retain historical serialization semantics',
+        },
+      ],
+      { ...baseCtx, crossResponses }
+    );
+    assert.strictEqual(r.passed, true, r.error);
+    assert.strictEqual(r.actual, 2);
   });
 
   it('fails when two resources were created (race not resolved)', () => {

--- a/test/lib/storyboard-validations.test.js
+++ b/test/lib/storyboard-validations.test.js
@@ -56,6 +56,24 @@ describe('all_fields_in_context_array', () => {
     );
     assert.strictEqual(result.passed, true, result.error);
   });
+
+  it('canonicalizes a directly selected agent_url terminal', () => {
+    const [result] = runOne(
+      [
+        {
+          check: 'all_fields_in_context_array',
+          path: 'formats[*].agent_url',
+          context_key: 'format_agents',
+          description: 'all format agents are known',
+        },
+      ],
+      'list_creative_formats',
+      { success: true, data: { formats: [{ agent_url: 'https://formats.example/' }] } },
+      { format_agents: ['https://formats.example'] }
+    );
+
+    assert.strictEqual(result.passed, true, result.error);
+  });
 });
 
 describe('validateErrorCode', () => {
@@ -633,6 +651,230 @@ describe('field_absent / envelope_field_absent (adcp#3429)', () => {
 });
 
 describe('field_contains (adcp#3803 item 2)', () => {
+  it('canonicalizes format_id agent_url values before subset comparison (adcp#7367)', () => {
+    const taskResult = {
+      success: true,
+      data: {
+        products: [
+          {
+            format_ids: [
+              {
+                agent_url: 'https://compliance.adcontextprotocol.org/',
+                id: 'get_products_pagination_integrity_display',
+              },
+            ],
+          },
+        ],
+      },
+    };
+
+    const [result] = runOne(
+      [
+        {
+          check: 'field_contains',
+          path: 'products[0].format_ids[*]',
+          value: {
+            agent_url: 'https://compliance.adcontextprotocol.org',
+            id: 'get_products_pagination_integrity_display',
+          },
+          description: 'format id URL uses canonical identity comparison',
+        },
+      ],
+      'get_products',
+      taskResult
+    );
+
+    assert.strictEqual(result.passed, true, result.error);
+  });
+
+  it('preserves query ordering when canonicalizing format_id agent_url values', () => {
+    const taskResult = {
+      success: true,
+      data: {
+        products: [
+          {
+            format_ids: [{ agent_url: 'https://formats.example/path?a=1&b=2', id: 'display' }],
+          },
+        ],
+      },
+    };
+
+    const [result] = runOne(
+      [
+        {
+          check: 'field_contains',
+          path: 'products[0].format_ids[*]',
+          value: { agent_url: 'https://formats.example/path?b=2&a=1', id: 'display' },
+          description: 'query order remains identity-significant',
+        },
+      ],
+      'get_products',
+      taskResult
+    );
+
+    assert.strictEqual(result.passed, false);
+  });
+
+  it('canonicalizes a directly selected agent_url field', () => {
+    const taskResult = {
+      success: true,
+      data: { format_id: { agent_url: 'HTTPS://FORMATS.EXAMPLE:443', id: 'display' } },
+    };
+
+    const [result] = runOne(
+      [
+        {
+          check: 'field_value',
+          path: 'format_id.agent_url',
+          value: 'https://formats.example/',
+          description: 'direct URL field uses canonical identity comparison',
+        },
+      ],
+      'list_creative_formats',
+      taskResult
+    );
+
+    assert.strictEqual(result.passed, true, result.error);
+  });
+
+  it('canonicalizes seller_agent_url identity fields', () => {
+    const [result] = runOne(
+      [
+        {
+          check: 'field_value',
+          path: 'seller_agent_url',
+          value: 'https://seller.example/',
+          description: 'seller identity uses canonical comparison',
+        },
+      ],
+      'identity_match',
+      { success: true, data: { seller_agent_url: 'https://seller.example' } }
+    );
+
+    assert.strictEqual(result.passed, true, result.error);
+  });
+
+  it('fails closed when identical agent_url values are malformed', () => {
+    const [result] = runOne(
+      [
+        {
+          check: 'field_value',
+          path: 'format_id.agent_url',
+          value: 'not-a-url',
+          description: 'malformed identity cannot compare equal',
+        },
+      ],
+      'list_creative_formats',
+      { success: true, data: { format_id: { agent_url: 'not-a-url', id: 'display' } } }
+    );
+
+    assert.strictEqual(result.passed, false);
+  });
+
+  for (const malformed of [null, 42]) {
+    it(`fails closed when identical agent_url values are ${malformed === null ? 'null' : 'numeric'}`, () => {
+      const [result] = runOne(
+        [
+          {
+            check: 'field_value',
+            path: 'format_id.agent_url',
+            value: malformed,
+            description: 'non-string identity cannot compare equal',
+          },
+        ],
+        'list_creative_formats',
+        { success: true, data: { format_id: { agent_url: malformed, id: 'display' } } }
+      );
+
+      assert.strictEqual(result.passed, false);
+    });
+  }
+
+  it('keeps non-identity resource URL fields byte-significant', () => {
+    const taskResult = {
+      success: true,
+      data: { preview_url: 'https://preview.example/render#variant-a' },
+    };
+
+    const [result] = runOne(
+      [
+        {
+          check: 'field_value',
+          path: 'preview_url',
+          value: 'https://preview.example/render#variant-b',
+          description: 'preview resource fragments remain distinct',
+        },
+      ],
+      'preview_creative',
+      taskResult
+    );
+
+    assert.strictEqual(result.passed, false);
+  });
+
+  for (const [name, actual, expected] of [
+    ['query percent-encoding', 'https://formats.example/path?x=%7e', 'https://formats.example/path?x=~'],
+    ['empty query marker', 'https://formats.example/path?', 'https://formats.example/path'],
+    ['consecutive path slashes', 'https://formats.example/a//b', 'https://formats.example/a/b'],
+  ]) {
+    it(`preserves identity-significant ${name}`, () => {
+      const [result] = runOne(
+        [
+          {
+            check: 'field_value',
+            path: 'format_id.agent_url',
+            value: expected,
+            description: `${name} remains distinct`,
+          },
+        ],
+        'list_creative_formats',
+        { success: true, data: { format_id: { agent_url: actual, id: 'display' } } }
+      );
+
+      assert.strictEqual(result.passed, false);
+    });
+  }
+
+  it('canonicalizes allowed agent_url values on the tolerant field branch', () => {
+    const [result] = runOne(
+      [
+        {
+          check: 'field_value_or_absent',
+          path: 'format_id.agent_url',
+          allowed_values: ['https://formats.example'],
+          description: 'present canonical equivalent is allowed',
+        },
+      ],
+      'list_creative_formats',
+      { success: true, data: { format_id: { agent_url: 'https://formats.example/', id: 'display' } } }
+    );
+
+    assert.strictEqual(result.passed, true, result.error);
+  });
+
+  it('canonicalizes nested agent_url values in field_contains allowed_values', () => {
+    const [result] = runOne(
+      [
+        {
+          check: 'field_contains',
+          path: 'format_ids[*]',
+          allowed_values: [
+            { agent_url: 'https://other.example/', id: 'display' },
+            { agent_url: 'https://formats.example', id: 'display' },
+          ],
+          description: 'one canonical format identity is allowed',
+        },
+      ],
+      'get_products',
+      {
+        success: true,
+        data: { format_ids: [{ agent_url: 'https://formats.example/', id: 'display' }] },
+      }
+    );
+
+    assert.strictEqual(result.passed, true, result.error);
+  });
+
   it('passes when value matches any element via [*] wildcard', () => {
     const taskResult = {
       success: true,

--- a/test/storyboard-cross-step-validators.test.js
+++ b/test/storyboard-cross-step-validators.test.js
@@ -377,6 +377,17 @@ describe('field_equals_context', () => {
     );
     assert.strictEqual(result.passed, true);
   });
+
+  it('canonicalizes agent_url values from context', () => {
+    const [result] = runValidations(
+      [{ check: 'field_equals_context', path: 'agent_url', context_key: 'agent_url', description: 'agent matches' }],
+      makeCtx({
+        data: { agent_url: 'https://formats.example/' },
+        storyboardContext: { agent_url: 'https://formats.example' },
+      })
+    );
+    assert.strictEqual(result.passed, true, result.error);
+  });
 });
 
 // ──────────────────────────────────────────────────────────────
@@ -397,6 +408,24 @@ describe('field_in_context_array', () => {
       makeCtx({ data: { billing: 'operator' }, storyboardContext: { supported_billing: ['operator', 'agent'] } })
     );
     assert.strictEqual(result.passed, true);
+  });
+
+  it('canonicalizes agent_url membership', () => {
+    const [result] = runValidations(
+      [
+        {
+          check: 'field_in_context_array',
+          path: 'agent_url',
+          context_key: 'agent_urls',
+          description: 'agent is in captured roster',
+        },
+      ],
+      makeCtx({
+        data: { agent_url: 'https://formats.example/' },
+        storyboardContext: { agent_urls: ['https://formats.example'] },
+      })
+    );
+    assert.strictEqual(result.passed, true, result.error);
   });
 
   it('fails when the response field is outside the captured array', () => {


### PR DESCRIPTION
## Summary

- canonicalize agent URL identity fields across storyboard value, subset, context, and cross-response validators
- preserve byte-significant resource URL and query behavior while failing closed for malformed or non-string identities
- add regression coverage for direct, nested, tolerant, context, and distinct-count paths, plus a patch changeset

## Testing

- `npm run build:lib -- --pretty false`
- `node --test test/lib/storyboard-validations.test.js test/lib/storyboard-parallel-dispatch.test.js test/storyboard-cross-step-validators.test.js` (166 passed)
- `npx eslint src/lib/testing/storyboard/validations.ts` (0 errors; 1 pre-existing warning)
- `npx prettier --check ...`
- pre-push validation

Fixes #2858.
Addresses adcontextprotocol/adcp#7367.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/1447e44e-0a32-4d05-8a96-24dcd5ba9bd6)
