### PR TITLE
fix(media-buy): support legacy catalog purchase handoff

### DIFF
--- a/.changeset/calm-catalogs-continue.md
+++ b/.changeset/calm-catalogs-continue.md
@@ -1,5 +1,5 @@
 ---
-'@adcp/sdk': patch
+'@adcp/sdk': minor
 ---
 
 Project representable compact catalog filters onto established sellers and expose durable purchase continuations for eligible tokenless legacy listings.

--- a/.changeset/calm-catalogs-continue.md
+++ b/.changeset/calm-catalogs-continue.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Project representable compact catalog filters onto established sellers and expose durable purchase continuations for eligible tokenless legacy listings.

--- a/docs/guides/MEDIA-BUY-3.2-COMPATIBILITY.md
+++ b/docs/guides/MEDIA-BUY-3.2-COMPATIBILITY.md
@@ -278,13 +278,24 @@ completion with the retained claim before allowing another lifecycle request. Su
 IDs are retained through `recordSubmittedTask()` so the same ledger can drive
 authoritative completion reconciliation after restart.
 
-### Products-only legacy continuations
+### Tokenless catalog and products-only legacy continuations
 
-An established 2.5, 3.0, or 3.1 seller may answer a brief with products but no
-proposal. Beta.4 projects that honest result as `products_available`; it never
-invents a proposal, terms digest, or feed fence. The returned
-`purchase_continuation` names the exact products and losses that must be
-accepted before the legacy `create_media_buy` mutation:
+An established 2.5, 3.0, or 3.1 seller may return purchasable catalog products
+without a wholesale feed token, or answer a brief with products but no
+proposal. The SDK never invents a proposal, terms digest, or feed fence. When
+`principalScope`, an account, and stable seller-session binding are available,
+`listProducts()` exposes an SDK-local `purchase_continuation` for an eligible
+tokenless catalog. Products must have distinct IDs and distinct selectable
+pricing-option IDs. A real seller feed token keeps the ordinary
+`listProducts()` → `buyProducts()` path and does not produce this handoff.
+
+`requestProposals()` continues to project an honest products-only brief result
+as `products_available`. Both entry points use the same durable continuation,
+account/selection binding, named losses, retry, and recovery machinery. The
+returned `purchase_continuation` names the exact products and losses that must
+be accepted before the legacy `create_media_buy` mutation. Re-observing one
+asynchronous listing completion reuses its issuance, while a separate listing
+invocation receives a fresh continuation even when the catalog is unchanged:
 
 ```ts
 const continuations = createInMemoryLegacyPurchaseContinuationStore();
@@ -296,24 +307,34 @@ const lifecycle = await agent.negotiateMediaBuyLifecycle({
   legacyPurchaseContinuationStore: continuations,
 });
 
-const discovery = await lifecycle.requestProposals({ account, brand, brief });
-if (discovery.status === 'completed' && discovery.data.outcome === 'products_available') {
-  const continuation = discovery.data.purchase_continuation;
-  if (continuation.kind === 'legacy_create') {
-    await lifecycle.continueLegacyPurchase({
-      idempotency_key: crypto.randomUUID(),
-      continuation_token: continuation.continuation_token,
-      account,
-      selected_product_ids: [continuation.product_ids[0]],
-      accepted_losses: continuation.losses,
-      legacy_create_request: exactLegacyCreateRequest,
-    });
-  } else {
-    // listed_purchase carries seller-issued feed/pricing fences and proceeds
-    // through the native buy_products flow.
-  }
+const discovery = await lifecycle.listProducts({
+  account,
+  criteria: { offer_filters: { countries: ['US'] } },
+});
+const continuation = discovery.data?.purchase_continuation;
+if (discovery.status === 'completed' && continuation?.kind === 'legacy_create') {
+  await lifecycle.continueLegacyPurchase({
+    idempotency_key: crypto.randomUUID(),
+    continuation_token: continuation.continuation_token,
+    account,
+    selected_product_ids: [continuation.product_ids[0]],
+    accepted_losses: continuation.losses,
+    legacy_create_request: exactLegacyCreateRequest,
+  });
 }
 ```
+
+This does not relax the native `buy_products` contract. Calling
+`buyProducts()` without a real `feed_version` remains an explicit
+`UNSUPPORTED_FEATURE` before any mutation. Use `continueLegacyPurchase()` only
+after accepting the exact returned loss set. If the application requires an
+enforceable observed catalog/pricing fence, do not accept the continuation;
+the tokenless catalog is read-only for that policy.
+
+On 2.5 the loss set also includes `mutation_idempotency_not_guaranteed`. On 3.0
+and 3.1 it includes that loss whenever the seller does not advertise a usable
+replay TTL. All tokenless catalog continuations include
+`feed_version_not_atomic` and `pricing_version_not_atomic`.
 
 The in-memory store is a single-process reference implementation. Production
 clusters should implement `LegacyPurchaseContinuationStore` with durable,
@@ -482,11 +503,11 @@ ambiguous, disposed, and expired refinements leave the source non-executable.
 
 | Coordinator operation | Compact tool | Established projection | Boundary |
 |---|---|---|---|
-| `listProducts` | `list_products` | `get_products(buying_mode='wholesale')` | Structured compact `criteria` is rejected unless a normative mapping exists. Actual `wholesale_feed_version` is renamed to `feed_version`; no value is invented. The stable response exposes `next_cursor` and `unchanged` in both lanes. The established request includes `pagination` only when the caller supplies a cursor or `max_results`; the SDK does not fabricate a page-size default. v2.5 pagination/field selection, pre-3.1 conditional feed/pricing reads, and response-field names absent from the negotiated enum are typed unsupported. |
+| `listProducts` | `list_products` | `get_products(buying_mode='wholesale')` | Representable `criteria.offer_filters` map field-by-field through the negotiated legacy offer-filter schema; country remains `filters.countries` and is never recast as delivery targeting. Other structured criteria report their exact unsupported field before dispatch. Actual `wholesale_feed_version` is renamed to `feed_version`; no value is invented. An eligible tokenless catalog may expose the SDK-local `purchase_continuation` described above while `raw` remains the canonical SDK source object. The stable response exposes `next_cursor` and `unchanged` in both lanes. The established request includes `pagination` only when the caller supplies a cursor or `max_results`; the SDK does not fabricate a page-size default. v2.5 pagination/field selection, pre-3.1 conditional feed/pricing reads, and response-field names absent from the negotiated enum are typed unsupported. |
 | `requestProposals` | `request_proposals` | `get_products(buying_mode='brief')` | Only offer-filter fields and metric values defined by the negotiated release map field-by-field, plus policy IDs. Compact catalog selection lacks the complete legacy catalog metadata and fails closed. Targeting-overlay requirements are forwarded only to a 3.2 established surface; 3.0/3.1 cannot represent them. Product-ID filters, compact-only offer prerequisites, `ext`, opportunity, and governance context fail preflight. |
 | `refineProposals` | `refine_proposals` | `get_products(buying_mode='refine')` | Ask and product include/omit map for revisions. Finalize maps only when it contains no additional refinement fields. Hard constraints, alternatives, criteria, amendment kinds, and finalize extras fail before dispatch. |
 | `declineProposals` | `decline_proposals` | proposal-scoped legacy omit | Rejected by default because omit is not a terminal decline and cannot carry the required compact reason/detail. Explicit opt-in reports `proposal_decline_not_terminal` and `proposal_decline_reason_not_forwarded`. |
-| `buyProducts` | `buy_products` | `create_media_buy` | Feed/pricing fencing is not atomic. Rejected by default; explicit opt-in names `feed_version_not_atomic` and, when present, `pricing_version_not_atomic`. Shared package fields and nested targeting/reporting enums map against the negotiated schema, including 3.1+ `format_option_refs`; newer targeting, metric, and postal shapes fail closed. v2.5 also rejects non-empty compact targeting and push notification configuration. A direct compact `total_budget` and fields introduced on the 3.2 established surface—including allocation, budget-cap, bidding, governance, opportunity, and newer package controls—map only on a negotiated 3.2 established lane. Compact `catalog_ids` and resolved `pricing` remain typed unsupported. |
+| `buyProducts` | `buy_products` | `create_media_buy` | Feed/pricing fencing is not atomic. Rejected by default; explicit opt-in names `feed_version_not_atomic` and, when present, `pricing_version_not_atomic`. A missing `feed_version` remains unsupported here; tokenless catalogs use the separate SDK-local `continueLegacyPurchase()` handoff. Shared package fields and nested targeting/reporting enums map against the negotiated schema, including 3.1+ `format_option_refs`; newer targeting, metric, and postal shapes fail closed. v2.5 also rejects non-empty compact targeting and push notification configuration. A direct compact `total_budget` and fields introduced on the 3.2 established surface—including allocation, budget-cap, bidding, governance, opportunity, and newer package controls—map only on a negotiated 3.2 established lane. Compact `catalog_ids` and resolved `pricing` remain typed unsupported. |
 | `acceptProposal` | `accept_proposal` | `create_media_buy(proposal_id=...)` | A compact-shaped proposal retains strict digest, immutable-snapshot, account-scope, kind/status, and expiry checks. Caller values cannot override digest-bound budget, budget-cap, timezone, or purchase-order terms. An honest 3.0/3.1 proposal remains executable with its ordinary `proposal_id` semantics only after explicit opt-in to `proposal_terms_digest_not_enforced`, `proposal_terms_digest_unavailable`, and `proposal_snapshot_not_immutable` (plus `proposal_hold_not_verifiable` when it has no expiry). The caller supplies the original brand/flight as `established_fallback`; the SDK does not claim those values came from the seller or synthesize a digest. |
 | `controlMediaBuy` | `control_media_buy` | `update_media_buy` | Account, media-buy ID, and a positive revision are required. Revision and identically shaped fields present in the negotiated established schema map directly; `name` maps on the 3.2 established surface and fails closed on 3.0/3.1, whose update schemas do not define it. v2.5 requires explicit `revision_not_atomic` opt-in and rejects cancellation plus v3-only package controls. Pre-3.2 lanes reject the broader compact optimization-goal union and nested targeting/keyword shapes they cannot represent. Compact `catalog_ids` cannot be cast to established `catalogs` objects, so it fails closed in every established lane. |
 | Readback | shared tools | `get_media_buys`, `get_media_buy_delivery` | Same public calls and canonical creative projection in every lane. Versioned request additions fail closed: webhook-activity and delivery-window/granularity options require 3.1+, while `indicator_types`, demographic breakdowns, and spot breakdowns require 3.2. Native postal reporting shapes require 3.1+. |

