### PR TITLE
fix(testing): preserve seeded pricing sentinel

### DIFF
--- a/.changeset/fix-seeded-pricing-sentinel.md
+++ b/.changeset/fix-seeded-pricing-sentinel.md
@@ -1,0 +1,5 @@
+---
+'@adcp/sdk': patch
+---
+
+Preserve the `test-pricing` compliance sentinel when seeded pricing options are not present in storyboard runner context.

--- a/src/lib/testing/storyboard/request-builder.ts
+++ b/src/lib/testing/storyboard/request-builder.ts
@@ -393,7 +393,7 @@ const REQUEST_ENRICHERS: Record<string, RequestEnricher> = {
         options.budget ??
         Math.max(1000, (pricingOption?.min_spend_per_package as number) ?? 1000),
       pricing_option_id:
-        fixturePricingOptionId ?? pricingOption?.pricing_option_id ?? context.pricing_option_id ?? 'default',
+        fixturePricingOptionId ?? pricingOption?.pricing_option_id ?? context.pricing_option_id ?? 'test-pricing',
     };
 
     // Synthesize a bid_price for auction/cpm pricing only when the fixture

--- a/test/lib/request-builder.test.js
+++ b/test/lib/request-builder.test.js
@@ -136,10 +136,10 @@ describe('Request Builder', () => {
       assert.strictEqual(result.packages[0].pricing_option_id, 'opt-1');
     });
 
-    test('includes default pricing_option_id when no products discovered', () => {
+    test('falls back to compliance fixture ids when no products are discovered', () => {
       const result = buildRequest(step('create_media_buy'), {}, DEFAULT_OPTIONS);
-      assert.strictEqual(result.packages[0].pricing_option_id, 'default');
-      assert.ok(result.packages[0].product_id, 'should have product_id');
+      assert.strictEqual(result.packages[0].pricing_option_id, 'test-pricing');
+      assert.strictEqual(result.packages[0].product_id, 'test-product');
       assert.ok(result.packages[0].budget > 0, 'should have positive budget');
     });
 
@@ -394,6 +394,18 @@ describe('Request Builder', () => {
         'sentinel pricing_option_id → discovery'
       );
       assert.strictEqual(result.packages[0].budget, 5000, 'non-sentinel fixture fields pass through');
+    });
+
+    test('preserves pricing sentinel for fixture binding when seeded products are not in runner context', () => {
+      const s = step('create_media_buy', {
+        sample_request: {
+          start_time: FUTURE_START,
+          packages: [{ product_id: 'test-product', budget: 5000, pricing_option_id: 'test-pricing' }],
+        },
+      });
+      const result = buildRequest(s, {}, DEFAULT_OPTIONS);
+      assert.strictEqual(result.packages[0].product_id, 'test-product');
+      assert.strictEqual(result.packages[0].pricing_option_id, 'test-pricing');
     });
 
     test('preserves top-level sample_request fields the enricher does not normalise (#1604)', () => {


### PR DESCRIPTION
Seeded `create_media_buy` storyboards can have no discovered pricing options in runner context. The request enricher replaced the authored `test-pricing` sentinel with `default`, preventing fixture binding from resolving the seeded price.

Preserve `test-pricing` as the terminal fallback, matching `test-product`. Explicit fixture IDs, discovered pricing, and context pricing keep their existing precedence. Includes a regression test and a patch changeset.

Fixes #2871.

Validation:

- `npm run build:lib`
- `NODE_ENV=test node --test-timeout=60000 --test-force-exit --test test/lib/request-builder.test.js` (92 passing)
- `npm run typecheck`
- Targeted Prettier, commit/title checks, and `git diff origin/main --check`

Live-agent validation was not run.