--- a/src/lib/core/AgentClient.ts
+++ b/src/lib/core/AgentClient.ts
@@ -430,9 +430,13 @@ export class AgentClient {
   getTaskStatus(
     taskId: string,
     transport?: import('../protocols').TransportOptions,
-    signal?: AbortSignal
+    signal?: AbortSignal,
+    wireOptions?: {
+      wireAdcpVersion?: string;
+      versionEnvelope?: import('../protocols').VersionEnvelopeMode;
+    }
   ): Promise<TaskInfo> {
-    return this.client.getTaskStatus(taskId, transport, signal);
+    return this.client.getTaskStatus(taskId, transport, signal, wireOptions);
   }
 
   /** Register restart/replica callback recovery for a compatibility coordinator. @internal */

--- a/src/lib/core/ConversationTypes.ts
+++ b/src/lib/core/ConversationTypes.ts
@@ -166,6 +166,19 @@ export interface TaskOptions {
    * the underlying official protocol client supports it.
    */
   signal?: AbortSignal;
+  /**
+   * INTERNAL — compatibility-coordinator wire release for this operation.
+   * Request/response validation remains pinned to the owning client.
+   *
+   * @internal
+   */
+  wireAdcpVersion?: string;
+  /**
+   * INTERNAL — compatibility-coordinator version-envelope mode for this operation.
+   *
+   * @internal
+   */
+  versionEnvelope?: import('../protocols').VersionEnvelopeMode;
   /** Maximum clarification rounds before failing */
   maxClarifications?: number;
   /**

--- a/src/lib/core/SingleAgentClient.ts
+++ b/src/lib/core/SingleAgentClient.ts
@@ -2410,7 +2410,11 @@ export class SingleAgentClient {
   async getTaskStatus(
     taskId: string,
     transport?: import('../protocols').TransportOptions,
-    signal?: AbortSignal
+    signal?: AbortSignal,
+    wireOptions?: {
+      wireAdcpVersion?: string;
+      versionEnvelope?: import('../protocols').VersionEnvelopeMode;
+    }
   ): Promise<TaskInfo> {
     // Transport options define the outbound trust boundary. Own them before
     // endpoint discovery yields so caller mutation cannot change the fetch or
@@ -2421,7 +2425,7 @@ export class SingleAgentClient {
       this.normalizedAgent.protocol === 'a2a'
         ? await this.ensureCanonicalUrlResolved(options)
         : await this.ensureEndpointDiscovered(options);
-    return this.executor.getTaskStatus(agent, taskId, transportSnapshot, signal);
+    return this.executor.getTaskStatus(agent, taskId, transportSnapshot, signal, wireOptions);
   }
 
   /** Register durable restart/replica settlement recovery for an SDK coordinator. @internal */

--- a/src/lib/core/TaskExecutor.ts
+++ b/src/lib/core/TaskExecutor.ts
@@ -1231,6 +1231,8 @@ export class TaskExecutor {
     const taskId = getTaskOperationId(options) ?? randomUUID();
     const startTime = Date.now();
     const workingTimeout = this.config.workingTimeout || 120000; // 120s max per PR #78
+    const wireAdcpVersion = options.wireAdcpVersion ?? this.config.wireAdcpVersion;
+    const versionEnvelope = options.versionEnvelope ?? this.config.versionEnvelope;
 
     // Auto-generate idempotency_key for mutating tasks when the caller didn't
     // supply one. The key lives on TaskState so internal retries reuse it —
@@ -1360,8 +1362,8 @@ export class TaskExecutor {
               operationId: taskId,
               serverVersion: effectiveServerVersion,
               adcpVersion: this.config.adcpVersion,
-              wireAdcpVersion: this.config.wireAdcpVersion,
-              versionEnvelope: this.config.versionEnvelope,
+              wireAdcpVersion,
+              versionEnvelope,
             }).args
           : params;
         if (await governanceMiddleware.shouldCheck(taskName, governableParams, targetCapabilities)) {
@@ -1435,8 +1437,8 @@ export class TaskExecutor {
         operationId: taskId,
         serverVersion: effectiveServerVersion,
         adcpVersion: this.config.adcpVersion,
-        wireAdcpVersion: this.config.wireAdcpVersion,
-        versionEnvelope: this.config.versionEnvelope,
+        wireAdcpVersion,
+        versionEnvelope,
       });
       let webhookRegistrationPersisted = false;
       if (webhookUrl && this.config.onWebhookRegistration) {
@@ -1541,8 +1543,8 @@ export class TaskExecutor {
         serverVersion: effectiveServerVersion,
         session: { contextId: options.contextId, taskId: options.taskId },
         adcpVersion: this.config.adcpVersion,
-        ...(this.config.wireAdcpVersion !== undefined && { wireAdcpVersion: this.config.wireAdcpVersion }),
-        ...(this.config.versionEnvelope !== undefined && { versionEnvelope: this.config.versionEnvelope }),
+        ...(wireAdcpVersion !== undefined && { wireAdcpVersion }),
+        ...(versionEnvelope !== undefined && { versionEnvelope }),
         transport: options.transport ?? this.config.transport,
         // Once dispatch begins for a live committed claim, post-call handling
         // owns durable settlement even if the caller's deadline fires later.
@@ -2313,7 +2315,9 @@ export class TaskExecutor {
       pollingTransport,
       metadata,
       deferTerminalTaskStatus,
-      serverVersion
+      serverVersion,
+      options.wireAdcpVersion ?? this.config.wireAdcpVersion,
+      options.versionEnvelope ?? this.config.versionEnvelope
     );
 
     this.compactIntermediateTaskState(taskId, 'submitted');
@@ -2339,7 +2343,9 @@ export class TaskExecutor {
     pollingTransport: import('../protocols').TransportOptions | undefined,
     metadata: TaskResultMetadata,
     deferTerminalTaskStatus: boolean,
-    serverVersion: 'v2' | 'v3'
+    serverVersion: 'v2' | 'v3',
+    wireAdcpVersion?: string,
+    versionEnvelope?: import('../protocols').VersionEnvelopeMode
   ): SubmittedContinuation<T> {
     return {
       taskId: serverTaskId,
@@ -2353,7 +2359,9 @@ export class TaskExecutor {
             transportSnapshot,
             undefined,
             taskName,
-            serverVersion
+            serverVersion,
+            wireAdcpVersion,
+            versionEnvelope
           )
         ).task;
         if (!deferTerminalTaskStatus && ['completed', 'failed', 'rejected', 'canceled'].includes(task.status)) {
@@ -2372,7 +2380,9 @@ export class TaskExecutor {
           metadata.a2aTaskId,
           taskName,
           taskId,
-          serverVersion
+          serverVersion,
+          wireAdcpVersion,
+          versionEnvelope
         );
         // `pollTaskCompletion` also returns nonresumable paused
         // input-required/auth-required states. Preserve that status so callers
@@ -2794,6 +2804,8 @@ export class TaskExecutor {
           ...(serverContextId !== undefined && { contextId: serverContextId }),
           a2aTaskId,
           serverVersion,
+          ...(options.wireAdcpVersion !== undefined && { wireAdcpVersion: options.wireAdcpVersion }),
+          ...(options.versionEnvelope !== undefined && { versionEnvelope: options.versionEnvelope }),
           serverVersionSynthetic: this.activeTasks.get(taskId)?.serverVersionSynthetic,
           agentId: agent.id,
           taskName,
@@ -2936,6 +2948,8 @@ export class TaskExecutor {
           ...(serverContextId !== undefined && { contextId: serverContextId }),
           a2aTaskId,
           serverVersion,
+          ...(options.wireAdcpVersion !== undefined && { wireAdcpVersion: options.wireAdcpVersion }),
+          ...(options.versionEnvelope !== undefined && { versionEnvelope: options.versionEnvelope }),
           serverVersionSynthetic: this.activeTasks.get(taskId)?.serverVersionSynthetic,
           agentId: agent.id,
           taskName,
@@ -3115,7 +3129,9 @@ export class TaskExecutor {
     transport?: import('../protocols').TransportOptions,
     signal?: AbortSignal,
     expectedTaskType?: string,
-    serverVersion?: 'v2' | 'v3'
+    serverVersion?: 'v2' | 'v3',
+    wireAdcpVersion?: string,
+    versionEnvelope?: import('../protocols').VersionEnvelopeMode
   ): Promise<TaskStatusPollResult> {
     // AdCP `tasks/get` is the cross-protocol work-status interface
     // (`schemas/cache/<v>/bundled/core/tasks-get-{request,response}.json`).
@@ -3151,8 +3167,12 @@ export class TaskExecutor {
       {
         serverVersion: serverVersion ?? this.lastKnownServerVersion,
         adcpVersion: this.config.adcpVersion,
-        ...(this.config.wireAdcpVersion !== undefined && { wireAdcpVersion: this.config.wireAdcpVersion }),
-        ...(this.config.versionEnvelope !== undefined && { versionEnvelope: this.config.versionEnvelope }),
+        ...((wireAdcpVersion ?? this.config.wireAdcpVersion) !== undefined && {
+          wireAdcpVersion: wireAdcpVersion ?? this.config.wireAdcpVersion,
+        }),
+        ...((versionEnvelope ?? this.config.versionEnvelope) !== undefined && {
+          versionEnvelope: versionEnvelope ?? this.config.versionEnvelope,
+        }),
         transport: transport ?? this.config.transport,
         signal,
         onTransportActivity: this.config.onTransportActivity,
@@ -3190,10 +3210,25 @@ export class TaskExecutor {
     agent: AgentConfig,
     taskId: string,
     transport?: import('../protocols').TransportOptions,
-    signal?: AbortSignal
+    signal?: AbortSignal,
+    wireOptions?: {
+      wireAdcpVersion?: string;
+      versionEnvelope?: import('../protocols').VersionEnvelopeMode;
+    }
   ): Promise<TaskInfo> {
     const transportSnapshot = snapshotTransportOptions(transport ?? this.config.transport);
-    return (await this.getTaskStatusWithRawResponse(agent, taskId, transportSnapshot, signal)).task;
+    return (
+      await this.getTaskStatusWithRawResponse(
+        agent,
+        taskId,
+        transportSnapshot,
+        signal,
+        undefined,
+        undefined,
+        wireOptions?.wireAdcpVersion,
+        wireOptions?.versionEnvelope
+      )
+    ).task;
   }
 
   async pollTaskCompletion<T>(
@@ -3205,7 +3240,9 @@ export class TaskExecutor {
     a2aCancellationTaskId?: string,
     expectedTaskType?: string,
     metadataTaskId = taskId,
-    serverVersion?: 'v2' | 'v3'
+    serverVersion?: 'v2' | 'v3',
+    wireAdcpVersion?: string,
+    versionEnvelope?: import('../protocols').VersionEnvelopeMode
   ): Promise<TaskResult<T>> {
     // Transport policy is a request trust boundary. Own one shallow snapshot
     // for the entire polling lifetime so caller mutation cannot substitute a
@@ -3292,7 +3329,9 @@ export class TaskExecutor {
           transportSnapshot,
           signal,
           expectedTaskType,
-          serverVersion
+          serverVersion,
+          wireAdcpVersion,
+          versionEnvelope
         );
         status = pollResult.task;
         rawResponse = pollResult.rawResponse;
@@ -3977,7 +4016,10 @@ export class TaskExecutor {
           task_id: state.settlementPendingTaskId,
         },
         state.messages,
-        {},
+        {
+          ...(state.wireAdcpVersion !== undefined && { wireAdcpVersion: state.wireAdcpVersion }),
+          ...(state.versionEnvelope !== undefined && { versionEnvelope: state.versionEnvelope }),
+        },
         [],
         Date.now(),
         true,
@@ -4223,7 +4265,10 @@ export class TaskExecutor {
         inputSnapshot,
         resumedMessages,
         undefined, // No handler for deferred tasks - input was provided by human
-        {},
+        {
+          ...(state.wireAdcpVersion !== undefined && { wireAdcpVersion: state.wireAdcpVersion }),
+          ...(state.versionEnvelope !== undefined && { versionEnvelope: state.versionEnvelope }),
+        },
         [],
         Date.now(),
         !publishTerminalTaskStatus || requiresSettlement,
@@ -4266,6 +4311,8 @@ export class TaskExecutor {
               : {}),
           a2aTaskId: nextA2ATaskId,
           serverVersion: state.serverVersion,
+          ...(state.wireAdcpVersion !== undefined && { wireAdcpVersion: state.wireAdcpVersion }),
+          ...(state.versionEnvelope !== undefined && { versionEnvelope: state.versionEnvelope }),
           ...(state.serverVersionSynthetic !== undefined && {
             serverVersionSynthetic: state.serverVersionSynthetic,
           }),
@@ -5382,8 +5429,12 @@ export class TaskExecutor {
         debugLogs,
         serverVersion,
         adcpVersion: this.config.adcpVersion,
-        ...(this.config.wireAdcpVersion !== undefined && { wireAdcpVersion: this.config.wireAdcpVersion }),
-        ...(this.config.versionEnvelope !== undefined && { versionEnvelope: this.config.versionEnvelope }),
+        ...((options.wireAdcpVersion ?? this.config.wireAdcpVersion) !== undefined && {
+          wireAdcpVersion: options.wireAdcpVersion ?? this.config.wireAdcpVersion,
+        }),
+        ...((options.versionEnvelope ?? this.config.versionEnvelope) !== undefined && {
+          versionEnvelope: options.versionEnvelope ?? this.config.versionEnvelope,
+        }),
         transport: options.transport ?? this.config.transport,
         session: { contextId, taskId: a2aTaskId },
         signal: options.signal,

--- a/src/lib/media-buy/compatibility.ts
+++ b/src/lib/media-buy/compatibility.ts
@@ -73,6 +73,7 @@ import {
 } from '../negotiation/verification';
 import { isAdcpOperationSuccess, isTerminalAdcpError } from '../utils/response-unwrapper';
 import { ConfigurationError } from '../errors';
+import { toReleasePrecisionVersion } from '../version';
 import { createAbortError, isAbortOrTimeoutError, MAX_TIMER_DELAY_MS, withAbortSignal } from '../protocols/abort';
 import { formatIssues, validateResponse } from '../validation/schema-validator';
 import { validateRequest } from '../validation/schema-validator';
@@ -585,6 +586,12 @@ export interface CompatibleProductsResponse {
   cache_scope?: 'public' | 'account';
   errors?: CompatibleErrors;
   context?: CompatibleContext;
+  /**
+   * SDK-local handoff for an eligible tokenless established catalog. Present
+   * only when the caller configured durable continuation bindings and the
+   * observed products contain selectable pricing options.
+   */
+  purchase_continuation?: RequestProposalsPurchaseContinuation;
   /** SDK-returned source object, retained for fields outside the stable compatibility view. */
   raw: ListProductsResponse | EstablishedProductsWireResponse;
 }
@@ -712,7 +719,7 @@ export interface MediaBuyLifecycleCoordinatorOptions {
    * 2.5, 3.0, or 3.1 sellers that provide no server context ID.
    */
   legacyPurchaseSellerSessionScope?: string;
-  /** Durable storage for products-only legacy purchase continuations. */
+  /** Durable storage for tokenless-catalog and products-only legacy purchase continuations. */
   legacyPurchaseContinuationStore?: LegacyPurchaseContinuationStore;
   /**
    * Durable storage for established 3.0/3.1 proposal evidence and mutation
@@ -1057,7 +1064,7 @@ function negotiatedVersion(capabilities: AdcpCapabilities, clientVersion: string
 }
 
 const MAX_PROPOSAL_TRAVERSAL_NODES = 4096;
-const LEGACY_PROPOSAL_RAW = Symbol('legacyProposalRaw');
+const LEGACY_DISCOVERY_RAW = Symbol('legacyDiscoveryRaw');
 const PROJECTED_RESPONSE_RAW = Symbol('projectedResponseRaw');
 const COMPACT_REQUEST_PROPOSALS_RESPONSE_FIELDS = new Set([
   'adcp_version',
@@ -1091,6 +1098,9 @@ const COMPACT_DECLINE_PROPOSALS_RESPONSE_FIELDS = new Set([
 
 function projectProducts(data: unknown, lifecycle: MediaBuyLifecycle): CompatibleProductsResponse {
   const source = compactWirePayload(data);
+  const hasSdkPurchaseContinuation =
+    (source as Record<PropertyKey, unknown>)[LEGACY_DISCOVERY_RAW] !== undefined &&
+    source.purchase_continuation !== undefined;
   const feedVersion = optionalString(lifecycle === 'compact' ? source.feed_version : source.wholesale_feed_version);
   const pricingVersion = optionalString(source.pricing_version);
   const nextCursor = optionalString(lifecycle === 'compact' ? source.next_cursor : record(source.pagination).cursor);
@@ -1107,7 +1117,12 @@ function projectProducts(data: unknown, lifecycle: MediaBuyLifecycle): Compatibl
     }),
     ...(Array.isArray(source.errors) && { errors: source.errors as CompatibleErrors }),
     ...(source.context !== undefined && { context: source.context as CompatibleContext }),
-    raw: source as ListProductsResponse | EstablishedProductsWireResponse,
+    ...(hasSdkPurchaseContinuation && {
+      purchase_continuation: source.purchase_continuation as RequestProposalsPurchaseContinuation,
+    }),
+    raw: ((source as Record<PropertyKey, unknown>)[LEGACY_DISCOVERY_RAW] ?? source) as
+      | ListProductsResponse
+      | EstablishedProductsWireResponse,
   };
 }
 
@@ -1234,7 +1249,7 @@ function projectRequestProposals(
     ...(source.purchase_continuation !== undefined && {
       purchase_continuation: source.purchase_continuation as RequestProposalsPurchaseContinuation,
     }),
-    raw: ((source as Record<PropertyKey, unknown>)[LEGACY_PROPOSAL_RAW] ?? source) as
+    raw: ((source as Record<PropertyKey, unknown>)[LEGACY_DISCOVERY_RAW] ?? source) as
       | RequestProposalsResponse
       | EstablishedProductsWireResponse,
   } as CompatibleRequestProposalsResponse;
@@ -1863,7 +1878,12 @@ export class MediaBuyLifecycleCoordinator {
       }
     }
     const expectedTaskType = recovered.request.claim.operation === 'accept' ? 'create_media_buy' : 'get_products';
-    const task = await this.agent.getTaskStatus(input.sellerTaskId, transport, signal);
+    const task = await this.agent.getTaskStatus(
+      input.sellerTaskId,
+      transport,
+      signal,
+      this.legacyWireTaskOptions(this.establishedProposalScope!.sourceAdcpVersion)
+    );
     if (task.taskId !== input.sellerTaskId || task.taskType !== expectedTaskType) {
       await this.requireEstablishedTransition(() =>
         this.establishedProposalStore!.markAmbiguous(recovered.request, 'commit-uncertain')
@@ -2721,6 +2741,28 @@ export class MediaBuyLifecycleCoordinator {
     );
   }
 
+  private projectLegacyOfferFilters(operation: string, value: unknown): Record<string, unknown> {
+    const offerFilters = record(value);
+    this.assertLegacyOfferFilterShapes(operation, offerFilters);
+    this.assertLegacyMetrics(operation, offerFilters.required_metrics, 'criteria.offer_filters.required_metrics');
+    const legacyOfferFilterFields =
+      compareRelease(this.negotiated_version, '3.1') >= 0
+        ? V31_OFFER_FILTER_FIELDS
+        : compareRelease(this.negotiated_version, '3.0') >= 0
+          ? V30_OFFER_FILTER_FIELDS
+          : V25_OFFER_FILTER_FIELDS;
+    const unsupportedFields = Object.keys(offerFilters).filter(field => !legacyOfferFilterFields.has(field));
+    if (unsupportedFields.length > 0) {
+      const paths = unsupportedFields.map(field => `criteria.offer_filters.${field}`);
+      throw this.unsupported(
+        operation,
+        paths.join(','),
+        `${operation} fields ${paths.join(', ')} have no declared compatibility projection.`
+      );
+    }
+    return Object.fromEntries(Object.entries(offerFilters).filter(([key]) => legacyOfferFilterFields.has(key)));
+  }
+
   private assertLegacyReportingWebhook(operation: string, value: unknown, path = 'reporting_webhook'): void {
     if (value === undefined || isCompactRelease(this.negotiated_version)) return;
     this.assertLegacyMetrics(operation, record(value).requested_metrics, `${path}.requested_metrics`);
@@ -2775,6 +2817,38 @@ export class MediaBuyLifecycleCoordinator {
     ];
   }
 
+  private legacyWireTaskOptions(
+    sourceVersion: string = this.negotiated_version
+  ): Pick<TaskOptions, 'wireAdcpVersion' | 'versionEnvelope'> {
+    return {
+      wireAdcpVersion: sourceVersion,
+      versionEnvelope: compareRelease(sourceVersion, '3.1') < 0 ? 'major-only' : 'auto',
+    };
+  }
+
+  private assertRequestedLegacyVersion(operation: string, input: Record<string, unknown>): void {
+    const negotiated = parseRelease(this.negotiated_version);
+    if (!negotiated) return;
+    if (input.adcp_major_version !== undefined && input.adcp_major_version !== negotiated.major) {
+      throw this.unsupported(
+        operation,
+        'adcp_major_version',
+        `${operation} requested adcp_major_version ${String(input.adcp_major_version)}, but the negotiated established lane is ${this.negotiated_version}. No request was sent.`
+      );
+    }
+    const expectedRelease = toReleasePrecisionVersion(this.negotiated_version);
+    if (
+      input.adcp_version !== undefined &&
+      (compareRelease(this.negotiated_version, '3.1') < 0 || input.adcp_version !== expectedRelease)
+    ) {
+      throw this.unsupported(
+        operation,
+        'adcp_version',
+        `${operation} requested adcp_version ${String(input.adcp_version)}, but the negotiated established lane is ${this.negotiated_version}. No request was sent.`
+      );
+    }
+  }
+
   private legacyPurchaseBinding(accountScope: string): LegacyPurchaseBinding {
     const agent = this.agent.getAgent();
     const contextId = this.agent.getContextId();
@@ -2782,7 +2856,7 @@ export class MediaBuyLifecycleCoordinator {
       let sessionScope = this.configuredLegacyPurchaseSellerSessionScope ?? contextId;
       if (sessionScope === undefined) {
         throw new ConfigurationError(
-          'Products-only legacy purchase continuations require legacyPurchaseSellerSessionScope in negotiateMediaBuyLifecycle() when the seller provides no context ID.'
+          'Legacy product-discovery purchase continuations require legacyPurchaseSellerSessionScope in negotiateMediaBuyLifecycle() when the seller provides no context ID.'
         );
       }
       this.resolvedLegacyPurchaseSellerSessionScope = sessionScope;
@@ -2800,7 +2874,9 @@ export class MediaBuyLifecycleCoordinator {
   private async projectLegacyProductsAvailable(
     data: unknown,
     accountScope: string | undefined,
-    discoveryRequestFingerprint: string
+    discoveryRequestFingerprint: string,
+    sourceOperation: 'proposal' | 'listing' = 'proposal',
+    issuanceDiscriminator?: string
   ): Promise<unknown> {
     const source = compactWirePayload(data);
     if ((proposalRows(source)?.length ?? 0) > 0 || !Array.isArray(source.products) || source.products.length === 0) {
@@ -2815,28 +2891,40 @@ export class MediaBuyLifecycleCoordinator {
       (negotiatedRelease.major > 3 || (negotiatedRelease.major === 3 && negotiatedRelease.minor >= 2))
     )
       return data;
+    // A real seller feed token keeps the catalog on the ordinary listProducts
+    // -> buyProducts path. The SDK-local continuation exists only to bridge
+    // unchanged established catalogs that cannot provide that compact fence.
+    if (sourceOperation === 'listing' && optionalString(source.wholesale_feed_version)) return data;
     if (!this.principalScope) {
       return data;
     }
     if (!accountScope) {
       return data;
     }
+    if (
+      sourceOperation === 'listing' &&
+      this.resolvedLegacyPurchaseSellerSessionScope === undefined &&
+      this.configuredLegacyPurchaseSellerSessionScope === undefined &&
+      this.agent.getContextId() === undefined
+    ) {
+      return data;
+    }
     if (containsCredentialShapedKey(source) || containsPresignedUrl(source)) {
       throw new LegacyPurchaseContinuationError(
         'request_invalid',
-        'The legacy products-only response contains credential-shaped material and cannot be persisted.'
+        'The legacy product-discovery response contains credential-shaped material and cannot be persisted.'
       );
     }
     const observedBytes = Buffer.byteLength(canonicalize(source), 'utf8');
     if (observedBytes > 256 * 1024) {
       throw new LegacyPurchaseContinuationError(
         'store_error',
-        'The legacy products-only response exceeds the 256 KiB continuation snapshot limit.'
+        'The legacy product-discovery response exceeds the 256 KiB continuation snapshot limit.'
       );
     }
     const productIds = source.products.map(product => optionalString(record(product).product_id));
     if (productIds.some(productId => productId === undefined) || new Set(productIds).size !== productIds.length) {
-      throw new TypeError('The legacy products-only response did not contain distinct non-empty product IDs.');
+      throw new TypeError('The legacy product-discovery response did not contain distinct non-empty product IDs.');
     }
     const hasBoundPricingOptions = source.products.every(product => {
       const pricingOptionIds = array(record(product).pricing_options).map(option =>
@@ -2857,6 +2945,7 @@ export class MediaBuyLifecycleCoordinator {
       ...binding,
       discoveryRequestFingerprint,
       observedResponse: source,
+      ...(issuanceDiscriminator !== undefined && { issuanceDiscriminator }),
     });
     let storedRecord: LegacyPurchaseContinuationRecord | undefined;
     for (let attempt = 0; attempt < 4 && !storedRecord; attempt += 1) {
@@ -2900,33 +2989,48 @@ export class MediaBuyLifecycleCoordinator {
         true
       );
     }
-    const projected: Record<PropertyKey, unknown> = {
-      outcome: 'products_available',
-      products: source.products,
-      ...(Array.isArray(source.incomplete) && { incomplete: source.incomplete }),
-      ...(Array.isArray(source.errors) && { errors: source.errors }),
-      ...(source.context !== undefined && { context: source.context }),
-      purchase_continuation: {
-        kind: 'legacy_create',
-        continuation_token: storedRecord.token,
-        continuation_expires_at: storedRecord.expiresAt,
-        source_adcp_version: storedRecord.sourceAdcpVersion,
-        product_ids: storedRecord.productIds,
-        losses: storedRecord.losses,
-        requires_explicit_acceptance: true,
-      },
+    const purchaseContinuation = {
+      kind: 'legacy_create' as const,
+      continuation_token: storedRecord.token,
+      continuation_expires_at: storedRecord.expiresAt,
+      source_adcp_version: storedRecord.sourceAdcpVersion,
+      product_ids: storedRecord.productIds,
+      losses: storedRecord.losses,
+      requires_explicit_acceptance: true as const,
     };
-    Object.defineProperty(projected, LEGACY_PROPOSAL_RAW, { value: source, enumerable: false });
+    const projected: Record<PropertyKey, unknown> =
+      sourceOperation === 'listing'
+        ? {
+            ...source,
+            purchase_continuation: purchaseContinuation,
+          }
+        : {
+            outcome: 'products_available',
+            products: source.products,
+            ...(Array.isArray(source.incomplete) && { incomplete: source.incomplete }),
+            ...(Array.isArray(source.errors) && { errors: source.errors }),
+            ...(source.context !== undefined && { context: source.context }),
+            purchase_continuation: purchaseContinuation,
+          };
+    Object.defineProperty(projected, LEGACY_DISCOVERY_RAW, { value: source, enumerable: false });
     return projected;
   }
 
-  private async prepareLegacyProposalResult<T>(
+  private async prepareLegacyPurchaseContinuationResult<T>(
     result: TaskResult<T>,
     accountScope: string | undefined,
-    discoveryRequestFingerprint: string
+    discoveryRequestFingerprint: string,
+    sourceOperation: 'proposal' | 'listing' = 'proposal',
+    issuanceDiscriminator?: string
   ): Promise<TaskResult<T>> {
     const prepare = (value: unknown): Promise<unknown> =>
-      this.projectLegacyProductsAvailable(value, accountScope, discoveryRequestFingerprint);
+      this.projectLegacyProductsAvailable(
+        value,
+        accountScope,
+        discoveryRequestFingerprint,
+        sourceOperation,
+        issuanceDiscriminator
+      );
     if (
       result.success &&
       result.status === 'completed' &&
@@ -2950,10 +3054,12 @@ export class MediaBuyLifecycleCoordinator {
           return task;
         },
         waitForCompletion: async (pollInterval?: number, signal?: AbortSignal) =>
-          this.prepareLegacyProposalResult(
+          this.prepareLegacyPurchaseContinuationResult(
             await submitted.waitForCompletion(pollInterval, signal),
             accountScope,
-            discoveryRequestFingerprint
+            discoveryRequestFingerprint,
+            sourceOperation,
+            issuanceDiscriminator
           ),
       };
     }
@@ -2962,7 +3068,13 @@ export class MediaBuyLifecycleCoordinator {
       (result as { deferred?: unknown }).deferred = {
         ...deferred,
         resume: async (input: unknown) =>
-          this.prepareLegacyProposalResult(await deferred.resume(input), accountScope, discoveryRequestFingerprint),
+          this.prepareLegacyPurchaseContinuationResult(
+            await deferred.resume(input),
+            accountScope,
+            discoveryRequestFingerprint,
+            sourceOperation,
+            issuanceDiscriminator
+          ),
       };
     }
     return result;
@@ -5180,11 +5292,27 @@ export class MediaBuyLifecycleCoordinator {
       );
     }
     this.assertLegacyProductFields('listProducts', input.fields);
-    if (input.criteria !== undefined || input.governance_context !== undefined || input.context_id !== undefined) {
+    const criteria = record(input.criteria);
+    this.assertRequestedLegacyVersion('listProducts', input);
+    const unsupportedCriteria = Object.keys(criteria).filter(field => field !== 'offer_filters');
+    if (unsupportedCriteria.length > 0) {
       throw this.unsupported(
         'listProducts',
-        'criteria/governance_context/context_id',
-        'Compact list_products criteria, governance context, and explicit context IDs have no general lossless established mapping.'
+        unsupportedCriteria.map(field => `criteria.${field}`).join(','),
+        `Compact list_products criteria fields ${unsupportedCriteria.join(
+          ', '
+        )} have no declared lossless established mapping.`
+      );
+    }
+    if (input.governance_context !== undefined || input.context_id !== undefined) {
+      const unsupportedContext = [
+        ...(input.governance_context !== undefined ? ['governance_context'] : []),
+        ...(input.context_id !== undefined ? ['context_id'] : []),
+      ];
+      throw this.unsupported(
+        'listProducts',
+        unsupportedContext.join(','),
+        `Compact list_products fields ${unsupportedContext.join(', ')} have no lossless established mapping.`
       );
     }
     if (input.push_notification_config !== undefined && compareRelease(this.negotiated_version, '3.1') < 0) {
@@ -5194,11 +5322,13 @@ export class MediaBuyLifecycleCoordinator {
         `The negotiated ${this.negotiated_version} get_products request cannot carry push_notification_config.`
       );
     }
+    const filters = this.projectLegacyOfferFilters('listProducts', criteria.offer_filters);
     const request: CanonicalGetProductsRequest = {
       buying_mode: 'wholesale',
       ...(input.idempotency_key !== undefined && { idempotency_key: input.idempotency_key as string }),
       ...(input.account !== undefined && { account: input.account as CanonicalGetProductsRequest['account'] }),
       ...(input.brand !== undefined && { brand: input.brand as CanonicalGetProductsRequest['brand'] }),
+      ...(Object.keys(filters).length > 0 && { filters: filters as CanonicalGetProductsRequest['filters'] }),
       ...(Array.isArray(input.fields) && { fields: input.fields as CanonicalGetProductsRequest['fields'] }),
       ...(compareRelease(this.negotiated_version, '3.0') >= 0 &&
         (input.cursor !== undefined || input.max_results !== undefined) && {
@@ -5216,7 +5346,19 @@ export class MediaBuyLifecycleCoordinator {
       }),
     };
     this.assertValidCompactRequest('list_products', params, lifecycle);
-    const result = await this.agent.getProducts(request, inputHandler, options);
+    const accountScope = this.accountScope(input.account);
+    // The discriminator belongs to one list invocation, not to the catalog
+    // contents. Async observations from this call reuse it, while a later
+    // identical listing receives a fresh purchasable continuation.
+    const issuanceDiscriminator = randomBytes(16).toString('base64url');
+    const legacyOptions = { ...options, ...this.legacyWireTaskOptions() };
+    const result = await this.prepareLegacyPurchaseContinuationResult(
+      await this.agent.getProducts(request, inputHandler, legacyOptions),
+      accountScope,
+      requestFingerprint(request),
+      'listing',
+      issuanceDiscriminator
+    );
     return this.adaptProjectedResult(result, this.makeReport(lifecycle, ['get_products'], []), data =>
       projectProducts(data, lifecycle)
     );
@@ -5251,6 +5393,7 @@ export class MediaBuyLifecycleCoordinator {
       );
     }
 
+    this.assertRequestedLegacyVersion('requestProposals', input);
     this.assertOnlyFields('requestProposals', input, REQUEST_PROPOSALS_FIELDS);
     const criteria = record(input.criteria);
     this.assertOnlyFields(
@@ -5293,13 +5436,7 @@ export class MediaBuyLifecycleCoordinator {
         `The negotiated ${this.negotiated_version} get_products request cannot carry push_notification_config.`
       );
     }
-    const offerFilters = record(criteria.offer_filters);
-    this.assertLegacyOfferFilterShapes('requestProposals', offerFilters);
-    this.assertLegacyMetrics(
-      'requestProposals',
-      offerFilters.required_metrics,
-      'criteria.offer_filters.required_metrics'
-    );
+    const filters = this.projectLegacyOfferFilters('requestProposals', criteria.offer_filters);
     if (criteria.product_ids !== undefined) {
       throw this.unsupported(
         'requestProposals',
@@ -5314,16 +5451,6 @@ export class MediaBuyLifecycleCoordinator {
         'Compact catalog selection omits the full legacy catalog metadata required by get_products. No request was sent.'
       );
     }
-    const legacyOfferFilterFields =
-      compareRelease(this.negotiated_version, '3.1') >= 0
-        ? V31_OFFER_FILTER_FIELDS
-        : compareRelease(this.negotiated_version, '3.0') >= 0
-          ? V30_OFFER_FILTER_FIELDS
-          : V25_OFFER_FILTER_FIELDS;
-    this.assertOnlyFields('requestProposals.criteria.offer_filters', offerFilters, legacyOfferFilterFields);
-    const filters = Object.fromEntries(
-      Object.entries(offerFilters).filter(([key]) => legacyOfferFilterFields.has(key))
-    );
     const request: CanonicalGetProductsRequest = {
       buying_mode: 'brief',
       brief: input.brief as string,
@@ -5355,9 +5482,13 @@ export class MediaBuyLifecycleCoordinator {
     this.assertValidCompactRequest('request_proposals', params, lifecycle, true);
     return this.captureProposalDispatch(
       accountScope,
-      () => this.agent.getProducts(request, inputHandler, options),
+      () => this.agent.getProducts(request, inputHandler, { ...options, ...this.legacyWireTaskOptions() }),
       async result => {
-        const prepared = await this.prepareLegacyProposalResult(result, accountScope, requestFingerprint(request));
+        const prepared = await this.prepareLegacyPurchaseContinuationResult(
+          result,
+          accountScope,
+          requestFingerprint(request)
+        );
         return this.adaptProjectedResult(
           prepared,
           this.makeReport(lifecycle, ['get_products'], []),
@@ -5371,8 +5502,9 @@ export class MediaBuyLifecycleCoordinator {
   }
 
   /**
-   * Redeem a beta.4 `legacy_create` continuation. This is an SDK-local
-   * coordinator operation; the input object itself is never sent on the wire.
+   * Redeem an SDK-local `legacy_create` continuation issued from an eligible
+   * tokenless catalog or products-only proposal result. The input object
+   * itself is never sent on the wire.
    */
   async continueLegacyPurchase(
     input: CompatibilityPurchaseCoordinatorInput,
@@ -5760,7 +5892,8 @@ export class MediaBuyLifecycleCoordinator {
                 context.publishSettledTaskStatus,
                 context.registerExternalTaskSettlement,
                 optionsSnapshot?.transport,
-                persistedOperation.deferredTaskToken
+                persistedOperation.deferredTaskToken,
+                this.legacyWireTaskOptions(continuation.sourceAdcpVersion)
               ),
             };
           }
@@ -5785,7 +5918,8 @@ export class MediaBuyLifecycleCoordinator {
             task = await this.agent.getTaskStatus(
               pending.serverTaskId,
               optionsSnapshot?.transport,
-              optionsSnapshot?.signal
+              optionsSnapshot?.signal,
+              this.legacyWireTaskOptions(continuation.sourceAdcpVersion)
             );
           } catch (error) {
             if (isAbortOrTimeoutError(error)) throw error;
@@ -5905,7 +6039,8 @@ export class MediaBuyLifecycleCoordinator {
             task = await this.agent.getTaskStatus(
               persistedOperation.sellerTaskId,
               optionsSnapshot?.transport,
-              optionsSnapshot?.signal
+              optionsSnapshot?.signal,
+              this.legacyWireTaskOptions(continuation.sourceAdcpVersion)
             );
           } catch (error) {
             if (isAbortOrTimeoutError(error)) throw error;
@@ -5945,7 +6080,16 @@ export class MediaBuyLifecycleCoordinator {
             }
             return {
               action: 'return',
-              result: await this.trackLegacyPurchaseResult(token, persistedClaim, resumed),
+              result: await this.trackLegacyPurchaseResult(
+                token,
+                persistedClaim,
+                resumed,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                this.legacyWireTaskOptions(continuation.sourceAdcpVersion)
+              ),
             };
           }
         }
@@ -5990,7 +6134,16 @@ export class MediaBuyLifecycleCoordinator {
               // it through the normal terminal path so callback-capable
               // operations fence completion-handler publication before the
               // completed result can be replayed or raced by a webhook.
-              result: await this.trackLegacyPurchaseResult(token, persistedClaim, terminal),
+              result: await this.trackLegacyPurchaseResult(
+                token,
+                persistedClaim,
+                terminal,
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                this.legacyWireTaskOptions(continuation.sourceAdcpVersion)
+              ),
             };
           }
         }
@@ -6013,7 +6166,9 @@ export class MediaBuyLifecycleCoordinator {
             result,
             context.publishSettledTaskStatus,
             context.registerExternalTaskSettlement,
-            optionsSnapshot?.transport
+            optionsSnapshot?.transport,
+            undefined,
+            this.legacyWireTaskOptions(continuation.sourceAdcpVersion)
           );
           settledInsideExecutor = true;
           return settled;
@@ -6049,13 +6204,23 @@ export class MediaBuyLifecycleCoordinator {
             continuation.operation.state !== 'available',
           skipAccountValidation: true,
           skipIdempotencyAutoInject: true,
+          ...this.legacyWireTaskOptions(continuation.sourceAdcpVersion),
         }
       );
       if (!claimedForDispatch) return result;
       if (settledInsideExecutor) return result;
       // Test doubles and older internal façades may invoke the pre-dispatch
       // hook without honoring its executor-owned settlement callbacks.
-      return this.trackLegacyPurchaseResult(token, claim, result, undefined, undefined, optionsSnapshot?.transport);
+      return this.trackLegacyPurchaseResult(
+        token,
+        claim,
+        result,
+        undefined,
+        undefined,
+        optionsSnapshot?.transport,
+        undefined,
+        this.legacyWireTaskOptions(continuation.sourceAdcpVersion)
+      );
     } catch (error) {
       if (!claimedForDispatch) throw error;
       if (settledInsideExecutor) throw error;
@@ -7387,7 +7552,8 @@ export class MediaBuyLifecycleCoordinator {
     publishSettledTaskStatus?: BeforeProtocolDispatchContext['publishSettledTaskStatus'],
     registerExternalTaskSettlement?: BeforeProtocolDispatchContext['registerExternalTaskSettlement'],
     settlementTransport?: TaskOptions['transport'],
-    expectedDeferredTaskToken?: string
+    expectedDeferredTaskToken?: string,
+    wireOptions?: Pick<TaskOptions, 'wireAdcpVersion' | 'versionEnvelope'>
   ): Promise<TaskResult<CreateMediaBuyResponse>> {
     try {
       const tracked = await this.trackLegacyPurchaseResultInternal(
@@ -7397,7 +7563,8 @@ export class MediaBuyLifecycleCoordinator {
         publishSettledTaskStatus,
         registerExternalTaskSettlement,
         settlementTransport,
-        expectedDeferredTaskToken
+        expectedDeferredTaskToken,
+        wireOptions
       );
       return transferDeferredSettlementAcknowledgement(result, tracked);
     } catch (error) {
@@ -7413,7 +7580,8 @@ export class MediaBuyLifecycleCoordinator {
     publishSettledTaskStatus?: BeforeProtocolDispatchContext['publishSettledTaskStatus'],
     registerExternalTaskSettlement?: BeforeProtocolDispatchContext['registerExternalTaskSettlement'],
     settlementTransport?: TaskOptions['transport'],
-    expectedDeferredTaskToken?: string
+    expectedDeferredTaskToken?: string,
+    wireOptions?: Pick<TaskOptions, 'wireAdcpVersion' | 'versionEnvelope'>
   ): Promise<TaskResult<CreateMediaBuyResponse>> {
     const durablePendingSettlement = hasDeferredPendingSettlement(result);
     let durableDeferredTaskToken = false;
@@ -7840,7 +8008,9 @@ export class MediaBuyLifecycleCoordinator {
             observed,
             publishSettledTaskStatus,
             registerExternalTaskSettlement,
-            settlementTransport
+            settlementTransport,
+            undefined,
+            wireOptions
           );
         } catch (error) {
           if (error instanceof LegacyPurchaseContinuationError && error.code === 'ambiguous') {
@@ -7903,7 +8073,7 @@ export class MediaBuyLifecycleCoordinator {
         void new Promise<void>(resolve => setTimeout(resolve, 0))
           .then(async () => {
             while (!watchSignal.aborted) {
-              const task = await this.agent.getTaskStatus(sellerTaskId, settlementTransport, watchSignal);
+              const task = await this.agent.getTaskStatus(sellerTaskId, settlementTransport, watchSignal, wireOptions);
               if (task.taskId !== sellerTaskId || task.taskType !== 'create_media_buy') {
                 throw this.legacyPurchaseAmbiguousError(
                   'The polled working seller task does not match the durably recorded create_media_buy task.'
@@ -7917,7 +8087,9 @@ export class MediaBuyLifecycleCoordinator {
                   observed,
                   publishSettledTaskStatus,
                   registerExternalTaskSettlement,
-                  settlementTransport
+                  settlementTransport,
+                  undefined,
+                  wireOptions
                 );
               }
               await waitForWorkingPoll();
@@ -7966,7 +8138,16 @@ export class MediaBuyLifecycleCoordinator {
           }
           const observed = this.legacyPurchaseResultFromTask(task, settlementMetadata);
           if (observed && ['completed', 'failed', 'governance-denied'].includes(observed.status)) {
-            const canonical = await this.trackLegacyPurchaseResult(token, claim, observed);
+            const canonical = await this.trackLegacyPurchaseResult(
+              token,
+              claim,
+              observed,
+              undefined,
+              undefined,
+              undefined,
+              undefined,
+              wireOptions
+            );
             return {
               ...task,
               status: canonical.status,
@@ -8034,7 +8215,9 @@ export class MediaBuyLifecycleCoordinator {
               observed,
               publishSettledTaskStatus,
               registerExternalTaskSettlement,
-              settlementTransport
+              settlementTransport,
+              undefined,
+              wireOptions
             );
           }
           await waitForNextPoll(state, signal);
@@ -8136,7 +8319,9 @@ export class MediaBuyLifecycleCoordinator {
                 completion,
                 publishSettledTaskStatus,
                 registerExternalTaskSettlement,
-                settlementTransport
+                settlementTransport,
+                undefined,
+                wireOptions
               );
             }
             return await waitForSharedCompletion(pollInterval, signal);
@@ -8220,7 +8405,8 @@ export class MediaBuyLifecycleCoordinator {
               publishSettledTaskStatus,
               registerExternalTaskSettlement,
               settlementTransport,
-              deferred.token
+              deferred.token,
+              wireOptions
             );
           } catch (error) {
             if (error instanceof DeferredSettlementOwnershipError) throw error;
@@ -8317,6 +8503,7 @@ export class MediaBuyLifecycleCoordinator {
       }
     }
 
+    this.assertRequestedLegacyVersion('refineProposals', record(params));
     this.assertProposalLifecycleAvailable('refineProposals');
 
     this.assertOnlyFields('refineProposals', record(params), REFINE_PROPOSALS_FIELDS);
@@ -8452,9 +8639,10 @@ export class MediaBuyLifecycleCoordinator {
       throw error;
     }
     const attemptEpoch = pendingRefinement.attemptEpoch;
-    const dispatchOptions = retry
-      ? { ...options, skipIdempotencyAutoInject: retry.skipIdempotencyAutoInject }
-      : options;
+    const dispatchOptions = {
+      ...(retry ? { ...options, skipIdempotencyAutoInject: retry.skipIdempotencyAutoInject } : options),
+      ...this.legacyWireTaskOptions(),
+    };
     const projectOnly = (data: CompatibleRefineProposalsWireResponse) =>
       projectRefineProposals(data, lifecycle, params.refinements);
     const projectAndSettle = (data: CompatibleRefineProposalsWireResponse) => {
@@ -8631,6 +8819,7 @@ export class MediaBuyLifecycleCoordinator {
       }
     }
 
+    this.assertRequestedLegacyVersion('declineProposals', input);
     this.assertProposalLifecycleAvailable('declineProposals');
 
     this.assertOnlyFields('declineProposals', input, DECLINE_PROPOSALS_FIELDS);
@@ -8701,9 +8890,10 @@ export class MediaBuyLifecycleCoordinator {
       throw error;
     }
     const attemptEpoch = pendingDecline.attemptEpoch;
-    const dispatchOptions = retry
-      ? { ...options, skipIdempotencyAutoInject: retry.skipIdempotencyAutoInject }
-      : options;
+    const dispatchOptions = {
+      ...(retry ? { ...options, skipIdempotencyAutoInject: retry.skipIdempotencyAutoInject } : options),
+      ...this.legacyWireTaskOptions(),
+    };
     const projectAndSettle = (data: CompatibleDeclineProposalsWireResponse) => {
       try {
         const projected = projectOnly(data, proposalIds);
@@ -8820,6 +9010,7 @@ export class MediaBuyLifecycleCoordinator {
       return this.adaptProjectedResult(result, this.makeReport(lifecycle, ['buy_products'], []), data => data);
     }
 
+    this.assertRequestedLegacyVersion('buyProducts', input);
     this.assertOnlyFields('buyProducts', input, BUY_PRODUCTS_FIELDS);
     this.assertLegacyReportingWebhook('buyProducts', input.reporting_webhook);
     this.assertCompactWireFieldsAbsent('buyProducts', input, [
@@ -8946,7 +9137,10 @@ export class MediaBuyLifecycleCoordinator {
       ...(input.context !== undefined && { context: input.context as CanonicalCreateMediaBuyRequest['context'] }),
     };
     this.assertValidCompactRequest('buy_products', params, lifecycle, true);
-    const result = await this.agent.createMediaBuy(request, inputHandler, options);
+    const result = await this.agent.createMediaBuy(request, inputHandler, {
+      ...options,
+      ...this.legacyWireTaskOptions(),
+    });
     return this.adaptProjectedResult(
       result,
       this.makeReport(lifecycle, ['create_media_buy'], losses, [
@@ -9122,6 +9316,7 @@ export class MediaBuyLifecycleCoordinator {
       return this.adaptProjectedResult(transitioned, this.makeReport(lifecycle, ['accept_proposal'], []), data => data);
     }
 
+    this.assertRequestedLegacyVersion('acceptProposal', input);
     this.assertProposalLifecycleAvailable('acceptProposal');
     this.assertOnlyFields('acceptProposal', input, ACCEPT_PROPOSAL_FIELDS);
     this.assertLegacyReportingWebhook('acceptProposal', input.reporting_webhook);
@@ -9408,9 +9603,12 @@ export class MediaBuyLifecycleCoordinator {
     });
     this.ownedAcceptanceReservations.set(reservation, { snapshotKey: snapshotKey!, snapshot });
     acceptanceReservationOwners.set(reservation, this);
-    const dispatchOptions = retryableAcceptance
-      ? { ...options, skipIdempotencyAutoInject: retryableAcceptance.skipIdempotencyAutoInject }
-      : options;
+    const dispatchOptions = {
+      ...(retryableAcceptance
+        ? { ...options, skipIdempotencyAutoInject: retryableAcceptance.skipIdempotencyAutoInject }
+        : options),
+      ...this.legacyWireTaskOptions(),
+    };
     let result: TaskResult<CreateMediaBuyResponse>;
     try {
       result =
@@ -9522,6 +9720,7 @@ export class MediaBuyLifecycleCoordinator {
       return this.adaptProjectedResult(result, this.makeReport(lifecycle, ['control_media_buy'], []), data => data);
     }
 
+    this.assertRequestedLegacyVersion('controlMediaBuy', input);
     this.assertOnlyFields('controlMediaBuy', input, CONTROL_MEDIA_BUY_FIELDS);
     this.assertLegacyReportingWebhook('controlMediaBuy', input.reporting_webhook);
     this.assertLegacyPushNotification('controlMediaBuy', input.push_notification_config);
@@ -9778,7 +9977,10 @@ export class MediaBuyLifecycleCoordinator {
       ...(input.context !== undefined && { context: input.context as CanonicalUpdateMediaBuyRequest['context'] }),
     };
     this.assertValidCompactRequest('control_media_buy', params, lifecycle, true);
-    const result = await this.agent.updateMediaBuy(request, inputHandler, options);
+    const result = await this.agent.updateMediaBuy(request, inputHandler, {
+      ...options,
+      ...this.legacyWireTaskOptions(),
+    });
     return this.adaptProjectedResult(
       result,
       this.makeReport(
@@ -9808,13 +10010,17 @@ export class MediaBuyLifecycleCoordinator {
     this.assertSharedToolAdvertised('get_media_buys');
     const input = record(params);
     this.assertLegacyReferenceShapes('getMediaBuys', input);
+    if (!isCompactRelease(this.negotiated_version)) this.assertRequestedLegacyVersion('getMediaBuys', input);
     if (compareRelease(this.negotiated_version, '3.1') < 0) {
       this.assertCompactWireFieldsAbsent('getMediaBuys', input, ['include_webhook_activity', 'webhook_activity_limit']);
     }
     if (!isCompactRelease(this.negotiated_version)) {
       this.assertCompactWireFieldsAbsent('getMediaBuys', input, ['indicator_types']);
     }
-    const result = await this.agent.getMediaBuys(params, inputHandler, options);
+    const result = await this.agent.getMediaBuys(params, inputHandler, {
+      ...options,
+      ...this.legacyWireTaskOptions(),
+    });
     return this.adaptProjectedResult(result, this.makeReport(this.lifecycle, ['get_media_buys'], []), data => data);
   }
 
@@ -9835,6 +10041,7 @@ export class MediaBuyLifecycleCoordinator {
     this.assertSharedToolAdvertised('get_media_buy_delivery');
     const input = record(params);
     this.assertBeta6ReportingRequest('getMediaBuyDelivery', 'get_media_buy_delivery', input);
+    if (!isCompactRelease(this.negotiated_version)) this.assertRequestedLegacyVersion('getMediaBuyDelivery', input);
     if (compareRelease(this.negotiated_version, '3.1') < 0) {
       this.assertCompactWireFieldsAbsent('getMediaBuyDelivery', input, [
         'include_window_breakdown',
@@ -9853,7 +10060,10 @@ export class MediaBuyLifecycleCoordinator {
     }
     this.assertLegacyReportingDimensions('getMediaBuyDelivery', input.reporting_dimensions);
     this.assertLegacyReferenceShapes('getMediaBuyDelivery', input);
-    const result = await this.agent.getMediaBuyDelivery(params, inputHandler, options);
+    const result = await this.agent.getMediaBuyDelivery(params, inputHandler, {
+      ...options,
+      ...this.legacyWireTaskOptions(),
+    });
     return this.adaptProjectedResult(
       result,
       this.makeReport(this.lifecycle, ['get_media_buy_delivery'], []),

--- a/src/lib/storage/interfaces.ts
+++ b/src/lib/storage/interfaces.ts
@@ -147,6 +147,10 @@ export interface DeferredTaskState {
   a2aTaskId: string;
   /** Seller wire generation used for the original task and every continuation. */
   serverVersion: 'v2' | 'v3';
+  /** Per-operation AdCP wire release retained across durable resume. */
+  wireAdcpVersion?: string;
+  /** Per-operation version-envelope mode retained across durable resume. */
+  versionEnvelope?: import('../protocols').VersionEnvelopeMode;
   /** True when the original seller-version decision used the SDK's synthetic fallback. */
   serverVersionSynthetic?: boolean;
   /** Trusted agent identifier resolved through current client configuration. */

--- a/test/lib/media-buy-lifecycle-compatibility.test.js
+++ b/test/lib/media-buy-lifecycle-compatibility.test.js
@@ -11,6 +11,7 @@ const { createIdempotencyStore, memoryBackend } = require('../../dist/lib/server
 
 async function withDualSurfaceSeller(serverAdcpVersion, buyerAdcpVersion, run, options = {}) {
   const calls = [];
+  const legacyRequests = [];
   let mediaBuy = {
     media_buy_id: 'hidden-legacy-media-buy-1',
     status: 'active',
@@ -50,6 +51,7 @@ async function withDualSurfaceSeller(serverAdcpVersion, buyerAdcpVersion, run, o
       requestProposals: async () =>
         adcpError('TERMS_REJECTED', { message: 'fixture rejection', recovery: 'correctable' }),
       getProducts: async params => {
+        legacyRequests.push(structuredClone(params));
         calls.push(['get_products', params.adcp_version, params.adcp_major_version]);
         if (params.buying_mode === 'brief' || params.buying_mode === 'refine') {
           const refinedProposalId = params.refine?.find(item => item.scope === 'proposal')?.proposal_id;
@@ -76,7 +78,7 @@ async function withDualSurfaceSeller(serverAdcpVersion, buyerAdcpVersion, run, o
             cache_scope: 'account',
           };
         }
-        return { products: [], cache_scope: 'public' };
+        return { products: options.legacyProducts ?? [], cache_scope: 'public' };
       },
       createMediaBuy: async params => {
         calls.push(['create_media_buy', params.adcp_version, params.adcp_major_version, structuredClone(params)]);
@@ -125,9 +127,10 @@ async function withDualSurfaceSeller(serverAdcpVersion, buyerAdcpVersion, run, o
   const buyer = AgentClient.fromMCPClient(mcpClient, {
     adcpVersion: buyerAdcpVersion,
     validation: { requests: 'strict', responses: 'off' },
+    ...(options.legacyFormatConverter && { legacyFormatConverter: options.legacyFormatConverter }),
   });
   try {
-    await run({ buyer, mcpClient, calls, getMediaBuy: () => mediaBuy });
+    await run({ buyer, mcpClient, calls, legacyRequests, getMediaBuy: () => mediaBuy });
   } finally {
     await Promise.allSettled([mcpClient.close(), server.close()]);
   }
@@ -362,7 +365,7 @@ test('SDK buyer uses the compact lifecycle against a 3.2 seller profile', async 
 
 for (const adcpVersion of ['3.1.18', '3.0.25']) {
   test(`SDK buyer pinned to ${adcpVersion} can call a 3.2 seller's hidden legacy facade`, async () => {
-    await withDualSurfaceSeller('3.2.0-rc.1', adcpVersion, async ({ buyer, mcpClient, calls }) => {
+    await withDualSurfaceSeller('3.2.0-rc.1', adcpVersion, async ({ buyer, mcpClient, calls, legacyRequests }) => {
       const listed = await mcpClient.listTools();
       assert.ok(!listed.tools.some(tool => tool.name === 'get_products'));
 
@@ -372,12 +375,29 @@ for (const adcpVersion of ['3.1.18', '3.0.25']) {
       assert.deepStrictEqual(calls, [expectedWireClaim]);
 
       const lifecycle = await buyer.negotiateMediaBuyLifecycle();
-      const compatible = await lifecycle.listProducts({ max_results: 5 });
+      const compatible = await lifecycle.listProducts({
+        idempotency_key: `legacy-list-${adcpVersion}`,
+        account: { account_id: 'account-1' },
+        brand: { domain: 'example.com' },
+        criteria: { offer_filters: { countries: ['US'] } },
+        cursor: 'legacy-cursor-1',
+        max_results: 5,
+      });
       assert.strictEqual(lifecycle.negotiated_version, adcpVersion === '3.1.18' ? '3.1' : '3.0');
       assert.strictEqual(compatible.compatibility.lifecycle, 'established');
       assert.strictEqual(compatible.compatibility.compatibility, 'lossless_projection');
       assert.deepStrictEqual(compatible.compatibility.tools_used, ['get_products']);
       assert.deepStrictEqual(calls.at(-1), expectedWireClaim);
+      assert.deepStrictEqual(legacyRequests.at(-1), {
+        buying_mode: 'wholesale',
+        idempotency_key: `legacy-list-${adcpVersion}`,
+        account: { account_id: 'account-1' },
+        brand: { domain: 'example.com' },
+        filters: { countries: ['US'] },
+        pagination: { cursor: 'legacy-cursor-1', max_results: 5 },
+        ...(adcpVersion === '3.1.18' && { adcp_version: '3.1' }),
+        adcp_major_version: 3,
+      });
     });
   });
 
@@ -583,5 +603,151 @@ for (const adcpVersion of ['3.1.18', '3.0.25']) {
       assert.deepStrictEqual(compatible.compatibility.tools_used, ['get_products']);
       assert.deepStrictEqual(calls.at(-1), expectedWireClaim);
     });
+  });
+}
+
+for (const lane of [
+  {
+    name: '3.1 served release',
+    negotiatedVersion: '3.1.18',
+    capabilities: {
+      version: 'v3',
+      servedVersion: '3.1.18',
+      supportedVersions: ['3.1.18'],
+      idempotency: { replayTtlSeconds: 3600 },
+      mediaBuyLifecycleTools: ['get_products'],
+      discoveredTools: ['get_products'],
+    },
+  },
+  {
+    name: 'metadata-free 3.0',
+    negotiatedVersion: '3.0',
+    capabilities: {
+      version: 'v3',
+      idempotency: { replayTtlSeconds: 3600 },
+      mediaBuyLifecycleTools: ['get_products'],
+      discoveredTools: ['get_products'],
+    },
+  },
+]) {
+  test(`3.2-pinned buyer projects ${lane.name} claims to a hidden legacy handler`, async () => {
+    await withDualSurfaceSeller(
+      '3.2.0-rc.1',
+      '3.2.0-rc.1',
+      async ({ buyer, mcpClient, calls, legacyRequests }) => {
+        const compactTools = await mcpClient.listTools({ _meta: { adcp_version: '3.2-rc.1' } });
+        assert.ok(!compactTools.tools.some(tool => tool.name === 'get_products'));
+
+        buyer.getCapabilities = async () => lane.capabilities;
+        const lifecycle = await buyer.negotiateMediaBuyLifecycle({
+          principalScope: 'hidden-boundary-buyer',
+          legacyPurchaseSellerSessionScope: 'hidden-boundary-seller-session',
+          allowedLosses: ['feed_version_not_atomic', 'pricing_version_not_atomic'],
+        });
+        const result = await lifecycle.listProducts({
+          idempotency_key: `hidden-${lane.negotiatedVersion}-list-0001`,
+          account: { account_id: 'account-hidden-boundary' },
+          criteria: { offer_filters: { countries: ['US'] } },
+          cursor: 'hidden-boundary-cursor',
+          max_results: 7,
+        });
+
+        assert.equal(lifecycle.negotiated_version, lane.negotiatedVersion);
+        assert.equal(result.success, true, JSON.stringify(result));
+        assert.deepStrictEqual(calls.at(-1), [
+          'get_products',
+          lane.negotiatedVersion.startsWith('3.1') ? '3.1' : undefined,
+          3,
+        ]);
+        assert.deepStrictEqual(legacyRequests.at(-1), {
+          buying_mode: 'wholesale',
+          adcp_major_version: 3,
+          ...(lane.negotiatedVersion.startsWith('3.1') && { adcp_version: '3.1' }),
+          idempotency_key: `hidden-${lane.negotiatedVersion}-list-0001`,
+          account: { account_id: 'account-hidden-boundary' },
+          filters: { countries: ['US'] },
+          pagination: { cursor: 'hidden-boundary-cursor', max_results: 7 },
+        });
+
+        const continuation = result.data.purchase_continuation;
+        assert.ok(continuation, JSON.stringify(result));
+        assert.equal(continuation.kind, 'legacy_create');
+        const legacyCreateIdempotencyKey = lane.negotiatedVersion.startsWith('3.1')
+          ? '6ec62a3e-9859-4b29-943f-53f10c988c2f'
+          : 'fc689f57-d34d-43b7-a7b9-8aa38f69af59';
+        const purchased = await lifecycle.continueLegacyPurchase({
+          idempotency_key: lane.negotiatedVersion.startsWith('3.1')
+            ? 'ccf730a8-a043-4b51-a7a3-e1cb77a908b9'
+            : '38a18528-b290-4a18-bf5d-58f05d481c14',
+          continuation_token: continuation.continuation_token,
+          account: { account_id: 'account-hidden-boundary' },
+          selected_product_ids: ['hidden-product-1'],
+          accepted_losses: continuation.losses,
+          legacy_create_request: {
+            idempotency_key: legacyCreateIdempotencyKey,
+            account: { account_id: 'account-hidden-boundary' },
+            brand: { domain: 'example.com' },
+            packages: [{ product_id: 'hidden-product-1', pricing_option_id: 'hidden-price-1', budget: 100 }],
+            start_time: '2027-01-01T00:00:00Z',
+            end_time: '2027-02-01T00:00:00Z',
+          },
+        });
+        assert.equal(purchased.success, true, JSON.stringify(purchased));
+        const createCall = calls.findLast(([tool]) => tool === 'create_media_buy');
+        assert.deepStrictEqual(createCall.slice(0, 3), [
+          'create_media_buy',
+          lane.negotiatedVersion.startsWith('3.1') ? '3.1' : undefined,
+          3,
+        ]);
+        assert.deepStrictEqual(createCall[3], {
+          adcp_major_version: 3,
+          ...(lane.negotiatedVersion.startsWith('3.1') && { adcp_version: '3.1' }),
+          idempotency_key: legacyCreateIdempotencyKey,
+          account: { account_id: 'account-hidden-boundary' },
+          brand: { domain: 'example.com' },
+          packages: [{ product_id: 'hidden-product-1', pricing_option_id: 'hidden-price-1', budget: 100 }],
+          start_time: '2027-01-01T00:00:00Z',
+          end_time: '2027-02-01T00:00:00Z',
+        });
+      },
+      {
+        legacyProducts: [
+          {
+            product_id: 'hidden-product-1',
+            name: 'Hidden legacy product',
+            description: 'Purchasable through the legacy facade',
+            publisher_properties: [{ publisher_domain: 'example.com', selection_type: 'all' }],
+            format_ids: [{ agent_url: 'https://formats.example/catalog', id: 'hidden-display' }],
+            delivery_type: 'non_guaranteed',
+            pricing_options: [
+              {
+                pricing_option_id: 'hidden-price-1',
+                pricing_model: 'cpm',
+                currency: 'USD',
+                fixed_price: 10,
+              },
+            ],
+            reporting_capabilities: {
+              available_reporting_frequencies: ['daily'],
+              expected_delay_minutes: 60,
+              timezone: 'UTC',
+              supports_webhooks: false,
+              available_metrics: ['impressions'],
+              date_range_support: 'date_range',
+            },
+          },
+        ],
+        legacyFormatConverter: () => ({
+          format_option_id: 'hidden-format-option',
+          format_kind: 'custom',
+          format_shape: 'display',
+          format_schema: {
+            uri: 'https://formats.example/schemas/hidden-display.json',
+            digest: `sha256:${'a'.repeat(64)}`,
+          },
+          params: {},
+        }),
+      }
+    );
   });
 }

--- a/test/lib/media-buy-lifecycle-coordinator.test.js
+++ b/test/lib/media-buy-lifecycle-coordinator.test.js
@@ -443,6 +443,75 @@ describe('MediaBuyLifecycleCoordinator negotiation matrix', () => {
     assert.deepEqual(requests[1].pagination, { max_results: 25 });
   });
 
+  for (const version of ['3.0', '3.1']) {
+    test(`${version} list projection preserves exact offer filters and pagination`, async () => {
+      const agent = clientWithCaps(capabilities({ version }), version);
+      const requests = [];
+      const sellerResponse = {
+        products: [],
+        pagination: { cursor: `seller-next-${version}`, has_more: true },
+        cache_scope: 'account',
+      };
+      agent.getProducts = async request => {
+        requests.push(structuredClone(request));
+        return completed('get_products', sellerResponse);
+      };
+      const coordinator = await agent.negotiateMediaBuyLifecycle();
+
+      const result = await coordinator.listProducts({
+        account: { account_id: `account-${version}` },
+        criteria: { offer_filters: { countries: ['US'], channels: ['display'] } },
+        cursor: `buyer-cursor-${version}`,
+        max_results: 17,
+      });
+
+      assert.deepEqual(requests, [
+        {
+          buying_mode: 'wholesale',
+          account: { account_id: `account-${version}` },
+          filters: { countries: ['US'], channels: ['display'] },
+          pagination: { cursor: `buyer-cursor-${version}`, max_results: 17 },
+        },
+      ]);
+      assert.equal(requests[0].targeting_overlay, undefined, 'country criteria must remain product filters');
+      assert.equal(result.data.next_cursor, `seller-next-${version}`);
+      assert.deepEqual(result.data.pagination, sellerResponse.pagination);
+      assert.strictEqual(result.data.raw, sellerResponse);
+    });
+  }
+
+  test('established list criteria report the exact unsupported field before dispatch', async () => {
+    const agent = clientWithCaps(capabilities({ version: '3.0' }), '3.0');
+    let dispatches = 0;
+    agent.getProducts = async () => {
+      dispatches += 1;
+      return completed('get_products', { products: [] });
+    };
+    const coordinator = await agent.negotiateMediaBuyLifecycle();
+
+    for (const [params, feature] of [
+      [{ criteria: { product_ids: ['product-1'] } }, 'criteria.product_ids'],
+      [
+        { criteria: { offer_filters: { required_metrics: ['viewable_rate'] } } },
+        'criteria.offer_filters.required_metrics',
+      ],
+      [
+        { criteria: { offer_filters: { required_metrics: ['impressions'] } } },
+        'criteria.offer_filters.required_metrics',
+      ],
+      [{ governance_context: 'governance-1' }, 'governance_context'],
+      [{ context_id: 'context-1' }, 'context_id'],
+      [{ adcp_version: '3.1' }, 'adcp_version'],
+      [{ adcp_major_version: 4 }, 'adcp_major_version'],
+    ]) {
+      await assert.rejects(
+        coordinator.listProducts(params),
+        error => error instanceof MediaBuyLifecycleCompatibilityError && error.feature === feature
+      );
+    }
+    assert.equal(dispatches, 0);
+  });
+
   test('malformed native proposal completions fail instead of fabricating a legacy outcome', async () => {
     const agent = clientWithCaps(capabilities({ tools: COMPACT_TOOLS }));
     agent.requestProposals = async () => completed('request_proposals', { proposals: [], products: [] });
@@ -5045,6 +5114,164 @@ describe('legacy products-only purchase continuations', () => {
       ...(sourceVersion.startsWith('3.1') && { confirmed_at: '2099-01-01T00:00:00Z', revision: 1 }),
     };
   }
+
+  test('purchases a tokenless 3.0 catalog through restart recovery and deterministic replay', async () => {
+    const store = createInMemoryLegacyPurchaseContinuationStore();
+    const firstAgent = clientWithCaps(capabilities({ version: '3.0' }), '3.0');
+    const product = legacyListedProduct('p-tokenless-catalog', 'Tokenless catalog');
+    firstAgent.getProducts = async () =>
+      completed('get_products', {
+        products: [product],
+        pagination: { cursor: 'catalog-next', has_more: true },
+        cache_scope: 'account',
+      });
+    const coordinatorOptions = {
+      principalScope: 'buyer-tokenless-catalog',
+      legacyPurchaseSellerSessionScope: 'seller-session-tokenless-catalog',
+      legacyPurchaseContinuationStore: store,
+      allowedLosses: ['feed_version_not_atomic', 'pricing_version_not_atomic'],
+    };
+    const first = await firstAgent.negotiateMediaBuyLifecycle(coordinatorOptions);
+    const listed = await first.listProducts({
+      account: { account_id: 'account-tokenless-catalog' },
+      criteria: { offer_filters: { countries: ['US'] } },
+      max_results: 1,
+    });
+
+    assert.equal(listed.data.feed_version, undefined);
+    assert.equal(listed.data.next_cursor, 'catalog-next');
+    assert.equal(listed.data.purchase_continuation.kind, 'legacy_create');
+    assert.deepEqual(listed.data.purchase_continuation.product_ids, ['p-tokenless-catalog']);
+    assert.deepEqual(listed.data.purchase_continuation.losses, [
+      'feed_version_not_atomic',
+      'pricing_version_not_atomic',
+    ]);
+    assert.equal(listed.data.raw.purchase_continuation, undefined, 'raw must remain the seller response');
+
+    let creates = 0;
+    firstAgent.createMediaBuy = async () => {
+      creates += 1;
+      return completed('create_media_buy', {});
+    };
+    await assert.rejects(
+      first.buyProducts({
+        idempotency_key: 'strict-tokenless-buy-0001',
+        account: { account_id: 'account-tokenless-catalog' },
+        brand: { domain: 'example.com' },
+        purchases: [{ product_id: 'p-tokenless-catalog', pricing_option_id: 'fixed-cpm', budget: 10 }],
+        start_time: '2099-01-01T00:00:00Z',
+        end_time: '2099-02-01T00:00:00Z',
+      }),
+      error => error instanceof MediaBuyLifecycleCompatibilityError && error.feature === 'feed_version'
+    );
+    assert.equal(creates, 0, 'strict compact selection must fail before mutation');
+
+    const recoveredAgent = clientWithCaps(capabilities({ version: '3.0' }), '3.0');
+    const recoveredCreates = [];
+    recoveredAgent.createMediaBuyLegacy = async request => {
+      recoveredCreates.push(structuredClone(request));
+      return completed('create_media_buy', {
+        media_buy_id: 'buy-tokenless-catalog',
+        packages: [],
+      });
+    };
+    const recovered = await recoveredAgent.negotiateMediaBuyLifecycle(coordinatorOptions);
+    const continuationInput = {
+      idempotency_key: 'a2f9f142-e760-4b53-8f64-a4e24070dc4e',
+      continuation_token: listed.data.purchase_continuation.continuation_token,
+      account: { account_id: 'account-tokenless-catalog' },
+      selected_product_ids: ['p-tokenless-catalog'],
+      accepted_losses: listed.data.purchase_continuation.losses,
+      legacy_create_request: {
+        idempotency_key: 'legacy-tokenless-create-0001',
+        account: { account_id: 'account-tokenless-catalog' },
+        brand: { domain: 'example.com' },
+        packages: [{ product_id: 'p-tokenless-catalog', pricing_option_id: 'fixed-cpm', budget: 10 }],
+        start_time: '2099-01-01T00:00:00Z',
+        end_time: '2099-02-01T00:00:00Z',
+      },
+    };
+    await assert.rejects(
+      recovered.continueLegacyPurchase({
+        ...continuationInput,
+        accepted_losses: ['feed_version_not_atomic'],
+      }),
+      error => error.code === 'loss_mismatch'
+    );
+    assert.equal(recoveredCreates.length, 0, 'loss consent must be complete before mutation');
+
+    const purchased = await recovered.continueLegacyPurchase(continuationInput);
+    const replayed = await recovered.continueLegacyPurchase(continuationInput);
+
+    assert.equal(purchased.data.media_buy_id, 'buy-tokenless-catalog');
+    assert.equal(replayed.data.media_buy_id, purchased.data.media_buy_id);
+    assert.equal(recoveredCreates.length, 1);
+    assert.deepEqual(recoveredCreates[0], continuationInput.legacy_create_request);
+
+    recoveredAgent.getProducts = async () =>
+      completed('get_products', {
+        products: [product],
+        pagination: { cursor: 'catalog-next', has_more: true },
+        cache_scope: 'account',
+      });
+    const relisted = await recovered.listProducts({
+      account: { account_id: 'account-tokenless-catalog' },
+      criteria: { offer_filters: { countries: ['US'] } },
+      max_results: 1,
+    });
+    assert.notEqual(
+      relisted.data.purchase_continuation.continuation_token,
+      listed.data.purchase_continuation.continuation_token,
+      'a fresh listing must not reuse a consumed purchase continuation'
+    );
+    await recovered.continueLegacyPurchase({
+      ...continuationInput,
+      idempotency_key: '047165ce-43a5-45d9-8c81-8fe671d52879',
+      continuation_token: relisted.data.purchase_continuation.continuation_token,
+      legacy_create_request: {
+        ...continuationInput.legacy_create_request,
+        idempotency_key: 'legacy-tokenless-create-0002',
+      },
+    });
+    assert.equal(recoveredCreates.length, 2);
+  });
+
+  test('listing continuations are limited to purchasable catalogs without a real feed token', async () => {
+    const responses = [
+      {
+        products: [legacyListedProduct('p-feed-backed', 'Feed backed')],
+        wholesale_feed_version: 'feed-real',
+        cache_scope: 'account',
+        purchase_continuation: {
+          kind: 'legacy_create',
+          continuation_token: 'seller-controlled',
+        },
+      },
+      { products: [{ product_id: 'p-no-pricing', name: 'No pricing' }], cache_scope: 'account' },
+      {
+        products: [legacyListedProduct('p-no-session-binding', 'No session binding')],
+        cache_scope: 'account',
+      },
+    ];
+    const agent = clientWithCaps(capabilities({ version: '3.1' }), '3.1');
+    agent.getProducts = async () => completed('get_products', responses.shift());
+    const coordinator = await agent.negotiateMediaBuyLifecycle({
+      principalScope: 'buyer-list-eligibility',
+      legacyPurchaseSellerSessionScope: undefined,
+      legacyPurchaseContinuationStore: createInMemoryLegacyPurchaseContinuationStore(),
+    });
+
+    const feedBacked = await coordinator.listProducts({ account: { account_id: 'account-list-eligibility' } });
+    const unpurchasable = await coordinator.listProducts({ account: { account_id: 'account-list-eligibility' } });
+    const unbound = await coordinator.listProducts({ account: { account_id: 'account-list-eligibility' } });
+
+    assert.equal(feedBacked.data.feed_version, 'feed-real');
+    assert.equal(feedBacked.data.purchase_continuation, undefined);
+    assert.equal(feedBacked.data.raw.purchase_continuation.continuation_token, 'seller-controlled');
+    assert.equal(unpurchasable.data.purchase_continuation, undefined);
+    assert.equal(unbound.data.products[0].product_id, 'p-no-session-binding');
+    assert.equal(unbound.data.purchase_continuation, undefined);
+  });
 
   test('keeps unsafe products-only discovery readable without issuing a purchase continuation', async () => {
     const agent = clientWithCaps(capabilities({ version: '3.1' }), '3.1');
@@ -11266,7 +11493,9 @@ describe('MediaBuyLifecycleCoordinator mutation boundaries', () => {
         brief: 'test',
         criteria: { offer_filters: { required_features: { property_filtering: true } } },
       }),
-      error => error instanceof MediaBuyLifecycleCompatibilityError && error.feature === 'required_features'
+      error =>
+        error instanceof MediaBuyLifecycleCompatibilityError &&
+        error.feature === 'criteria.offer_filters.required_features'
     );
     assert.equal(calls, 0);
   });

--- a/test/lib/task-executor-async-patterns.test.js
+++ b/test/lib/task-executor-async-patterns.test.js
@@ -405,6 +405,8 @@ describe(
         let callCount = 0;
         ProtocolClient.callTool = mock.fn(async (_agent, taskName, params, options) => {
           callCount += 1;
+          assert.strictEqual(options.wireAdcpVersion, '3.0');
+          assert.strictEqual(options.versionEnvelope, 'major-only');
           assert.strictEqual(taskName, 'needsInput');
           if (callCount === 1) {
             return a2aPausedTask({
@@ -422,7 +424,10 @@ describe(
         });
 
         const executor = new TaskExecutor({ strictSchemaValidation: false });
-        const paused = await executor.executeTask(a2aAgent, 'needsInput', {});
+        const paused = await executor.executeTask(a2aAgent, 'needsInput', {}, undefined, {
+          wireAdcpVersion: '3.0',
+          versionEnvelope: 'major-only',
+        });
         const resumed = await paused.deferred.resume('approved');
         assert.strictEqual(resumed.status, 'completed');
       });
@@ -433,6 +438,8 @@ describe(
         let callCount = 0;
         ProtocolClient.callTool = mock.fn(async (_agent, taskName, params, options) => {
           callCount += 1;
+          assert.strictEqual(options.wireAdcpVersion, '3.0');
+          assert.strictEqual(options.versionEnvelope, 'major-only');
           if (callCount === 1) {
             return a2aPausedTask({
               question: 'Approve after restart?',
@@ -450,8 +457,14 @@ describe(
         });
 
         const firstExecutor = new TaskExecutor({ deferredStorage: storage, strictSchemaValidation: false });
-        const paused = await firstExecutor.executeTask(a2aAgent, 'needsInput', {});
+        const paused = await firstExecutor.executeTask(a2aAgent, 'needsInput', {}, undefined, {
+          wireAdcpVersion: '3.0',
+          versionEnvelope: 'major-only',
+        });
         assert.strictEqual(await storage.has(paused.deferred.token), true);
+        const stored = await storage.get(paused.deferred.token);
+        assert.strictEqual(stored.wireAdcpVersion, '3.0');
+        assert.strictEqual(stored.versionEnvelope, 'major-only');
 
         const restartedExecutor = new TaskExecutor({
           deferredStorage: storage,
@@ -635,16 +648,29 @@ describe(
           },
         };
 
-        ProtocolClient.callTool = mock.fn(async (agent, taskName, params) => {
+        let polls = 0;
+        ProtocolClient.callTool = mock.fn(async (agent, taskName, params, options) => {
+          assert.strictEqual(options.wireAdcpVersion, '3.0');
+          assert.strictEqual(options.versionEnvelope, 'major-only');
           if (taskName === 'tasks/get' || taskName === 'tasks_get') {
-            return { task: { ...mockTaskStatus.task, taskId: params.task_id } };
+            polls += 1;
+            return {
+              task: {
+                ...mockTaskStatus.task,
+                taskId: params.task_id,
+                ...(polls > 1 && { status: 'completed', result: { done: true } }),
+              },
+            };
           } else {
             return mockSubmitResponse;
           }
         });
 
         const executor = new TaskExecutor();
-        const result = await executor.executeTask(mockAgent, 'submitTask', {});
+        const result = await executor.executeTask(mockAgent, 'submitTask', {}, undefined, {
+          wireAdcpVersion: '3.0',
+          versionEnvelope: 'major-only',
+        });
 
         assert.strictEqual(result.status, 'submitted');
 
@@ -652,6 +678,8 @@ describe(
         const status = await result.submitted.track();
         assert.strictEqual(status.status, 'working');
         assert.strictEqual(status.taskType, 'submitTask');
+        const completed = await result.submitted.waitForCompletion(0);
+        assert.strictEqual(completed.status, 'completed');
       });
 
       test('waitForCompletion preserves the client correlation ID and exposes the seller work ID separately', async () => {


### PR DESCRIPTION
Closes #2874

## Summary
- project representable offer filters and pagination onto 3.0/3.1 `get_products` listings
- add durable SDK-local purchase continuations for eligible tokenless legacy catalogs
- preserve negotiated wire versions through purchase, polling, and deferred resume boundaries
- keep native `buy_products` feed fencing strict and document the named compatibility losses

## Validation
- `npm run typecheck`
- `npm run build:lib`
- 404 focused media-buy, async-task, and deferred-recovery tests
- protocol, implementation, and test expert reviews converged with no blockers

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/86b4e67e-9206-41ce-aa01-ce7f80eadf54)
